### PR TITLE
Add template to `mktemp` to fix #175

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -289,7 +289,7 @@ class BaseRemoteMachine(object):
     def tempdir(self):
         """A context manager that creates a remote temporary directory, which is removed when
         the context exits"""
-        _, out, _ = self._session.run("mktemp -d")
+        _, out, _ = self._session.run("mktemp -d tmp.XXXXXXXXXX")
         dir = self.path(out.strip())  # @ReservedAssignment
         try:
             yield dir


### PR DESCRIPTION
See #175. Briefly, `mktemp -d` with no other parameters is only legal on the GNU version of `mktemp`, not the BSD version; explicitly passing the GNU version's default works on both.