### PR TITLE
Add 'timeout' and 'look_for_keys' optional params to ParamikoMachine.__init__()

### DIFF
--- a/plumbum/paramiko_machine.py
+++ b/plumbum/paramiko_machine.py
@@ -134,6 +134,8 @@ class ParamikoMachine(BaseRemoteMachine):
 
     :param look_for_keys: set to False to disable searching for discoverable
                           private key files in ``~/.ssh``
+
+    :param timeout: timout for the TCP connect
     """
     def __init__(self, host, user = None, port = None, password = None, keyfile = None, 
             load_system_host_keys = True, missing_host_policy = None, encoding = "utf8",
@@ -158,6 +160,8 @@ class ParamikoMachine(BaseRemoteMachine):
             self._client.set_missing_host_key_policy(missing_host_policy)
         if look_for_keys is not None:
             kwargs["look_for_keys"] = look_for_keys
+        if timeout is not None:
+            kwargs["timeout"] = timeout
         self._client.connect(host, **kwargs)
         self._sftp = None
         BaseRemoteMachine.__init__(self, encoding)


### PR DESCRIPTION
There are two additional params in paramiko.SSHClient.connect:
timeout - specifies TCP timeount
look_for_keys - used for disabling private key search in ~/.ssh
Adding them to plumbum.paramiko_machine.ParamikoMachine.**init**()
