### PR TITLE
Remove newline from user expansion in path

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -45,7 +45,7 @@ class RemoteEnv(BaseEnv):
                      home shortcuts (as ``~/.bashrc``)
 
         :returns: The expanded string"""
-        return self.remote._session.run("echo %s" % (expr,))[1]
+        return self.remote._session.run("echo %s" % (expr,))[1].strip()
 
     def expanduser(self, expr):
         """Expand home shortcuts (e.g., ``~/foo/bar`` or ``~john/foo/bar``)
@@ -56,7 +56,7 @@ class RemoteEnv(BaseEnv):
         if not any(part.startswith("~") for part in expr.split("/")):
             return expr
         # we escape all $ signs to avoid expanding env-vars
-        return self.remote._session.run("echo %s" % (expr.replace("$", "\\$"),))[1]
+        return self.remote._session.run("echo %s" % (expr.replace("$", "\\$"),))[1].strip()
 
     # def clear(self):
     #    BaseEnv.clear(self, *args, **kwargs)


### PR DESCRIPTION
Added strip() to remove the trailing newline added by echo during user path expansion. This would result in either problems with paths that have a \n in the middle of them, or things like plumbum.path.util.copy failing because scp cannot handle a trailing newline in path names.
