### PR TITLE
Tweak ParamikoMachine for python3 compatibility

### DIFF
--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -91,8 +91,8 @@ class ParamikoPopen(object):
             else:
                 coll.append(line)
         self.wait()
-        stdout = six.b("").join(stdout)
-        stderr = six.b("").join(stderr)
+        stdout = six.b("").join([six.b(s) for s in stdout])
+        stderr = six.b("").join([six.b(s) for s in stderr])
         return stdout, stderr
 
 


### PR DESCRIPTION
I am new to Python, so I'm not entirely familiar with the reasons why you need a byte string here, since (under python 3 at least) stdout and stderr contain utf strings. But I'll go along with it and convert them to byte strings too, which ought to also work in Python 2.

Note that I am using scottkmaxwell/paramiko for python 3 compatibility: https://github.com/scottkmaxwell/paramiko/tree/py3-support-without-py25
