### PR TITLE
Cli direct run

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -48,6 +48,9 @@ And you can run it::
 
 So far you've only seen the very basic usage. We'll now start to explore the library.
 
+.. versionadded:: 1.6.1
+
+    You can also directly run the app, as ``MyApp()``, without arguments, instead of calling ``.main()``.
 
 Application
 -----------

--- a/examples/simple_cli.py
+++ b/examples/simple_cli.py
@@ -55,5 +55,5 @@ class MyCompiler(cli.Application):
 
 
 if __name__ == "__main__":
-    MyCompiler.run()
+    MyCompiler()
 


### PR DESCRIPTION
This adds calling an `Application()` directly without arguments as a shortcut to `Application.run()`. This is needed for some systems with entry points (like conda) that do not support a `.` in the entry point syntax.