### PR TITLE
Positional argument decorator

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -198,6 +198,28 @@ these values. Here's an example ::
    All of these convert the argument to a :ref:`local path <guide-paths>`.
 
 
+Positional Arguements
+^^^^^^^^^^^^^^^^^^^^^
+
+You can supply positional argument validators using the ``cli.positional`` decorator. Simply
+pass the validators in the decorator matching the names in the main function. For example::
+
+    class MyApp(cli.Application):
+        @positional(cli.ExistingFile, cli.NonexistantPath)
+        def main(self, infile, *outfiles):
+            "infile is a path, outfiles are a list of paths, proper errors are given"
+
+If you only want to run your application in Python 3, you can also use annotations to
+specify the validators. For example::
+
+    class MyApp(cli.Application):
+        def main(self, infile : cli.ExistingFile, *outfiles : cli.NonexistantPath):
+        "Identical to above MyApp"
+
+Annotations are ignored if the positional decorator is present.
+    
+.. versionadded:: 1.5.0
+
 Repeatable Switches
 ^^^^^^^^^^^^^^^^^^^
 Many times, you would like to allow a certain switch to be given multiple times. For instance,

--- a/plumbum/cli/__init__.py
+++ b/plumbum/cli/__init__.py
@@ -1,3 +1,3 @@
-from plumbum.cli.switches import SwitchError, switch, autoswitch, SwitchAttr, Flag, CountOf, validate
+from plumbum.cli.switches import SwitchError, switch, autoswitch, SwitchAttr, Flag, CountOf, positional
 from plumbum.cli.switches import Range, Set, ExistingDirectory, ExistingFile, NonexistentPath, Predicate
 from plumbum.cli.application import Application, ColorfulApplication

--- a/plumbum/cli/__init__.py
+++ b/plumbum/cli/__init__.py
@@ -1,3 +1,3 @@
-from plumbum.cli.switches import SwitchError, switch, autoswitch, SwitchAttr, Flag, CountOf
+from plumbum.cli.switches import SwitchError, switch, autoswitch, SwitchAttr, Flag, CountOf, validate
 from plumbum.cli.switches import Range, Set, ExistingDirectory, ExistingFile, NonexistentPath, Predicate
 from plumbum.cli.application import Application, ColorfulApplication

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function, absolute_import
 import os
 import sys
-import inspect
 import functools
 from textwrap import TextWrapper
 from collections import defaultdict
@@ -388,19 +387,50 @@ class Application(object):
                 raise SwitchCombinationError("Given %s, the following are invalid %r" %
                     (swfuncs[func].swname, [swfuncs[f].swname for f in invalid]))
 
-        m_args, m_varargs, _, m_defaults = six.getargspec(self.main)
-        max_args = six.MAXSIZE if m_varargs else len(m_args) - 1
-        min_args = len(m_args) - 1 - (len(m_defaults) if m_defaults else 0)
+        m = six.getfullargspec(self.main)
+        max_args = six.MAXSIZE if m.varargs else len(m.args) - 1
+        min_args = len(m.args) - 1 - (len(m.defaults) if m.defaults else 0)
         if len(tailargs) < min_args:
             raise PositionalArgumentsError("Expected at least %d positional arguments, got %r" %
                 (min_args, tailargs))
         elif len(tailargs) > max_args:
             raise PositionalArgumentsError("Expected at most %d positional arguments, got %r" %
-                (max_args, tailargs))
+                (max_args, tailargs))            
+                
+        # Positional arguement validataion
+        if hasattr(self.main, 'positional'):
+            tailargs = self._positional_validate(tailargs, self.main.positional, self.main.positional_varargs)
+            
+        elif hasattr(m, 'annotations'):
+            args_names = list(m.args[1:])
+            positional = [None]*len(args_names)
+            varargs = None
+            
+            
+             # All args are positional, so convert kargs to positional
+            for item in m.annotations:
+                if item == m.varargs:
+                    varargs = m.annotations[item]
+                else:
+                    positional[args_names.index(item)] = m.annotations[item]
+
+            tailargs = self._positional_validate(tailargs, positional, varargs)
 
         ordered = [(f, a) for _, f, a in
             sorted([(sf.index, f, sf.val) for f, sf in swfuncs.items()])]
         return ordered, tailargs
+
+    def _positional_validate(self, args, validator_list, varargs):
+        """Makes sure args follows the validation given input"""
+        out_args = list(args)
+        
+        for i in range(min(len(args),len(validator_list))):
+            out_args[i] = args[i] if validator_list[i] is None else validator_list[i](args[i])
+        
+        if len(args) > len(validator_list):
+            out_args[len(validator_list):] = args[len(validator_list):] if varargs is None else list(map(varargs,args[len(validator_list):]))
+        
+        return out_args
 
     @classmethod
     def run(cls, argv = None, exit = True):  # @ReservedAssignment
@@ -473,23 +503,8 @@ class Application(object):
         """
 
         inst = cls("")
-        swfuncs = {}
-        for index, (swname, val) in enumerate(switches.items(), 1):
-            switch = getattr(cls, swname)
-            swinfo = inst._switches_by_func[switch._switch_info.func]
-            if isinstance(switch, CountOf):
-                p = (range(val),)
-            elif swinfo.list and not hasattr(val, "__iter__"):
-                raise SwitchError("Switch %r must be a sequence (iterable)" % (swname,))
-            elif not swinfo.argtype:
-                # a flag
-                if val not in (True, False, None, Flag):
-                    raise SwitchError("Switch %r is a boolean flag" % (swname,))
-                p = ()
-            else:
-                p = (val,)
-            swfuncs[swinfo.func] = SwitchParseInfo(swname, p, index)
-
+        
+        swfuncs = inst._parse_kwd_args(switches)
         ordered, tailargs = inst._validate_args(swfuncs, args)
         for f, a in ordered:
             f(inst, *a)
@@ -507,6 +522,26 @@ class Application(object):
             cleanup()
 
         return inst, retcode
+
+    def _parse_kwd_args(self, switches):
+        """Parses keywords (positional arguments), used by invoke."""
+        swfuncs = {}
+        for index, (swname, val) in enumerate(switches.items(), 1):
+            switch = getattr(type(self), swname)
+            swinfo = self._switches_by_func[switch._switch_info.func]
+            if isinstance(switch, CountOf):
+                p = (range(val),)
+            elif swinfo.list and not hasattr(val, "__iter__"):
+                raise SwitchError("Switch %r must be a sequence (iterable)" % (swname,))
+            elif not swinfo.argtype:
+                # a flag
+                if val not in (True, False, None, Flag):
+                    raise SwitchError("Switch %r is a boolean flag" % (swname,))
+                p = ()
+            else:
+                p = (val,)
+            swfuncs[swinfo.func] = SwitchParseInfo(swname, p, index)
+        return swfuncs
 
     def main(self, *args):
         """Implement me (no need to call super)"""
@@ -555,13 +590,13 @@ class Application(object):
         if self.DESCRIPTION:
             print(self.COLOR_DISCRIPTION[self.DESCRIPTION.strip() + '\n'])
 
-        m_args, m_varargs, _, m_defaults = six.getargspec(self.main)
-        tailargs = m_args[1:]  # skip self
-        if m_defaults:
-            for i, d in enumerate(reversed(m_defaults)):
+        m = six.getfullargspec(self.main)
+        tailargs = m.args[1:]  # skip self
+        if m.defaults:
+            for i, d in enumerate(reversed(m.defaults)):
                 tailargs[-i - 1] = "[%s=%r]" % (tailargs[-i - 1], d)
-        if m_varargs:
-            tailargs.append("%s..." % (m_varargs,))
+        if m.varargs:
+            tailargs.append("%s..." % (m.varargs,))
         tailargs = " ".join(tailargs)
 
         with self.COLOR_USAGE:

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -282,6 +282,8 @@ class positional(object):
     Validators should be callable, and should have a .choices() function with
     possible choices. (For future argument completion, for example)
     
+    Default arguments do not go through the validator.
+    
     #TODO: Check with MyPy
     
     """

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -1,7 +1,5 @@
-import inspect
 from plumbum.lib import six, getdoc
 from plumbum import local
-import functools
 
 from abc import abstractmethod
 
@@ -261,13 +259,13 @@ class CountOf(SwitchAttr):
 
 
 
-class validate(object):
+class positional(object):
     """
     Runs a validator on the main function for a class.    
     This should be used like this:
     
     class MyApp(cli.Application):
-        @cli.validate(cli.Range(1,10), cli.ExistingFile)
+        @cli.positional(cli.Range(1,10), cli.ExistingFile)
         def main(self, x, *f):
             # x is a range, f's are all ExistingFile's)
     

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -10,7 +10,6 @@ With the ``Style`` class, any color can be directly called or given to a with st
 from __future__ import print_function
 import sys
 import os
-import platform
 import re
 from copy import copy
 from plumbum.colorlib.names import color_names, color_html
@@ -126,9 +125,6 @@ class Color(ABC):
 
         self.exact = True
         'This is false if the named color does not match the real color'
-
-        self.use_color = True
-        'This is a toggle for color (or max representation)'
 
         if None in (g,b):
             if not r_or_color:

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -27,7 +27,7 @@ class six(object):
     A light-weight version of six (which works on IronPython)
     """
     PY3 = sys.version_info[0] >= 3
-    ABC = ABCMeta('ABC', (object,), {'__module__':__name__})
+    ABC = ABCMeta('ABC', (object,), {'__module__':__name__, '__slots__':()})
 
     # Be sure to use named-tuple access, so that different order doesn't affect usage
     try:

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -29,12 +29,11 @@ class six(object):
     PY3 = sys.version_info[0] >= 3
     ABC = ABCMeta('ABC', (object,), {'__module__':__name__, '__slots__':()})
 
-    # Be sure to use named-tuple access, so that different order doesn't affect usage
+    # Be sure to use named-tuple access, so that usage is not affected
     try:
-        getargspec = staticmethod(inspect.getargspec)
+        getfullargspec = staticmethod(inspect.getfullargspec)
     except AttributeError:
-        getargspec = staticmethod(lambda func: inspect.getfullargspec(func)[:4])
-
+        getfullargspec = staticmethod(inspect.getargspec) # extra fields will not be available
 
     if PY3:
         integer_types = (int,)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,9 @@
-import sys
 import unittest
-from plumbum import cli
 import time
 
 from plumbum import cli, local
 from plumbum.cli.terminal import ask, choose, hexdump, Progress
-from plumbum.lib import six, captured_stdout, StringIO, ensure_skipIf
+from plumbum.lib import captured_stdout, ensure_skipIf
 
 ensure_skipIf(unittest)
 
@@ -31,10 +29,7 @@ class TestApp(cli.Application):
         self.eggs = old
         self.tailargs = args
         
-class MainValidator(cli.Application):
-    @cli.validate
-    def main(self, myint:int, *mylist:int):
-        print(myint, mylist)
+
 
 class Geet(cli.Application):
     debug = cli.Flag("--debug")
@@ -204,34 +199,6 @@ class CLITest(unittest.TestCase):
             _, rc = TestApp.run(["arg"], exit = False)
             self.assertEqual(rc, 2)
             self.assertIn("bacon is mandatory", stream.getvalue())
-
-class TestValidator(unittest.TestCase):
-    def test_valid(self):
-        
-        class DummyApplication(object):
-            pass
-        
-        class Try(DummyApplication):
-            @cli.validate(x=abs, y=str)
-            def main(selfy, x, y):
-                self.assertEqual(x,1)
-                self.assertEqual(y,'2')
-
-        Try().main(-1, 2)
-
-        class Try2(DummyApplication):
-            @cli.validate
-            def main(selfy, x:float, *args:abs):
-                self.assertEqual(x, 1.0)
-                self.assertEqual(args, (2,3,4))
-                
-        Try2().main(1, -2, -3, 4)
-        
-        self.assertTrue(hasattr(Try.main, 'keywords'))
-        
-    def test_prog(self):
-        _, rc = MainValidator.run(["1.1", '1', '2'], exit = False)
-        self.assertEqual(rc, 0)
 
 
 class TestTerminal(unittest.TestCase):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,18 +2,18 @@
 from __future__ import print_function, division
 import unittest
 from plumbum import cli
-from plumbum.lib import captured_stdout, ensure_skipIf
+from plumbum.lib import captured_stdout
 from plumbum.lib import six
 
 class MainValidator(cli.Application):
-    @cli.validate(int, int, int)
+    @cli.positional(int, int, int)
     def main(self, myint, myint2, *mylist):
         print(myint, myint2, mylist)
 
 class TestValidator(unittest.TestCase):
     def test_named(self):
         class Try(object):
-            @cli.validate(x=abs, y=str)
+            @cli.positional(x=abs, y=str)
             def main(selfy, x, y):
                 pass
 
@@ -22,7 +22,7 @@ class TestValidator(unittest.TestCase):
 
     def test_position(self):
         class Try(object):
-            @cli.validate(abs, str)
+            @cli.positional(abs, str)
             def main(selfy, x, y):
                 pass
 
@@ -31,7 +31,7 @@ class TestValidator(unittest.TestCase):
 
     def test_mix(self):
         class Try(object):
-            @cli.validate(abs, str, d=bool)
+            @cli.positional(abs, str, d=bool)
             def main(selfy, x, y, z, d):
                 pass
 
@@ -40,7 +40,7 @@ class TestValidator(unittest.TestCase):
 
     def test_var(self):
         class Try(object):
-            @cli.validate(abs, str, int)
+            @cli.positional(abs, str, int)
             def main(selfy, x, y, *g):
                 pass
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import unittest
+from plumbum import cli
+from plumbum.lib import captured_stdout, ensure_skipIf
+from plumbum.lib import six
+
+class MainValidator(cli.Application):
+    @cli.validate(int, int, int)
+    def main(self, myint, myint2, *mylist):
+        print(myint, myint2, mylist)
+
+class TestValidator(unittest.TestCase):
+    def test_named(self):
+        class Try(object):
+            @cli.validate(x=abs, y=str)
+            def main(selfy, x, y):
+                pass
+
+        self.assertEqual(Try.main.positional, [abs, str])
+        self.assertEqual(Try.main.positional_varargs, None)
+
+    def test_position(self):
+        class Try(object):
+            @cli.validate(abs, str)
+            def main(selfy, x, y):
+                pass
+
+        self.assertEqual(Try.main.positional, [abs, str])
+        self.assertEqual(Try.main.positional_varargs, None)
+        
+    def test_mix(self):  
+        class Try(object):
+            @cli.validate(abs, str, d=bool)
+            def main(selfy, x, y, z, d):
+                pass
+
+        self.assertEqual(Try.main.positional, [abs, str, None, bool])
+        self.assertEqual(Try.main.positional_varargs, None)
+        
+    def test_var(self):
+        class Try(object):
+            @cli.validate(abs, str, int)
+            def main(selfy, x, y, *g):
+                pass
+
+        self.assertEqual(Try.main.positional, [abs, str])
+        self.assertEqual(Try.main.positional_varargs, int)
+        
+class TestProg(unittest.TestCase):
+    def test_prog(self):
+        with captured_stdout() as stream:
+            _, rc = MainValidator.run(["prog", "1", "2", '3', '4', '5'], exit = False)
+        self.assertEqual(rc, 0)
+        self.assertIn("1 2 (3, 4, 5)", stream.getvalue())
+   
+# Unfortionatly, Py3 anotations are a syntax error in Py2, so using exec to add test for Py3     
+if six.PY3:
+    exec("""
+class Main3Validator(cli.Application):
+    def main(self, myint:int, myint2:int, *mylist:int):
+        print(myint, myint2, mylist)
+class TestProg3(unittest.TestCase):
+    def test_prog(self):
+        with captured_stdout() as stream:
+            _, rc = Main3Validator.run(["prog", "1", "2", '3', '4', '5'], exit = False)
+        self.assertEqual(rc, 0)
+        self.assertIn("1 2 (3, 4, 5)", stream.getvalue())""")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -73,7 +73,8 @@ class TestProg(unittest.TestCase):
             _, rc = MainValidator.run(["prog", "1.2", "2", '3', '4', '5'], exit = False)
         self.assertEqual(rc, 2)
         value = stream.getvalue().strip()
-        self.assertTrue("Error: Argument of myint expected to be <class 'int'>, not '1.2':" in value)
+        self.assertTrue("'int'>, not '1.2':" in value)
+        self.assertTrue(" 'int'>, not '1.2':" in value)
         self.assertTrue('''ValueError("invalid literal for int() with base 10: '1.2'"''' in value)
 
     def test_defaults(self):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function, division
 import unittest
 from plumbum import cli
 from plumbum.lib import captured_stdout, ensure_skipIf
@@ -27,8 +28,8 @@ class TestValidator(unittest.TestCase):
 
         self.assertEqual(Try.main.positional, [abs, str])
         self.assertEqual(Try.main.positional_varargs, None)
-        
-    def test_mix(self):  
+
+    def test_mix(self):
         class Try(object):
             @cli.validate(abs, str, d=bool)
             def main(selfy, x, y, z, d):
@@ -36,7 +37,7 @@ class TestValidator(unittest.TestCase):
 
         self.assertEqual(Try.main.positional, [abs, str, None, bool])
         self.assertEqual(Try.main.positional_varargs, None)
-        
+
     def test_var(self):
         class Try(object):
             @cli.validate(abs, str, int)
@@ -45,15 +46,15 @@ class TestValidator(unittest.TestCase):
 
         self.assertEqual(Try.main.positional, [abs, str])
         self.assertEqual(Try.main.positional_varargs, int)
-        
+
 class TestProg(unittest.TestCase):
     def test_prog(self):
         with captured_stdout() as stream:
             _, rc = MainValidator.run(["prog", "1", "2", '3', '4', '5'], exit = False)
         self.assertEqual(rc, 0)
         self.assertIn("1 2 (3, 4, 5)", stream.getvalue())
-   
-# Unfortionatly, Py3 anotations are a syntax error in Py2, so using exec to add test for Py3     
+
+# Unfortionatly, Py3 anotations are a syntax error in Py2, so using exec to add test for Py3
 if six.PY3:
     exec("""
 class Main3Validator(cli.Application):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -52,7 +52,17 @@ class TestProg(unittest.TestCase):
         with captured_stdout() as stream:
             _, rc = MainValidator.run(["prog", "1", "2", '3', '4', '5'], exit = False)
         self.assertEqual(rc, 0)
-        self.assertIn("1 2 (3, 4, 5)", stream.getvalue())
+        self.assertEqual("1 2 (3, 4, 5)", stream.getvalue().strip())
+
+    def test_failure(self):
+        with captured_stdout() as stream:
+            _, rc = MainValidator.run(["prog", "1.2", "2", '3', '4', '5'], exit = False)
+        self.assertEqual(rc, 2)
+        value = stream.getvalue().strip()
+        self.assertTrue("Error: Argument of myint expected to be <class 'int'>, not '1.2':" in value)
+        self.assertTrue('''ValueError("invalid literal for int() with base 10: '1.2'"''' in value)
+
+        
 
 # Unfortionatly, Py3 anotations are a syntax error in Py2, so using exec to add test for Py3
 if six.PY3:


### PR DESCRIPTION
​Adding positional arguments decorator to `plumbum.cli`. This allows positional or named validators to be added via a decorator on the main function. Default arguments do not go through the validator. For example:
```python
class MyApp(cli.Application):
    @cli.positional(int, float, cli.ExistingFile)
    def main(self, myint, myfloat, *inputs):
        assert isinstance(myint,int)
        ...
```
This also supports Python 3 notation:
```python
class MyApp(cli.Application):
    def main(self, myint : int, myfloat : float, *inputs : cli.ExistingFile):
        assert isinstance(x,int)
        ...
```
Also fixed a bug with missing `__slots__` in `ABC`, causing `ABC` subclasses to be `__dict__` classes.

Besides convenience and clarity, especially for variable args, this is going to be important for 1.7.0 if we can get argument completion (since the classic method of manually validating each argument inside main is not introspectable). I have not changed the help output, but that is another future possibility.

Closes #200 (my own request)