### PR TITLE
New alternative for resolving program names, replacing underscores with periods

### DIFF
--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -163,13 +163,15 @@ class LocalMachine(object):
 
         :param progname: The program's name. Note that if underscores (``_``) are present
                          in the name, and the exact name is not found, they will be replaced
-                         by hyphens (``-``) and the name will be looked up again
+                         in turn by hyphens (``-``) then periods (``.``), and the name will 
+                         be looked up again for each alternative
 
         :returns: A :class:`LocalPath <plumbum.machines.local.LocalPath>`
         """
         alternatives = [progname]
         if "_" in progname:
             alternatives.append(progname.replace("_", "-"))
+            alternatives.append(progname.replace("_", "."))
         for pn in alternatives:
             path = cls._which(pn)
             if path:

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -170,13 +170,15 @@ class BaseRemoteMachine(object):
 
         :param progname: The program's name. Note that if underscores (``_``) are present
                          in the name, and the exact name is not found, they will be replaced
-                         by hyphens (``-``) and the name will be looked up again
+                         in turn by hyphens (``-``) then periods (``.``), and the name will 
+                         be looked up again for each alternative
 
         :returns: A :class:`RemotePath <plumbum.path.local.RemotePath>`
         """
         alternatives = [progname]
         if "_" in progname:
             alternatives.append(progname.replace("_", "-"))
+            alternatives.append(progname.replace("_", "."))
         for name in alternatives:
             rc, out, _ = self._session.run("which %s" % (shquote(name),), retcode = None)
             if rc == 0:


### PR DESCRIPTION
This should make possible:

```
from plumbum.cmd import mysql_server
```

where the actual command is mysql.server.
