### PR TITLE
Path subclassing str

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -145,14 +145,16 @@ class BaseRemoteMachine(BaseMachine):
 
     # allow inheritors to override the RemoteCommand class
     RemoteCommand = RemoteCommand
-
+    
+    @property
+    def cwd(self):
+        return RemoteWorkdir(self)
 
     def __init__(self, encoding = "utf8", connect_timeout = 10, new_session = False):
         self.encoding = encoding
         self.connect_timeout = connect_timeout
         self._session = self.session(new_session = new_session)
         self.uname = self._get_uname()
-        self.cwd = RemoteWorkdir(self)
         self.env = RemoteEnv(self)
         self._python = None
 

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -26,7 +26,6 @@ class Path(str, six.ABC):
     :class:`RemotePath <plumbum.path.remote.RemotePath>`.
     """
 
-    __slots__ = ()
     CASE_SENSITIVE = True
 
     def __repr__(self):
@@ -337,7 +336,6 @@ class RelativePath(object):
 
     Relative paths are created by subtracting paths (``Path.relative_to``)
     """
-    __slots__ = ('parts',)
 
     def __init__(self, parts):
         self.parts = parts

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -20,13 +20,13 @@ class FSUser(int):
         self.name = name
         return self
 
-class Path(six.ABC):
+class Path(str, six.ABC):
     """An abstraction over file system paths. This class is abstract, and the two implementations
     are :class:`LocalPath <plumbum.machines.local.LocalPath>` and
     :class:`RemotePath <plumbum.path.remote.RemotePath>`.
     """
 
-    __slots__ = []
+    __slots__ = ()
     CASE_SENSITIVE = True
 
     def __repr__(self):
@@ -337,6 +337,8 @@ class RelativePath(object):
 
     Relative paths are created by subtracting paths (``Path.relative_to``)
     """
+    __slots__ = ('parts',)
+
     def __init__(self, parts):
         self.parts = parts
     def __str__(self):

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -38,7 +38,6 @@ logger = logging.getLogger("plumbum.local")
 class LocalPath(Path):
     """The class implementing local-machine paths"""
 
-    __slots__ = ()
     CASE_SENSITIVE = not IS_WIN32
 
     def __new__(cls, *parts):
@@ -313,7 +312,6 @@ class LocalPath(Path):
 class LocalWorkdir(LocalPath):
     """Working directory manipulator"""
 
-    __slots__ = ()
 
     def __hash__(self):
         raise TypeError("unhashable type")

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -30,7 +30,6 @@ class StatRes(object):
 class RemotePath(Path):
     """The class implementing remote-machine paths"""
 
-    __slots__ = ("remote", "CASE_SENSITIVE")
 
     def __new__(cls, remote, *parts):
         if not parts:
@@ -56,7 +55,7 @@ class RemotePath(Path):
                     normed.append(item)
         if windows:
             self = super(RemotePath, cls).__new__(cls, "\\".join(normed))
-            self.CASE_SENSITIVE = False
+            self.CASE_SENSITIVE = False # On this object only
         else:
             self = super(RemotePath, cls).__new__(cls, "/" + "/".join(normed))
             self.CASE_SENSITIVE = True

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -377,6 +377,19 @@ class LocalMachineTest(unittest.TestCase):
 
         self.assertFalse(dir.exists())
 
+    def test_direct_open_tmpdir(self):
+        from plumbum.cmd import cat
+        with local.tempdir() as dir:
+            self.assertTrue(dir.is_dir())
+            data = six.b("hello world")
+            with open(dir / "test.txt", "wb") as f:
+                f.write(data)
+            with open(dir / "test.txt", "rb") as f:
+                self.assertEqual(f.read(), data)
+
+        self.assertFalse(dir.exists())
+
+
     def test_read_write(self):
         with local.tempdir() as tmp:
             data = six.b("hello world")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -35,7 +35,7 @@ class RemotePathTest(unittest.TestCase):
         self.assertEqual("ftp://", p1.as_uri('ftp')[:6])
         self.assertEqual("ssh://", p1.as_uri('ssh')[:6])
         self.assertEqual("/some/long/path/to/file.txt", p1.as_uri()[-27:])
-        
+
     def test_stem(self):
         p = RemotePath(self._connect(), "/some/long/path/to/file.txt")
         self.assertEqual(p.stem, "file")
@@ -79,17 +79,13 @@ class RemotePathTest(unittest.TestCase):
 class BaseRemoteMachineTest(object):
     TUNNEL_PROG = r"""import sys, socket
 s = socket.socket()
-if sys.version_info[0] < 3:
-    b = lambda x: x
-else:
-    b = lambda x: bytes(x, "utf8")
 s.bind(("", 0))
 s.listen(1)
-sys.stdout.write(b("%s\n" % (s.getsockname()[1],)))
+sys.stdout.write("%s\n" % (s.getsockname()[1],))
 sys.stdout.flush()
 s2, _ = s.accept()
 data = s2.recv(100)
-s2.send(b("hello ") + data)
+s2.send("hello " + data)
 s2.close()
 s.close()
 """


### PR DESCRIPTION
This patch changes path to be a subclass of str, similar to unipath. Since path was always supposed to be immutable, this was a simple change. The only api change is that cwd behaves slightly differently; due to the latest changes with the way it's now generated when you call local.cwd, this should be completely transparent. (For example, all tests pass). You now can use the as clause of a with statement to grab the new path.

Because of this change, treating the path like a string now works as expected; you can use `.endswith`, etc., and you can even directly open a path without converting it to a string first.