### PR TITLE
Adding suffix methods and properties

### DIFF
--- a/docs/local_machine.rst
+++ b/docs/local_machine.rst
@@ -117,6 +117,8 @@ etc. ::
     <LocalPath c:\windows\notepad.exe>
     >>> (p / "notepad.exe").isfile()
     True
+    >>> (p / "notepad.exe").with_suffix(".dll")
+    <LocalPath c:\windows\notepad.dll>
     >>> for p2, _ in zip(p, range(3)):
     ...     print p2
     ...
@@ -129,6 +131,7 @@ etc. ::
     [<LocalPath c:\windows\apppatch\acgenral.dll>, ...]
     >>> local.cwd / "docs" // "*.rst"
     [<LocalPath d:\workspace\plumbum\docs\cli.rst>, ...]
+
 
 If you need to **copy**, **move**, or **delete** paths, see the :ref:`utils modules <guide-utils>`
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,5 @@
+testfigure.pdf
+testfigure.svg
+testfigure.log
+testfigure.aux
+testfigure.png

--- a/examples/make_figures.py
+++ b/examples/make_figures.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+from __future__ import print_function, unicode_literals
+
+from plumbum.cmd import pdflatex, convert
+from plumbum import local, cli, FG
+from plumbum.path.utils import delete
+
+
+def image_comp(item):
+    pdflatex["-shell-escape", item] & FG
+    print("Converting", item)
+    convert[item.with_suffix(".svg"),
+            item.with_suffix(".png")] & FG
+
+    delete(item.with_suffix(".log"),
+           item.with_suffix(".aux"),
+           )
+
+
+class MyApp(cli.Application):
+    def main(self, *srcfiles):
+        print("Tex files should start with:")
+        print(r"\documentclass[tikz,convert={outfile=\jobname.svg}]{standalone}")
+        items = map(cli.ExistingFile, srcfiles) if srcfiles else local.cwd // "*.tex"
+        for item in items:
+            image_comp(item)
+
+
+if __name__ == "__main__":
+    MyApp.run()

--- a/examples/testfigure.tex
+++ b/examples/testfigure.tex
@@ -1,0 +1,9 @@
+\documentclass[tikz,convert={outfile=\jobname.svg}]{standalone}
+%\usetikzlibrary{...}% tikz package already loaded by 'tikz' option
+\begin{document}
+\begin{tikzpicture}% Example:
+  \draw (0,0) -- (10,10); % ...
+  \draw (10,0) -- (0,10); % ...
+  \node at (5,5) {Lorem ipsum at domine standalonus};
+\end{tikzpicture}
+\end{document}

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -99,6 +99,16 @@ class Path(object):
     def dirname(self):
         """The dirname component of this path"""
         raise NotImplementedError()
+        
+    @property
+    def suffix(self):
+        """The suffix of this file"""
+        raise NotImplementedError()
+    @property
+    def suffixes(self):
+        """This is a list of all suffixes"""
+        raise NotImplementedError()
+        
     @property
     def uid(self):
         """The user that owns this path. The returned value is a :class:`FSUser <plumbum.path.FSUser>`
@@ -133,6 +143,15 @@ class Path(object):
         """Returns ``True`` if this path exists, ``False`` otherwise"""
         raise NotImplementedError()
     def stat(self):
+        raise NotImplementedError()
+    def with_name(self, name):
+        """Returns a path with the name replaced"""
+        raise NotImplementedError()
+    def with_suffix(self, suffix, depth=1):
+        """Returns a path with the suffix replaced. Up to last ``depth`` suffixes will be
+        replaces. None will replace all suffixes. If there are less than ``depth`` suffixes,
+        this will replace all suffixes. ``.tar.gz`` is an example where ``depth=2`` or
+        ``depth=None`` is useful"""
         raise NotImplementedError()
     def glob(self, pattern):
         """Returns a (possibly empty) list of paths that matched the glob-pattern under this path"""

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -68,6 +68,22 @@ class LocalPath(Path):
 
     @property
     @_setdoc(Path)
+    def suffix(self):
+        return os.path.splitext(str(self))[1]
+        
+    @property
+    def suffixes(self):
+        exts = []
+        base = str(self)
+        while True:
+            base, ext = os.path.splitext(base)
+            if ext:
+                exts.append(ext)
+            else:
+                return list(reversed(exts))
+
+    @property
+    @_setdoc(Path)
     def uid(self):
         uid = self.stat().st_uid
         name = getpwuid(uid)[0]
@@ -107,6 +123,20 @@ class LocalPath(Path):
     @_setdoc(Path)
     def stat(self):
         return os.stat(str(self))
+        
+    @_setdoc(Path)
+    def with_name(self, name):
+        return LocalPath(self.dirname) / name
+        
+    @_setdoc(Path)
+    def with_suffix(self, suffix, depth=1):
+        if (suffix and not suffix.startswith(os.path.extsep) or suffix == os.path.extsep):
+            raise ValueError("Invalid suffix %r" % (suffix))
+        name = self.basename
+        depth = len(self.suffixes) if depth is None else min(depth, len(self.suffixes))
+        for i in range(depth):
+            name, ext = os.path.splitext(name)
+        return LocalPath(self.dirname) / (name + suffix)
 
     @_setdoc(Path)
     def glob(self, pattern):

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -76,6 +76,21 @@ class RemotePath(Path):
         if not "/" in str(self):
             return str(self)
         return self.__class__(self.remote, str(self).rsplit("/", 1)[0])
+        
+    @property
+    @_setdoc(Path)
+    def suffix(self):
+        return '.' + self.basename.rsplit('.',1)[1]
+        
+    @property
+    @_setdoc(Path)
+    def suffixes(self):
+        name = self.basename
+        exts = []
+        while '.' in name:
+            name, ext = name.rsplit('.',1)
+            exts.append('.' + ext)
+        return list(reversed(exts))
 
     @property
     @_setdoc(Path)
@@ -133,6 +148,20 @@ class RemotePath(Path):
         if res is None:
             raise OSError(errno.ENOENT)
         return res
+
+    @_setdoc(Path)
+    def with_name(self, name):
+        return self.__class__(self.remote, self.dirname) / name
+        
+    @_setdoc(Path)
+    def with_suffix(self, suffix, depth=1):
+        if (suffix and not suffix.startswith('.') or suffix == '.'):
+            raise ValueError("Invalid suffix %r" % (suffix))
+        name = self.basename
+        depth = len(self.suffixes) if depth is None else min(depth, len(self.suffixes))
+        for i in range(depth):
+            name, ext = name.rsplit('.',1)
+        return self.__class__(self.remote, self.dirname) / (name + suffix)
 
     @_setdoc(Path)
     def glob(self, pattern):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -50,6 +50,25 @@ class LocalPathTest(unittest.TestCase):
     def test_split(self):
         p = local.path("/var/log/messages")
         self.assertEqual(p.split(), ["var", "log", "messages"])
+        
+    def test_suffix(self):
+        p1 = local.path("/some/long/path/to/file.txt")
+        p2 = local.path("file.tar.gz")
+        self.assertEqual(p1.suffix, ".txt")
+        self.assertEqual(p1.suffixes, [".txt"])
+        self.assertEqual(p2.suffix, ".gz")
+        self.assertEqual(p2.suffixes, [".tar",".gz"])
+        self.assertEqual(p1.with_suffix(".tar.gz"), local.path("/some/long/path/to/file.tar.gz"))
+        self.assertEqual(p2.with_suffix(".other"), local.path("file.tar.other"))
+        self.assertEqual(p2.with_suffix(".other", 2), local.path("file.other"))
+        self.assertEqual(p2.with_suffix(".other", 0), local.path("file.tar.gz.other"))
+        self.assertEqual(p2.with_suffix(".other", None), local.path("file.other"))
+        
+    def test_newname(self):
+        p1 = local.path("/some/long/path/to/file.txt")
+        p2 = local.path("file.tar.gz")
+        self.assertEqual(p1.with_name("something.tar"), local.path("/some/long/path/to/something.tar"))
+        self.assertEqual(p2.with_name("something.tar"), local.path("something.tar"))
 
     def test_relative_to(self):
         p = local.path("/var/log/messages")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -33,6 +33,7 @@ if not hasattr(unittest, "skipIf"):
 class RemotePathTest(unittest.TestCase):
     def _connect(self):
         return SshMachine(TEST_HOST)
+        
 
     def test_basename(self):
         name = RemotePath(self._connect(), "/some/long/path/to/file.txt").basename
@@ -43,6 +44,27 @@ class RemotePathTest(unittest.TestCase):
         name = RemotePath(self._connect(), "/some/long/path/to/file.txt").dirname
         self.assertTrue(isinstance(name, RemotePath))
         self.assertEqual("/some/long/path/to", str(name))
+        
+    def test_suffix(self):
+        p1 = RemotePath(self._connect(), "/some/long/path/to/file.txt")
+        p2 = RemotePath(self._connect(), "file.tar.gz")
+        strcmp = lambda a,b: self.assertEqual(str(a),str(b))
+        self.assertEqual(p1.suffix, ".txt")
+        self.assertEqual(p1.suffixes, [".txt"])
+        self.assertEqual(p2.suffix, ".gz")
+        self.assertEqual(p2.suffixes, [".tar",".gz"])
+        strcmp(p1.with_suffix(".tar.gz"), RemotePath(self._connect(), "/some/long/path/to/file.tar.gz"))
+        strcmp(p2.with_suffix(".other"), RemotePath(self._connect(), "file.tar.other"))
+        strcmp(p2.with_suffix(".other", 2), RemotePath(self._connect(), "file.other"))
+        strcmp(p2.with_suffix(".other", 0), RemotePath(self._connect(), "file.tar.gz.other"))
+        strcmp(p2.with_suffix(".other", None), RemotePath(self._connect(), "file.other"))
+        
+    def test_newname(self):
+        p1 = RemotePath(self._connect(), "/some/long/path/to/file.txt")
+        p2 = RemotePath(self._connect(), "file.tar.gz")
+        strcmp = lambda a,b: self.assertEqual(str(a),str(b))
+        strcmp(p1.with_name("something.tar"), RemotePath(self._connect(), "/some/long/path/to/something.tar"))
+        strcmp(p2.with_name("something.tar"), RemotePath(self._connect(), "something.tar"))
 
     @unittest.skipIf(not hasattr(os, "chown"), "os.chown not supported")
     def test_chown(self):


### PR DESCRIPTION
The suffix, suffixes properties and` with_name`, `with_suffix` methods were added
(names chosen to be similar to other packages, like the builtin `pathlib`). One
difference vs. pathlib is an optional parameter for the `with_suffix` method that
allows simple manipulation of extended suffixes, like `.tar.gz`.

These additions are useful for working with multiple files of the same name,
such as when compiling programs or documents, and for packing/changing
compressed files.

Documentation, local and remote (and base class) support, unittests, and an
example were added.

As a quick example, here is .tar.gz -> .zip conversion, adopted from the bash script at http://stackoverflow.com/questions/6301885/convert-tar-gz-to-zip :

```python
from plumbum import local
from plumbum.cmd import tar, zip, mkdir, rm
files = local.cwd // "*.tar.gz"
for file in files:
    tmpfolder = file.with_suffix(".tmp", 0) # .tar.gz.tmp temporary folder
    mkdir(tmpfolder)
    tar("-C", tmpfolder, "-xvzf", file)
    with local.cwd(tmpfolder):
        zip("-r", file.with_suffix(".zip", 2), ".")
    rm("-rf", tmpfolder)
```

And this would compile a tex file and remove the extra files generated:

```python
from plumbum.cmd import pdflatex
from plumbum.path.utils import delete
from plumbum import local, FG
item = local.cwd / "document.tex"
pdflatex[item] & FG
delete(item.with_suffix(".log"), item.with_suffix(".aux"))
```