### PR TITLE
ignore encoding errors when converting to bytes (latin-1). closes #154

### DIFF
--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -34,7 +34,7 @@ class six(object):
         
         @staticmethod
         def b(s):
-            return s.encode("latin-1")
+            return s.encode("latin-1", "replace")
         @staticmethod
         def u(s):
             return s

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -431,7 +431,10 @@ for _ in range(%s):
     def test_pipeline_failure(self):
         from plumbum.cmd import ls, head
         self.assertRaises(ProcessExecutionError, (ls["--no-such-option"] | head))
-    
+
+    def test_issue_154(self):
+        self.assertEqual(local["echo"]("\u2018hello\u2018"), "\u2018hello\u2018\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -202,6 +202,9 @@ class RemoteMachineTest(unittest.TestCase, BaseRemoteMachineTest):
             with local.as_root():
                 local["userdel"]("-r", "testuser")
 
+    def test_issue_154(self):
+        with self._connect() as rem:
+            self.assertEqual(rem["echo"]("\u2018hello\u2018"), "\u2018hello\u2018\n")
 
 
 try:
@@ -229,7 +232,10 @@ else:
                 data = s.recv(100)
                 s.close()
                 self.assertEqual(data, six.b("hello world"))
-    
+
+        def test_issue_154(self):
+            with self._connect() as rem:
+                self.assertEqual(rem["echo"]("\u2018hello\u2018"), "?hello?\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This appears to be happening on paramiko only, not quite sure why.
This should be a good-enough workaround.
