### PR TITLE
Faster which/command lookup implementation

### DIFF
--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -143,25 +143,10 @@ class LocalMachine(object):
     else:
         @classmethod
         def _which(cls, progname):
-            """
-            Code based on the Twisted library MIT Licensed.
-            """
-
-            flags=os.X_OK
-            exts = filter(None, os.environ.get('PATHEXT', '').split(os.pathsep))
-            path = os.environ.get('PATH', None)
-
-            if path is None:
-                return None
-
-            for p in os.environ.get('PATH', '').split(os.pathsep):
-                p = os.path.join(p, progname)
-                if os.access(p, flags):
-                    return LocalPath(p)
-                for e in exts:
-                    pext = p + e
-                    if os.access(pext, flags):
-                        return LocalPath(text)
+            for p in cls.env.path:
+                f = p / progname
+                if os.access(str(f), os.X_OK):
+                    return f
 
             return None
 


### PR DESCRIPTION
Taken from the twister.python.procutils.which this function speeds up the
importing of commands by a factor of 6, and which itself by a several
hundred times.

This is an example fix for issue #97.

On the master branch:

```
jlisee:$ time python -c "from plumbum.cmd import grep, wc, cat, head, ls, touch, mkdir, rm, echo, dd"

real  0m0.646s
user  0m0.588s
sys   0m0.048s
```

With this fix

```
jlisee:$ time python -c "from plumbum.cmd import grep, wc, cat, head, ls, touch, mkdir, rm, echo, dd"

real  0m0.061s
user  0m0.024s
sys   0m0.016s
```
