### PR TITLE
possibility to disable calling main if nested_command is called

### DIFF
--- a/plumbum/cli.py
+++ b/plumbum/cli.py
@@ -401,6 +401,7 @@ class Application(object):
     DESCRIPTION = None
     VERSION = None
     USAGE = None
+    CALL_MAIN_IF_NESTED_COMMAND = True
     parent = None
     nested_command = None
 
@@ -626,7 +627,9 @@ class Application(object):
         else:
             for f, a in ordered:
                 f(inst, *a)
-            retcode = inst.main(*tailargs)
+            retcode = None
+            if not inst.nested_command or inst.CALL_MAIN_IF_NESTED_COMMAND:
+                retcode = inst.main(*tailargs)
             if not retcode and inst.nested_command:
                 subapp, argv = inst.nested_command
                 subapp.parent = inst


### PR DESCRIPTION
In [tpv.cli](https://github.com/chaoflow/tpv.cli/blob/master/src/tpv/cli/__init__.py#L24) I'd like `main()` not to be called, if actually a subcommand will be called. Having this flag would make this possible.

What do you think about it in general/detail?
