### PR TITLE
Move plumbum.cmd hack into __init__.py

### DIFF
--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -34,6 +34,9 @@ of command-line interface (CLI) programs.
 
 See http://plumbum.readthedocs.org for full details
 """
+import sys
+from types import ModuleType
+
 from plumbum.commands import FG, BG, ERROUT
 from plumbum.commands import ProcessExecutionError, CommandNotFound, ProcessTimedOut
 from plumbum.path import Path
@@ -43,3 +46,18 @@ from plumbum.version import version as __version__
 
 __author__ = "Tomer Filiba (tomerfiliba@gmail.com)"
 
+#===================================================================================================
+# Module hack: ``from plumbum.cmd import ls``
+#===================================================================================================
+class LocalModule(ModuleType):
+    """The module-hack that allows us to use ``from plumbum.cmd import some_program``"""
+    __file__ = None
+    __package__ = __name__
+    __getattr__ = local.__getitem__
+
+cmd = LocalModule(__name__ + ".cmd")
+sys.modules[cmd.__name__] = cmd
+
+del sys
+del ModuleType
+del LocalModule

--- a/plumbum/local_machine.py
+++ b/plumbum/local_machine.py
@@ -12,7 +12,6 @@ import six
 from tempfile import mkdtemp
 from subprocess import Popen, PIPE
 from contextlib import contextmanager
-from types import ModuleType
 
 from plumbum.path import Path, FSUser
 from plumbum.remote_path import RemotePath
@@ -583,18 +582,3 @@ Attributes:
 * ``env`` - the local environment
 * ``encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
 """
-
-#===================================================================================================
-# Module hack: ``from plumbum.cmd import ls``
-#===================================================================================================
-class LocalModule(ModuleType):
-    """The module-hack that allows us to use ``from plumbum.cmd import some_program``"""
-    def __init__(self, name):
-        ModuleType.__init__(self, name, __doc__)
-        self.__file__ = None
-        self.__package__ = ".".join(name.split(".")[:-1])
-    def __getattr__(self, name):
-        return local[name]
-
-LocalModule = LocalModule("plumbum.cmd")
-sys.modules[LocalModule.__name__] = LocalModule


### PR DESCRIPTION
I found it a bit confusing that you could 

```
from plumbum.cmd import some_command
```

but you couldn't

```
import plumbum.cmd
```

I went looking at `__init__.py` and found it wasn't there at all, as I would expect it to be.

This patch moves the module hack into `__init__.py` so it can be easily found, and gives it a name (in addition to adding it to `sys.modules`) so it can be directly imported.

It also simplifies the code slightly, removes the hardcoded use of `plumbum` as the package name so that plumbum can be used as a subpackage, and allows:

```
plumbum.cmd["some_command"]
```

as `local` does.
