### PR TITLE
Fix mismatch between format string and format tuple in remote._path_link

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -384,6 +384,4 @@ class BaseRemoteMachine(object):
             self.upload(f.name, fn)
 
     def _path_link(self, src, dst, symlink):
-        self._session.run("ln -s %s %s" % ("-s" if symlink else "", shquote(src), shquote(dst)))
-
-
+        self._session.run("ln %s %s %s" % ("-s" if symlink else "", shquote(src), shquote(dst)))


### PR DESCRIPTION
This PR just fixes a little mismatch in BaseRemoteMachine._path_link between the arguments in the format string and the format tuple. I changed the `"-s"`in the format string to a `%s` that should get replaced by `"-s" if symlink else ""` at run time, which appears to have been the original intent.