### PR TITLE
Added a definition of the size of the terminal on FreeBSD

### DIFF
--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -15,7 +15,6 @@ def get_terminal_size():
     Adapted from https://gist.github.com/jtriley/1108174
     Originally from: http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python
     """
-    size = (80, 25)
     current_os = platform.system()
     if current_os == 'Windows':
         size = _get_terminal_size_windows()
@@ -24,6 +23,8 @@ def get_terminal_size():
             size = _get_terminal_size_tput()
     elif current_os in ('Linux', 'Darwin', 'FreeBSD') or current_os.startswith('CYGWIN'):
         size = _get_terminal_size_linux()
+    else:
+        size = (80, 25)
     return size
 
 def _get_terminal_size_windows():


### PR DESCRIPTION
Added "FreeBSD" in the list of unix systems, when determining the size of the terminal. And fixed the bug in 26 line that caused the error UnboundLocalError, if the system has not been defined in previous if-statement.
