### PR TITLE
Fix typo: str.startwith() --> str.startswith()

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -53,7 +53,7 @@ class RemoteEnv(BaseEnv):
         :param expr: An expression containing home shortcuts
 
         :returns: The expanded string"""
-        if not any(part.startwith("~") for part in expr.split("/")):
+        if not any(part.startswith("~") for part in expr.split("/")):
             return expr
         # we escape all $ signs to avoid expanding env-vars
         return self.remote._session.run("echo %s" % (expr.replace("$", "\\$"),))


### PR DESCRIPTION
While this is necessary, there's still something funky going on.

``` python
from plumbum import SshMachine
remote_box = SshMachine('10.10.10.10')
p = remote_box.path('~')
p
>> <RemotePath /Users/user/(0, u'/Users/user\n', u'')>
print p
>> /Users/user/(0, u'/Users/user\n', u'')
```
