### PR TITLE
Fix for extra help message

### DIFF
--- a/examples/geet.py
+++ b/examples/geet.py
@@ -49,6 +49,7 @@ except ImportError:
 from plumbum import cli, colors
 
 class Geet(cli.Application):
+    SUBCOMMAND_HELPMSG = False
     DESCRIPTION = colors.yellow | """The l33t version control"""
     PROGNAME = colors.green
     VERSION = colors.blue | "1.7.2"

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -97,6 +97,9 @@ class Application(object):
     * ``COLOR_GROUPS`` - A dictionary that sets colors for the groups, like Meta-switches, Switches,
       and Subcommands
 
+    * ``SUBCOMMAND_HELPMSG`` - Controls the printing of extra "see subcommand -h" help message.
+      Default is a message, set to false to remove.
+
     A note on sub-commands: when an application is the root, its ``parent`` attribute is set to
     ``None``. When it is used as a nested-command, ``parent`` will point to be its direct ancestor.
     Likewise, when an application is invoked with a sub-command, its ``nested_command`` attribute
@@ -111,7 +114,7 @@ class Application(object):
     COLOR_USAGE = None
     COLOR_GROUPS = None
     CALL_MAIN_IF_NESTED_COMMAND = True
-    SUBCOMMAND_HELPMSG = True
+    SUBCOMMAND_HELPMSG = "see '{parent} {sub} --help' for more info"
 
     parent = None
     nested_command = None
@@ -658,7 +661,7 @@ class Application(object):
                     doc = subapp.DESCRIPTION if subapp.DESCRIPTION else getdoc(subapp)
                     if self.SUBCOMMAND_HELPMSG:
                         help = doc + "; " if doc else ""  # @ReservedAssignment
-                        help += "see '%s %s --help' for more info" % (self.PROGNAME, name)
+                        help += self.SUBCOMMAND_HELPMSG.format(parent=self.PROGNAME, sub=name)
                     else:
                         help = doc if doc else "" # @ReservedAssignment
 


### PR DESCRIPTION
This small patch allows customization or removal of the extra help message on subcommands, addresses #232. You can remove a subcommand extra help message by setting the class variable `SUBCOMMAND_HELPMSG` to `False`/`None`, or you can customize it with a string (`{parent}` and `{sub}` refer to the parent and subcommand name, respectively, in the string).

Also fixed color output on subcommands, the help message color matches the subcommand color now, if the subcommand color was set. See the geet.py example for an example of both changes.

PS: Unrelated to this patch: Travis fails occasionally, simple rerunning of the failed matrix element without changes fixes the problem.