### PR TITLE
local.cwd doesn't work if cwd changes by non-plumbum means

### DIFF
--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -59,3 +59,13 @@ class six(object):
         def get_method_function(m):
             return m.im_func
 
+class StaticProperty(object):
+    """This acts like a static property, allowing access via class or object.
+    This is a non-data descriptor."""
+    def __init__(self, function):
+        self._function = function
+        self.__doc__ = function.__doc__
+
+    def __get__(self, obj, klass=None):
+        return self._function()
+

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -112,6 +112,18 @@ class LocalCommand(ConcreteCommand):
 #===================================================================================================
 # Local Machine
 #===================================================================================================
+
+class _FunctionDescriptor(object):
+    """This acts like a static property, allowing access via class or object.
+    This is a non-data descriptor."""
+    def __init__(self, function):
+        self._function = function
+        self.__doc__ = function.__doc__
+
+    def __get__(self, obj, klass=None):
+        return self._function()
+
+
 class LocalMachine(BaseMachine):
     """The *local machine* (a singleton object). It serves as an entry point to everything
     related to the local machine, such as working directory and environment manipulation,
@@ -123,8 +135,10 @@ class LocalMachine(BaseMachine):
     * ``env`` - the local environment
     * ``encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
     """
-    cwd = LocalWorkdir()
+
+    cwd = _FunctionDescriptor(LocalWorkdir)
     env = LocalEnv()
+
     encoding = sys.getfilesystemencoding()
     uname = platform.uname()[0]
 

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from plumbum.path.remote import RemotePath
 from plumbum.commands import CommandNotFound, ConcreteCommand
 from plumbum.machines.session import ShellSession
-from plumbum.lib import ProcInfo, IS_WIN32, six
+from plumbum.lib import ProcInfo, IS_WIN32, six, StaticProperty
 from plumbum.commands.daemons import win32_daemonize, posix_daemonize
 from plumbum.commands.processes import iter_lines
 from plumbum.machines.base import BaseMachine
@@ -113,16 +113,6 @@ class LocalCommand(ConcreteCommand):
 # Local Machine
 #===================================================================================================
 
-class _FunctionDescriptor(object):
-    """This acts like a static property, allowing access via class or object.
-    This is a non-data descriptor."""
-    def __init__(self, function):
-        self._function = function
-        self.__doc__ = function.__doc__
-
-    def __get__(self, obj, klass=None):
-        return self._function()
-
 
 class LocalMachine(BaseMachine):
     """The *local machine* (a singleton object). It serves as an entry point to everything
@@ -136,7 +126,7 @@ class LocalMachine(BaseMachine):
     * ``encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
     """
 
-    cwd = _FunctionDescriptor(LocalWorkdir)
+    cwd = StaticProperty(LocalWorkdir)
     env = LocalEnv()
 
     encoding = sys.getfilesystemencoding()

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -131,6 +131,13 @@ class LocalMachineTest(unittest.TestCase):
         self.assertTrue("__init__.py" not in ls().splitlines())
         self.assertRaises(OSError, local.cwd.chdir, "../non_exist1N9")
 
+    def test_mixing_chdir(self):
+        self.assertEqual(local.cwd, os.getcwd())
+        os.chdir('../plumbum')
+        self.assertEqual(local.cwd, os.getcwd())
+        os.chdir('../tests')
+        self.assertEqual(local.cwd, os.getcwd())
+
     def test_path(self):
         self.assertFalse((local.cwd / "../non_exist1N9").exists())
         self.assertTrue((local.cwd / ".." / "plumbum").isdir())


### PR DESCRIPTION
This patch makes the `local.cwd` the current working directory, not just the current working directory when Plumbum loaded, so code like this now works:

```python
assert local.cwd == os.getcwd()
os.chdir('../plumbum')
assert local.cwd == os.getcwd()
os.chdir('../tests')
assert local.cwd == os.getcwd()
```

The `cwd` is now a descriptor in the local machine (and works from class or object access). Added a test similar to the lines above to verify that it works.

(Example of use case: This is a common problem when working with Plumbum in IPython and trying to use `local.cwd` to find files after changing the directory with `cd`.)