### PR TITLE
Nohup and glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 *.ropeproject
 *.swp
 *~
+*.spyder*

--- a/docs/local_commands.rst
+++ b/docs/local_commands.rst
@@ -232,6 +232,17 @@ or input from the user. ::
     >>> f.stdout
     '.\n..\n.git\n.gitignore\n.project\n.pydevproject\nREADME.rst\nplumbum\n[...]'
 
+
+You can also start a long running process and detach it in ``nohup`` mode using the ``NOHUP`` modifier::
+
+    >>> ls["-a"] & NOHUP
+
+If you want to redirect the input or output to something other than ``nohup.out``, you can add parameters to the modifier::
+
+    >>> ls["-a"] & NOHUP(stdout='/dev/null') # Or None
+
+.. version-added:: 1.6.0
+
 .. _guide-local-commands-nesting:
     
 Command Nesting

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -35,7 +35,7 @@ of command-line interface (CLI) programs.
 See http://plumbum.readthedocs.org for full details
 """
 from plumbum.commands import ProcessExecutionError, CommandNotFound, ProcessTimedOut
-from plumbum.commands import FG, BG, TF, RETCODE, ERROUT
+from plumbum.commands import FG, BG, TF, RETCODE, ERROUT, NOHUP
 from plumbum.path import Path, LocalPath, RemotePath
 from plumbum.machines import local, BaseRemoteMachine, SshMachine, PuttyMachine
 from plumbum.version import version

--- a/plumbum/commands/__init__.py
+++ b/plumbum/commands/__init__.py
@@ -1,4 +1,4 @@
 from plumbum.commands.base import shquote, shquote_list, BaseCommand, ERROUT, ConcreteCommand
-from plumbum.commands.modifiers import ExecutionModifier, Future, FG, BG, TF, RETCODE
+from plumbum.commands.modifiers import ExecutionModifier, Future, FG, BG, TF, RETCODE, NOHUP
 from plumbum.commands.processes import run_proc
 from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut, CommandNotFound

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -134,6 +134,10 @@ class BaseCommand(object):
         :returns: A ``Popen``-like object
         """
         raise NotImplementedError()
+        
+    def nohup(self, command, cwd='.', stdout='nohup.out', stderr=None, append=True):
+        """Runs a command detached."""
+        return self.machine.daemonic_popen(self, cwd, stdout, stderr, append)
 
     @contextmanager
     def bgrun(self, args = (), **kwargs):
@@ -402,8 +406,13 @@ class ConcreteCommand(BaseCommand):
         self.encoding = encoding
         self.cwd = None
         self.env = None
+        
     def __str__(self):
         return str(self.executable)
+        
+    def __repr__(self):
+        return "{0}({1})".format(type(self).__name__, self.executable)        
+    
     def _get_encoding(self):
         return self.encoding
 
@@ -425,7 +434,8 @@ class ConcreteCommand(BaseCommand):
         #    argv = [a.encode(self.encoding) for a in argv if isinstance(a, six.string_types)]
         return argv
 
-
+        
+        
 
 
 

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -7,8 +7,19 @@ import signal
 import traceback
 from plumbum.commands.processes import ProcessExecutionError
 
+class _fake_lock(object):
+    """Needed to allow normal os.exit() to work without error"""
+    def acquire(self, val):
+        return True
+    def release(self):
+        pass
 
-def posix_daemonize(command, cwd):
+def posix_daemonize(command, cwd, stdout=None, stderr=None):
+    if stdout is None:
+        stdout = os.devnull
+    if stderr is None:
+        stderr = stdout
+
     MAX_SIZE = 16384
     rfd, wfd = os.pipe()
     argv = command.formulate()
@@ -21,8 +32,8 @@ def posix_daemonize(command, cwd):
             os.setsid()
             os.umask(0)
             stdin = open(os.devnull, "r")
-            stdout = open(os.devnull, "w")
-            stderr = open(os.devnull, "w")
+            stdout = open(stdout, "w")
+            stderr = open(stderr, "w")
             signal.signal(signal.SIGHUP, signal.SIG_IGN)
             proc = command.popen(cwd = cwd, close_fds = True, stdin = stdin.fileno(), 
                 stdout = stdout.fileno(), stderr = stderr.fileno())
@@ -56,6 +67,7 @@ def posix_daemonize(command, cwd):
         proc.pid = secondpid
         proc.universal_newlines = False
         proc._input = None
+        proc._waitpid_lock = _fake_lock()
         proc._communication_started = False
         proc.args = argv
         proc.argv = argv
@@ -84,11 +96,15 @@ def posix_daemonize(command, cwd):
         return proc
 
 
-def win32_daemonize(command, cwd):
+def win32_daemonize(command, cwd, stdout=None, stderr=None):
+    if stdout is None:
+        stdout = os.devnull
+    if stderr is None:
+        stderr = stdout
     DETACHED_PROCESS = 0x00000008
     stdin = open(os.devnull, "r")
-    stdout = open(os.devnull, "w")
-    stderr = open(os.devnull, "w")
+    stdout = open(stdout, "w")
+    stderr = open(stderr, "w")
     return command.popen(cwd = cwd, stdin = stdin.fileno(), stdout = stdout.fileno(), stderr = stderr.fileno(), 
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS)
 

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -14,7 +14,7 @@ class _fake_lock(object):
     def release(self):
         pass
 
-def posix_daemonize(command, cwd, stdout=None, stderr=None):
+def posix_daemonize(command, cwd, stdout=None, stderr=None, append=True):
     if stdout is None:
         stdout = os.devnull
     if stderr is None:
@@ -32,8 +32,8 @@ def posix_daemonize(command, cwd, stdout=None, stderr=None):
             os.setsid()
             os.umask(0)
             stdin = open(os.devnull, "r")
-            stdout = open(stdout, "w")
-            stderr = open(stderr, "w")
+            stdout = open(stdout, "a" if append else "w")
+            stderr = open(stderr, "a" if append else "w")
             signal.signal(signal.SIGHUP, signal.SIG_IGN)
             proc = command.popen(cwd = cwd, close_fds = True, stdin = stdin.fileno(), 
                 stdout = stdout.fileno(), stderr = stderr.fileno())
@@ -96,15 +96,15 @@ def posix_daemonize(command, cwd, stdout=None, stderr=None):
         return proc
 
 
-def win32_daemonize(command, cwd, stdout=None, stderr=None):
+def win32_daemonize(command, cwd, stdout=None, stderr=None, append=True):
     if stdout is None:
         stdout = os.devnull
     if stderr is None:
         stderr = stdout
     DETACHED_PROCESS = 0x00000008
     stdin = open(os.devnull, "r")
-    stdout = open(stdout, "w")
-    stderr = open(stderr, "w")
+    stdout = open(stdout, "a" if append else "w")
+    stderr = open(stderr, "a" if append else "w")
     return command.popen(cwd = cwd, stdin = stdin.fileno(), stdout = stdout.fileno(), stderr = stderr.fileno(), 
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS)
 

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -40,5 +40,8 @@ class BaseMachine(object):
             return False
         else:
             return True
+            
+    def daemonic_popen(self, command, cwd = "/", stdout=None, stderr=None, append=True):
+        raise NotImplementedError("This is not implemented on this machine!")
 
 

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -101,6 +101,11 @@ class LocalCommand(ConcreteCommand):
     def machine(self):
         return local
 
+    def nohup(self, command, cwd='.', stdout=None, stderr=None):
+        """Runs a command detached. Does not redirect to nohup.out by default
+        (for compatibility with SSHMachine's old default)"""
+        return local.daemonic_popen(self, cwd, stdout, stderr)
+
     def popen(self, args = (), cwd = None, env = None, **kwargs):
         if isinstance(args, six.string_types):
             args = (args,)
@@ -262,7 +267,8 @@ class LocalMachine(BaseMachine):
         proc.argv = argv
         return proc
 
-    def daemonic_popen(self, command, cwd = "/"):
+
+    def daemonic_popen(self, command, cwd = "/", stdout=None, stderr=None):
         """
         On POSIX systems:
 
@@ -281,9 +287,9 @@ class LocalMachine(BaseMachine):
         .. versionadded:: 1.3
         """
         if IS_WIN32:
-            return win32_daemonize(command, cwd)
+            return win32_daemonize(command, cwd, stdout, stderr)
         else:
-            return posix_daemonize(command, cwd)
+            return posix_daemonize(command, cwd, stdout, stderr)
 
     if IS_WIN32:
         def list_processes(self):

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -94,22 +94,15 @@ class LocalCommand(ConcreteCommand):
     def __init__(self, executable, encoding = "auto"):
         ConcreteCommand.__init__(self, executable,
             local.encoding if encoding == "auto" else encoding)
-    def __repr__(self):
-        return "LocalCommand(%r)" % (self.executable,)
 
     @property
     def machine(self):
         return local
 
-    def nohup(self, command, cwd='.', stdout=None, stderr=None):
-        """Runs a command detached. Does not redirect to nohup.out by default
-        (for compatibility with SSHMachine's old default)"""
-        return local.daemonic_popen(self, cwd, stdout, stderr)
-
     def popen(self, args = (), cwd = None, env = None, **kwargs):
         if isinstance(args, six.string_types):
             args = (args,)
-        return local._popen(self.executable, self.formulate(0, args),
+        return self.machine._popen(self.executable, self.formulate(0, args),
             cwd = self.cwd if cwd is None else cwd, env = self.env if env is None else env,
             **kwargs)
 
@@ -268,7 +261,7 @@ class LocalMachine(BaseMachine):
         return proc
 
 
-    def daemonic_popen(self, command, cwd = "/", stdout=None, stderr=None):
+    def daemonic_popen(self, command, cwd = "/", stdout=None, stderr=None, append=True):
         """
         On POSIX systems:
 
@@ -287,9 +280,9 @@ class LocalMachine(BaseMachine):
         .. versionadded:: 1.3
         """
         if IS_WIN32:
-            return win32_daemonize(command, cwd, stdout, stderr)
+            return win32_daemonize(command, cwd, stdout, stderr, append)
         else:
-            return posix_daemonize(command, cwd, stdout, stderr)
+            return posix_daemonize(command, cwd, stdout, stderr, append)
 
     if IS_WIN32:
         def list_processes(self):

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -113,6 +113,9 @@ class RemoteCommand(ConcreteCommand):
         return "RemoteCommand(%r, %r)" % (self.remote, self.executable)
     def popen(self, args = (), **kwargs):
         return self.remote.popen(self[args], **kwargs)
+    def nohup(self, cwd='.', stdout='nohup.out', stderr=None, append=True):
+        """Runs a command detached."""
+        return machine.nohup(self, cwd, stdout, stderr, append)
 
 class ClosedRemoteMachine(Exception):
     pass

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -146,12 +146,12 @@ class SshMachine(BaseRemoteMachine):
         if stdout is None:
             stdout = "/dev/null"
         if stderr is None:
-            stderr = stdout
+            stderr = "&1"
 
         args = ["cd", str(cwd), "&&", "nohup"]
         args.extend(command.formulate())
         args.extend([(">>" if append else ">")+str(stdout),
-            "2"+(">>" if append else ">")+str(stderr), "</dev/null"])
+            "2"+(">>" if (append and stderr!="&1") else ">")+str(stderr), "</dev/null"])
         proc = self.popen(args, ssh_opts = ["-f"])
         rc = proc.wait()
         try:

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -133,22 +133,26 @@ class SshMachine(BaseRemoteMachine):
         """
         warnings.warn("Use .nohup on the command or use daemonic_popen)", DeprecationWarning)
         self.daemonic_popen(command, cwd='.', stdout=None, stderr=None, append=False)
-        
+
     def daemonic_popen(self, command, cwd='.', stdout=None, stderr=None, append=True):
         """
         Runs the given command using ``nohup`` and redirects std handles,
         allowing the command to run "detached" from its controlling TTY or parent.
         Does not return anything.
-        
+
         .. versionadded:: 1.6.0
-        
+
         """
         if stdout is None:
             stdout = "/dev/null"
         if stderr is None:
             stderr = "&1"
 
-        args = ["cd", str(cwd), "&&", "nohup"]
+        if str(cwd) == '.':
+            args = []
+        else:
+            args = ["cd", str(cwd), "&&"]
+        args.append("nohup")
         args.extend(command.formulate())
         args.extend([(">>" if append else ">")+str(stdout),
             "2"+(">>" if (append and stderr!="&1") else ">")+str(stderr), "</dev/null"])

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -264,6 +264,17 @@ class Path(six.ABC):
         """Same as ``self.relative_to(other)``"""
         return self.relative_to(other)
 
+    def _glob(self, pattern, fn):
+        """Applies a glob string or list/tuple/iterable to the current path, using ``fn``"""
+        if isinstance(pattern, str):
+            return fn(pattern)
+        else:
+            results = []
+            for single_pattern in pattern:
+                results.extend(fn(single_pattern))
+            return sorted(list(set(results)))
+
+
 
 class RelativePath(object):
     """

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -139,7 +139,8 @@ class LocalPath(Path):
 
     @_setdoc(Path)
     def glob(self, pattern):
-        return [LocalPath(fn) for fn in glob.glob(str(self / pattern))]
+        fn = lambda pat: [LocalPath(m) for m in glob.glob(str(self / pat))]
+        return self._glob(pattern, fn) 
 
     @_setdoc(Path)
     def delete(self):

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -164,7 +164,8 @@ class RemotePath(Path):
 
     @_setdoc(Path)
     def glob(self, pattern):
-        return [RemotePath(self.remote, m) for m in self.remote._path_glob(self, pattern)]
+        fn = lambda pat: [RemotePath(self.remote, m) for m in self.remote._path_glob(self, pat)]
+        return self._glob(pattern, fn)
 
     @_setdoc(Path)
     def delete(self):

--- a/tests/slow_process.bash
+++ b/tests/slow_process.bash
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-echo "Starting test" > outputfile.out
-for i in $(seq 1 10)
+echo "Starting test" > slow_process.out
+for i in $(seq 1 3)
 do
     echo $i
-    echo $i >> outputfile.out
-    sleep 2
+    echo $i >> slow_process.out
+    sleep .5
 done
 

--- a/tests/slow_process.bash
+++ b/tests/slow_process.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Starting test" > outputfile.out
+for i in $(seq 1 10)
+do
+    echo $i
+    echo $i >> outputfile.out
+    sleep 2
+done
+

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -153,6 +153,10 @@ class LocalMachineTest(unittest.TestCase):
             if fn.basename == "index.rst":
                 found = True
         self.assertTrue(found)
+        for fn in local.cwd / ".." // ("*/*.rst", "*./*.html"):
+            if fn.basename == "index.rst":
+                found = True
+        self.assertTrue(found)
 
     def test_env(self):
         self.assertTrue("PATH" in local.env)

--- a/tests/test_nohup.py
+++ b/tests/test_nohup.py
@@ -9,7 +9,7 @@ from plumbum.path.utils import delete
 
 class NOHUP_LOCAL(unittest.TestCase):
     def read_file(self, filename):
-        self.assertIn(filename, os.listdir())
+        self.assertIn(filename, os.listdir('.'))
         with open(filename) as f:
             return f.read()
 

--- a/tests/test_nohup.py
+++ b/tests/test_nohup.py
@@ -1,0 +1,62 @@
+import os
+import unittest
+import sys
+import time
+from plumbum import local, NOHUP
+from plumbum.cmd import bash, echo
+from plumbum.path.utils import delete
+
+
+class NOHUP_LOCAL(unittest.TestCase):
+    def read_file(self, filename):
+        self.assertIn(filename, os.listdir())
+        with open(filename) as f:
+            return f.read()
+
+    def test_slow(self):
+        delete('nohup.out')
+        sp = bash['slow_process.bash']
+        sp & NOHUP
+        time.sleep(.1)
+        self.assertEqual(self.read_file('slow_process.out'), 'Starting test\n1\n')
+        self.assertEqual(self.read_file('nohup.out'), '1\n')
+        time.sleep(.5)
+        self.assertEqual(self.read_file('slow_process.out'), 'Starting test\n1\n2\n')
+        self.assertEqual(self.read_file('nohup.out'), '1\n2\n')
+        time.sleep(1.1)
+        delete('nohup.out', 'slow_process.out')
+
+    def test_append(self):
+        delete('nohup.out')
+        output = echo['This is output']
+        output & NOHUP
+        time.sleep(.1)
+        self.assertEqual(self.read_file('nohup.out'), 'This is output\n')
+        output & NOHUP
+        time.sleep(.1)
+        self.assertEqual(self.read_file('nohup.out'), 'This is output\n'*2)
+        delete('nohup.out')
+
+    def test_redir(self):
+        delete('nohup_new.out')
+        output = echo['This is output']
+
+        output & NOHUP(stdout = 'nohup_new.out')
+        time.sleep(.1)
+        self.assertEqual(self.read_file('nohup_new.out'), 'This is output\n')
+        delete('nohup_new.out')
+
+        (output > 'nohup_new.out') & NOHUP
+        time.sleep(.1)
+        self.assertEqual(self.read_file('nohup_new.out'), 'This is output\n')
+        delete('nohup_new.out')
+
+        output & NOHUP
+        time.sleep(.1)
+        self.assertEqual(self.read_file('nohup.out'), 'This is output\n')
+        delete('nohup.out')
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -107,6 +107,12 @@ s.close()
                 self.assertTrue("'|'" in str(cmd))
                 self.assertTrue("test_remote.py" in cmd())
                 self.assertTrue("test_remote.py" in [f.basename for f in rem.cwd // "*.py"])
+                
+    def test_glob(self):
+        with self._connect() as rem:
+            filenames = [f.basename for f in rem.cwd // ("*.py", "*.bash")]
+            self.assertTrue("test_remote.py" in filenames)
+            self.assertTrue("slow_process.bash" in filenames)
 
     def test_download_upload(self):
         with self._connect() as rem:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -236,6 +236,7 @@ class RemoteMachineTest(unittest.TestCase, BaseRemoteMachineTest):
             sleep = rem["sleep"]
             sleep["5.793817"] & NOHUP(stdout = None)
             time.sleep(.5)
+            print(rem["ps"]("aux"))
             self.assertTrue(list(rem.pgrep("5.793817")))
             time.sleep(6)
             self.assertFalse(list(rem.pgrep("5.793817")))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -107,12 +107,13 @@ s.close()
                 self.assertTrue("'|'" in str(cmd))
                 self.assertTrue("test_remote.py" in cmd())
                 self.assertTrue("test_remote.py" in [f.basename for f in rem.cwd // "*.py"])
-                
+
     def test_glob(self):
         with self._connect() as rem:
-            filenames = [f.basename for f in rem.cwd // ("*.py", "*.bash")]
-            self.assertTrue("test_remote.py" in filenames)
-            self.assertTrue("slow_process.bash" in filenames)
+            with rem.cwd(os.path.dirname(os.path.abspath(__file__))):
+                filenames = [f.basename for f in rem.cwd // ("*.py", "*.bash")]
+                self.assertTrue("test_remote.py" in filenames)
+                self.assertTrue("slow_process.bash" in filenames)
 
     def test_download_upload(self):
         with self._connect() as rem:
@@ -234,7 +235,7 @@ class RemoteMachineTest(unittest.TestCase, BaseRemoteMachineTest):
     def test_nohup(self):
         with self._connect() as rem:
             sleep = rem["sleep"]
-            sleep["5.793817"] & NOHUP(stdout = None)
+            sleep["5.793817"] & NOHUP(stdout = None, append=False)
             time.sleep(.5)
             print(rem["ps"]("aux"))
             self.assertTrue(list(rem.pgrep("5.793817")))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -229,6 +229,7 @@ class RemoteMachineTest(unittest.TestCase, BaseRemoteMachineTest):
         with self._connect() as rem:
             sleep = rem["sleep"]
             sleep["5.793817"] & NOHUP(stdout = None)
+            time.sleep(.5)
             self.assertTrue(list(rem.pgrep("5.793817")))
             time.sleep(6)
             self.assertFalse(list(rem.pgrep("5.793817")))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -4,7 +4,7 @@ import socket
 import unittest
 import time
 import logging
-from plumbum import RemotePath, SshMachine, ProcessExecutionError, local, ProcessTimedOut
+from plumbum import RemotePath, SshMachine, ProcessExecutionError, local, ProcessTimedOut, NOHUP
 from plumbum import CommandNotFound
 from plumbum.lib import six
 
@@ -228,7 +228,7 @@ class RemoteMachineTest(unittest.TestCase, BaseRemoteMachineTest):
     def test_nohup(self):
         with self._connect() as rem:
             sleep = rem["sleep"]
-            rem.nohup(sleep["5.793817"])
+            sleep["5.793817"] & NOHUP(stdout = None)
             self.assertTrue(list(rem.pgrep("5.793817")))
             time.sleep(6)
             self.assertFalse(list(rem.pgrep("5.793817")))


### PR DESCRIPTION
This patch adds two things:

1:
I've added a NOHUP modifier, working on both local and ssh_machines. It unifies the syntax for the two machines and makes it easier to use. The classic methods of doing this, `local.daemonic_popen` and `ssh_machine.nohup` are still supported for compatibility. As part of the patch, minor cleanup was done on execution modifiers class structure. The nohup modifier is a little like bash syntax:
```python
>>> local['sleep'][1.234] & NOHUP
```
vs.
```bash
>>> nohup sleep 1.234 & 
```

It defaults to nohup's std output, but can use new output files and `"/dev/null"` too, and can append or replace. It even respects `>` and `>>` on the command it is applied to.

Like bash's nohup, it disconnects from the process started, even if the current process/shell is exited.

2:
Added support for globbing with a list. You can now do:
```python
>>> local.cwd // ('*.tar.gz', '*.zip')
```
And get a list of items that match both globs. This helps make up for the fact that that python's glob module doesn't support the '{}' syntax of bash.