### PR TITLE
fix to issue 27

### DIFF
--- a/plumbum/paramiko_machine.py
+++ b/plumbum/paramiko_machine.py
@@ -150,6 +150,8 @@ class ParamikoMachine(BaseRemoteMachine):
             kwargs["key_filename"] = keyfile
         if password is not None:
             kwargs["password"] = password
+        if user is not None:
+            kwargs["username"] = user
         if missing_host_policy is not None:
             self._client.set_missing_host_key_policy(missing_host_policy)
         self._client.connect(host, **kwargs)


### PR DESCRIPTION
I added username to the keyword arguments in the **init** method for the ParamikoMachine to enable logging in as a different user on the remote host.

It might have been more elegent to change the user parameter to username but i didn't want to break the api.

Please let me know if you have any issues or concerns.
