### PR TITLE
Issue#32 LocalPath.dirname returns LocalPath, ditto RemotePath

### DIFF
--- a/plumbum/local_machine.py
+++ b/plumbum/local_machine.py
@@ -53,7 +53,7 @@ class LocalPath(Path):
     @property
     @_setdoc(Path)
     def dirname(self):
-        return os.path.dirname(str(self))
+        return self.__class__(os.path.dirname(str(self)))
 
     @_setdoc(Path)
     def join(self, other):

--- a/plumbum/remote_path.py
+++ b/plumbum/remote_path.py
@@ -57,7 +57,7 @@ class RemotePath(Path):
     def dirname(self):
         if not "/" in str(self):
             return str(self)
-        return str(self).rsplit("/", 1)[0]
+        return self.__class__(self.remote, str(self).rsplit("/", 1)[0])
 
     def _get_info(self):
         return (self.remote, self._path)


### PR DESCRIPTION
LocalPath.dirname returns LocalPath instance. Similar RemotePath.dirname retuns RemotePath instance. Issue #32 https://github.com/tomerfiliba/plumbum/issues/32

Sorry about whitespace changes, My editor automatically deletes trailing whitespace on save.
