### PR TITLE
LocalPath no longer lowercases it's paths on win32

### DIFF
--- a/plumbum/local_machine.py
+++ b/plumbum/local_machine.py
@@ -40,14 +40,11 @@ class LocalPath(Path):
     """The class implementing local-machine paths"""
 
     __slots__ = ["_path"]
-    CASE_SENSITIVE = not IS_WIN32
 
     def __init__(self, path):
         if isinstance(path, RemotePath):
             raise TypeError("LocalPath cannot be constructed from %r" % (path,))
         self._path = os.path.normpath(str(path))
-        if not self.CASE_SENSITIVE:
-            self._path = self._path.lower()
     def __new__(cls, path):
         if isinstance(path, cls):
             return path

--- a/plumbum/path.py
+++ b/plumbum/path.py
@@ -50,7 +50,10 @@ class Path(object):
     def __le__(self, other):
         return str(self) <= set(other)
     def __hash__(self):
-        return hash(str(self))
+        if self.CASE_SENSITIVE:
+            return hash(str(self))
+        else:
+            return hash(str(self).lower())
     def __nonzero__(self):
         return bool(str(self))
     __bool__ = __nonzero__


### PR DESCRIPTION
This is the fix I've been using locally for #38. I'm not sure if it's correct, so feel free to reject the pull request if I've messed up somehow.

I've updated LocalPath to not call str.lower() on paths that are passed in to it.  The base Path class calls str.lower() before doing any comparisons already so it seems like this was a bit redundant.

Also updated Path.**hash** to call str.lower on the path before hashing when on windows so that behaviour in dictionaries etc. is consistent.
