### PR TITLE
Better error message

### DIFF
--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -11,13 +11,9 @@ class ShellSessionError(Exception):
     :func:`ShellSession.popen <plumbum.session.ShellSession.popen>`"""
     pass
 
-class SSHCommsError(Exception):
+class SSHCommsError(EOFError):
     """Raises when the communication channel can't be created on the
     remote host or it times out."""
-
-class SSHUnsupportedError(SSHCommsError):
-    """Raises when the error channel can't be opened or times out. Usually
-    because the remote doesn't have Bash as the default shell."""
 
 shell_logger = logging.getLogger("plumbum.shell")
 

--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -15,6 +15,9 @@ class SSHCommsError(EOFError):
     """Raises when the communication channel can't be created on the
     remote host or it times out."""
 
+class SSHCommsChannel2Error(SSHCommsError):
+    """Raises when channel 2 (stderr) is not available"""
+
 shell_logger = logging.getLogger("plumbum.shell")
 
 
@@ -98,8 +101,9 @@ class SessionPopen(object):
                 shell_logger.debug("%s> %r", name, line)
             except EOFError:
                 shell_logger.debug("%s> Nothing returned.", name)
-                msg = "Nothing returned, not even flags. Does the remote exist and have Bash as the default shell?"
-                raise SSHCommsError(msg)
+                msg = "No communication channel detected. Does the remote exist?"
+                msgerr = "No stderr result detected. Does the remote have Bash as the default shell?"
+                raise SSHCommsChannel2Error(msgerr) if name=="2" else SSHCommsError(msg)
             if not line:
                 del sources[i]
             else:


### PR DESCRIPTION
This is a better error message than `EOFError`, hopefully will make #111, #173, and maybe #187 a little clearer by reminding users that bash must be on the remote machine as the default shell. This also makes trying to connect to a non-existent server give a better error message - and the error message is different for this case, making it possible to tell if the remote is accessible at all.