### PR TITLE
Two more modifiers for return codes

### DIFF
--- a/docs/local_commands.rst
+++ b/docs/local_commands.rst
@@ -129,6 +129,25 @@ one you passed::
    If you wish to accept several valid exit codes, ``retcode`` may be a tuple or a list. 
    For instance, ``grep("foo", "myfile.txt", retcode = (0, 2))``   
 
+
+If you need the value of the exit code, there are two ways to do it. You can call ``.run(retcode=None)``
+(or any other valid retcode value) on a command, you will get a tuple ``(retcode, stdin, stdout)``. If
+you just need the recode, or want to check the retcode, there are two special objects that can be applied
+to your command to run it and get or test the retcode. For example::
+
+    >>> cat["non/existing.file"] & RETCODE
+    1
+    >>> cat["non/existing.file"] & TF
+    False
+    >>> cat["non/existing.file"] & TF(1)
+    True
+
+.. note::
+   If you want to run these commands in the foreground (see below), you can give
+   ``FG=True`` to ``TF`` or ``RETCODE``.
+   For instance, ``cat["non/existing.file"] & TF(1,FG=True)``
+    
+
 Run and Popen
 -------------
 Notice that calling commands (or chained-commands) only returns their ``stdout``. In order to

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -35,7 +35,7 @@ of command-line interface (CLI) programs.
 See http://plumbum.readthedocs.org for full details
 """
 from plumbum.commands import ProcessExecutionError, CommandNotFound, ProcessTimedOut
-from plumbum.commands import FG, BG, TF, ERROUT
+from plumbum.commands import FG, BG, TF, RETCODE, ERROUT
 from plumbum.path import Path, LocalPath, RemotePath
 from plumbum.machines import local, BaseRemoteMachine, SshMachine, PuttyMachine
 from plumbum.version import version

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -35,7 +35,7 @@ of command-line interface (CLI) programs.
 See http://plumbum.readthedocs.org for full details
 """
 from plumbum.commands import ProcessExecutionError, CommandNotFound, ProcessTimedOut
-from plumbum.commands import FG, BG, ERROUT
+from plumbum.commands import FG, BG, TF, ERROUT
 from plumbum.path import Path, LocalPath, RemotePath
 from plumbum.machines import local, BaseRemoteMachine, SshMachine, PuttyMachine
 from plumbum.version import version

--- a/plumbum/commands/__init__.py
+++ b/plumbum/commands/__init__.py
@@ -1,4 +1,4 @@
 from plumbum.commands.base import shquote, shquote_list, BaseCommand, ERROUT, ConcreteCommand
-from plumbum.commands.modifiers import ExecutionModifier, Future, FG, BG, TF
+from plumbum.commands.modifiers import ExecutionModifier, Future, FG, BG, TF, RETCODE
 from plumbum.commands.processes import run_proc
 from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut, CommandNotFound

--- a/plumbum/commands/__init__.py
+++ b/plumbum/commands/__init__.py
@@ -1,4 +1,4 @@
 from plumbum.commands.base import shquote, shquote_list, BaseCommand, ERROUT, ConcreteCommand
-from plumbum.commands.modifiers import ExecutionModifier, Future, FG, BG
+from plumbum.commands.modifiers import ExecutionModifier, Future, FG, BG, TF
 from plumbum.commands.processes import run_proc
 from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut, CommandNotFound

--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -217,6 +217,34 @@ class TF(ExecutionModifier):
 TF = TF()
 
 
+class RETCODE(ExecutionModifier):
+    """
+    An execution modifier that runs the given command, causing it to run and return the retcode.
+    This is useful for working with bash commands that have important retcodes but not very
+    useful output.
 
-# TODO: Add RETCODE modifier, causing a command to return it's return code (like subprocess.call)
+    If you want to run the process in the forground, then use ``RETCODE(FG=True)``.
+
+    Example::
+
+        local['touch']['/root/test'] & RETCODE # Returns 1, since this cannot be touched
+        local['touch']['/root/test'] & RETCODE(FG=True) * Returns 1, will show error message
+    """
+
+    def __init__(self,  FG=False):
+        """`FG` to True to run in the foreground.
+        """
+        self.foreground = FG
+
+    @classmethod
+    def __call__(cls, *args, **kwargs):
+        return cls(*args, **kwargs)
+
+    def __rand__(self, cmd):
+            if self.foreground:
+                return cmd.run(retcode = None, stdin = None, stdout = None, stderr = None)[0]
+            else:
+                return cmd.run(retcode = None)[0]
+
+RETCODE = RETCODE()
 

--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -3,7 +3,7 @@ from select import select
 from subprocess import PIPE
 import sys
 
-from plumbum.commands.processes import run_proc
+from plumbum.commands.processes import run_proc, ProcessExecutionError
 
 
 #===================================================================================================
@@ -112,7 +112,7 @@ class FG(ExecutionModifier):
 
     In order to mimic shell syntax, it applies when you right-and it with a command.
     If you wish to expect a different return code (other than the normal success indicate by 0),
-    use ``BG(retcode)``. Example::
+    use ``FG(retcode)``. Example::
 
         vim & FG       # run vim in the foreground, expecting an exit code of 0
         vim & FG(7)    # run vim in the foreground, expecting an exit code of 7
@@ -137,7 +137,7 @@ class TEE(ExecutionModifier):
     """
     def __init__(self, retcode=0, buffered=True):
         """`retcode` is the return code to expect to mean "success".  Set
-        `buffered` to false to disable line-buffering the output, which may
+        `buffered` to False to disable line-buffering the output, which may
         cause stdout and stderr to become more entangled than usual.
         """
         self.retcode = retcode
@@ -175,3 +175,48 @@ class TEE(ExecutionModifier):
             return p.returncode, ''.join(outbuf), ''.join(errbuf)
 
 TEE = TEE()
+
+class TF(ExecutionModifier):
+    """
+    An execution modifier that runs the given command, but returns True/False depending on the retcode.
+    This returns True if the expected exit code is returned, and false if it is not.
+    This is useful for checking true/false bash commands.
+
+    If you wish to expect a different return code (other than the normal success indicate by 0),
+    use ``TF(retcode)``. If you want to run the process in the forground, then use
+    ``TF(FG=True)``.
+
+    Example::
+
+        local['touch']['/root/test'] & TF * Returns False, since this cannot be touched
+        local['touch']['/root/test'] & TF(1) # Returns True
+        local['touch']['/root/test'] & TF(FG=True) * Returns False, will show error message
+    """
+
+    def __init__(self, retcode=0, FG=False):
+        """`retcode` is the return code to expect to mean "success".  Set
+        `FG` to True to run in the foreground.
+        """
+        self.retcode = retcode
+        self.foreground = FG
+
+    @classmethod
+    def __call__(cls, *args, **kwargs):
+        return cls(*args, **kwargs)
+
+    def __rand__(self, cmd):
+        try:
+            if self.foreground:
+                cmd(retcode = self.retcode, stdin = None, stdout = None, stderr = None)
+            else:
+                cmd(retcode = self.retcode)
+            return True
+        except ProcessExecutionError:
+            return False
+
+TF = TF()
+
+
+
+# TODO: Add RETCODE modifier, causing a command to return it's return code (like subprocess.call)
+


### PR DESCRIPTION
I was writing a little tutorial for plumbum and converting one of my more complex bash scripts to plumbum, and I noticed one common use that `subprocess.call` does well that plumbum works a little harder for. It was in checking and working with return codes. While the exception method is excellent, if you are working with, for example, git, and you want to toggle behavior based on the return code of a command (like `git rev-list HEAD..origin`), then you have to use `.run(retcode=None)[0]` or try/except blocks (which then require accessing the stdin/stderr differently in the except block).

I added two modifiers alongside FG and BG, namely TF and RETCODE, that make working with return codes easy and natural in plumbum. They work a lot like BG, for example:
```python
>>> git['rev-list', 'HEAD..origin'] & TF
True
>>> git['rev-list', 'HEAD..origin'] & TF(1)
False
>>> git['rev-list', 'HEAD..origin'] & RETCODE
0
```

They support foreground execution with `FG=True` in the call, and TF can take retcode just like FG. Note that the bash syntax for using true/false return codes is &&, so this is a little like it, like BG.

I've added the two new objects, a test, documentation, and docstrings. Also fixed one minor typo in the docstring for FG.

PS: Should I add to the "what's new" documentation, too? I'm assuming you do that, but I'm happy to help if you need me to. Also, let me know if you have recommendations about names, etc, I'm happy to change them and resubmit if you have better ideas.) Thanks for such a brilliant library! I'll send a link to my blog post tutorial when I'm done with it if you want to see it. It should have a plumbum vs. bash example.