### PR TITLE
args now can be given as string

### DIFF
--- a/plumbum/commands.py
+++ b/plumbum/commands.py
@@ -1,3 +1,4 @@
+import shlex
 import six
 import subprocess
 import time
@@ -206,11 +207,14 @@ class BaseCommand(object):
     def __getitem__(self, args):
         """Creates a bound-command with the given arguments"""
         if not isinstance(args, (tuple, list)):
-            args = (args,)
+            args = tuple(shlex.split(args))
+        else:
+            args = tuple(sum([shlex.split(arg) if isinstance(arg, six.string_types) else [arg] for arg in args],[]))
+
         if not args:
             return self
         if isinstance(self, BoundCommand):
-            return BoundCommand(self.cmd, self.args + tuple(args))
+            return BoundCommand(self.cmd, self.args + args)
         else:
             return BoundCommand(self, args)
 
@@ -293,7 +297,7 @@ class BoundCommand(BaseCommand):
         return self.cmd.formulate(level + 1, self.args + tuple(args))
     def popen(self, args = (), **kwargs):
         if isinstance(args, six.string_types):
-            args = (args,)
+            args = shlex.split(args)
         return self.cmd.popen(self.args + tuple(args), **kwargs)
 
 class Pipeline(BaseCommand):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -111,7 +111,9 @@ class LocalMachineTest(unittest.TestCase):
         self.assertTrue("PATH" in local.env.getdict())
         self.assertEqual(local.path("foo"), os.path.join(os.getcwd(), "foo"))
         local.which("ls")
-        local["ls"]
+        local["ls"]()
+        local["ls"]['-a','-l']()
+        local["ls"]['-a -l']()
         self.assertEqual(local.python("-c", "print ('hi there')").splitlines(), ["hi there"])
 
     def test_piping(self):
@@ -187,9 +189,13 @@ class LocalMachineTest(unittest.TestCase):
         ssh = local["ssh"]
         pwd = local["pwd"]
 
-        cmd = ssh["localhost", "cd", "/usr", "&&", ssh["localhost", "cd", "/", "&&",
+        cmd1 = ssh["localhost", "cd", "/usr", "&&", ssh["localhost", "cd", "/", "&&",
             ssh["localhost", "cd", "/bin", "&&", pwd]]]
-        self.assertTrue("\"'&&'\"" in " ".join(cmd.formulate(0)))
+        self.assertTrue("\"'&&'\"" in " ".join(cmd1.formulate(0)))
+
+        cmd2 = ssh["localhost cd /usr &&", ssh["localhost cd / &&",
+            ssh["localhost cd /bin &&", pwd]]]
+        self.assertEqual(" ".join(cmd1.formulate(0)), " ".join(cmd2.formulate(0)))
 
         ls = local['ls']
         try:


### PR DESCRIPTION
now it can be used not only as ls['-la','*.py'](), but also in this way ls['-la *.py']()
