### PR TITLE
Allow running an application using a function call - MyApp.invoke(...)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,9 @@ class CLITest(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(inst.eggs, None)
 
+    def test_invoke(self):
+        inst, rc = TestApp.invoke("arg1", "arg2", eggs="sunny", bacon=10, verbose=2)
+        self.assertEqual((inst.eggs, inst.verbose, inst.tailargs), ("sunny", 2, ("arg1", "arg2")))
 
 class TestTerminal(unittest.TestCase):
     def test_ask(self):


### PR DESCRIPTION
The invoke method is similar to the run method, except that it takes its arguments from the method call instead of the command line, which means skipping the parsing phase.
