### PR TITLE
Introduce a sane way to terminate background threads

### DIFF
--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -36,6 +36,7 @@ See http://plumbum.readthedocs.org for full details
 """
 from plumbum.commands import FG, BG, ERROUT
 from plumbum.commands import ProcessExecutionError, CommandNotFound, ProcessTimedOut
+from plumbum.commands import shutdown
 from plumbum.path import Path
 from plumbum.local_machine import local, LocalPath
 from plumbum.remote_machine import SshMachine, RemotePath, PuttyMachine


### PR DESCRIPTION
Sometimes during interpreter shutdown you can see the following:
"Exception in thread PlumbumTimeoutThread (most likely raised during interpreter shutdown)"

It happens due to the fact that there is no sane way to terminate two background PlumbumTimeoutThread-s. 

My patch does the following:
1) Introduces plumbum.shutdown() function
2) Modifies _timeout_thread() to avoid infinite blocking on Queue.get()
