### PR TITLE
Update terminal.py

### DIFF
--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -23,7 +23,8 @@ def get_terminal_size():
             size = _get_terminal_size_tput()
     elif current_os in ('Linux', 'Darwin', 'FreeBSD') or current_os.startswith('CYGWIN'):
         size = _get_terminal_size_linux()
-    else:
+    
+    if size is None: # we'll assume the standard 80x25 if for any reason we don't know the terminal size
         size = (80, 25)
     return size
 


### PR DESCRIPTION
Changed the if, elif, else logic for get_terminal_size(). When I am testing code in an IDE on Windows, the typical Windows code fails to work and get_terminal_size() returns None--which throws an exception later in the code. The quick fix is to modify the logic so that if we don't have a method for determining the terminal size OR if any of our known methods fail, we just assume a standard terminal. It might be better to add more error handling downstream of this method in the execution, but assuming a standard terminal definitely seems like a 'good enough' solution to me.
