### PR TITLE
BUGFIX: Early binding to mutable list

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -324,9 +324,10 @@ class Application(object):
         return ordered, tailargs
 
     @classmethod
-    def run(cls, argv = sys.argv, exit = True):  # @ReservedAssignment
+    def run(cls, argv = None, exit = True):  # @ReservedAssignment
         """
-        Runs the application, taking the arguments from ``sys.argv`` by default. If ``exit`` is
+        Runs the application, taking the arguments from ``sys.argv`` by default if
+        nothing is passed. If ``exit`` is
         ``True`` (the default), the function will exit with the appropriate return code;
         otherwise it will return a tuple of ``(inst, retcode)``, where ``inst`` is the
         application instance created internally by this function and ``retcode`` is the
@@ -336,6 +337,8 @@ class Application(object):
            Setting ``exit`` to ``False`` is intendend for testing/debugging purposes only -- do
            not override it other situations.
         """
+        if argv is None:
+            argv = sys.argv
         argv = list(argv)
         inst = cls(argv.pop(0))
         retcode = 0


### PR DESCRIPTION
The library evaluates the sys.argv at the [wrong time](http://docs.python-guide.org/en/latest/writing/gotchas/), since it is a list being given as a default argument. Compare to argparse in IPython:

    %%writefile test_argparse.py
    import argparse
    
    def main():
        parser = argparse.ArgumentParser(description='Echo a command in color.')
        parser.add_argument('-c','--color', type=str,
                           help='Color to print')
        parser.add_argument('echo',
                           help='The item to print in color')
    
        args = parser.parse_args()
        print('I should print', args.echo, 'in', args.color, "- but I'm lazy.")
        
    if __name__ == '__main__':
        main()

    Overwriting test_argparse.py

Then, run it:

    %run test_argparse.py -c red item

    I should print item in red - but I'm lazy.

    %run test_argparse.py -c green item

    I should print item in green - but I'm lazy.

Now, Plumbum:

    %%writefile test_plumbum.py
    from plumbum import cli
    
    class ColorApp(cli.Application):
        color = cli.SwitchAttr(['-c','--color'], help='Color to print')
        
        def main(self, echo):
            print('I should print', echo, 'in', self.color, "- but I'm lazy.")
    
    if __name__ == '__main__':
        ColorApp.run()

    Overwriting test_plumbum.py

When it runs;

    %run test_plumbum.py -c red item

    I should print item in red - but I'm lazy.

    %run test_plumbum.py -c green item

    I should print item in red - but I'm lazy.

If you import cli before running this, it will error out because it has IPython's command line instead of the one you are giving it.

The following patch fixes this behavior.