### PR TITLE
Remote cwd overuse

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -13,6 +13,7 @@ class RemoteEnv(BaseEnv):
     """The remote machine's environment; exposes a dict-like interface"""
 
     __slots__ = ["_orig", "remote"]
+
     def __init__(self, remote):
         self.remote = remote
         session = remote._session
@@ -143,7 +144,7 @@ class BaseRemoteMachine(BaseMachine):
     * ``connect_timeout`` - the connection timeout
 
 
-    There also is a _cwd attribute that is None if the cwd is not current (set to None if cwd is changed).
+    There also is a _cwd attribute that exists if the cwd is not current (del if cwd is changed).
     """
 
     # allow inheritors to override the RemoteCommand class
@@ -151,7 +152,7 @@ class BaseRemoteMachine(BaseMachine):
     
     @property
     def cwd(self):
-        if self._cwd is None:
+        if not hasattr(self, '_cwd'):
             self._cwd = RemoteWorkdir(self)
         return self._cwd
 
@@ -162,7 +163,6 @@ class BaseRemoteMachine(BaseMachine):
         self.uname = self._get_uname()
         self.env = RemoteEnv(self)
         self._python = None
-        self._cwd = None
 
     def _get_uname(self):
         rc, out, _ = self._session.run("uname", retcode = None)

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -141,6 +141,9 @@ class BaseRemoteMachine(BaseMachine):
     * ``env`` - the remote environment
     * ``encoding`` - the remote machine's default encoding (assumed to be UTF8)
     * ``connect_timeout`` - the connection timeout
+
+
+    There also is a _cwd attribute that is None if the cwd is not current (set to None if cwd is changed).
     """
 
     # allow inheritors to override the RemoteCommand class
@@ -148,7 +151,9 @@ class BaseRemoteMachine(BaseMachine):
     
     @property
     def cwd(self):
-        return RemoteWorkdir(self)
+        if self._cwd is None:
+            self._cwd = RemoteWorkdir(self)
+        return self._cwd
 
     def __init__(self, encoding = "utf8", connect_timeout = 10, new_session = False):
         self.encoding = encoding
@@ -157,6 +162,7 @@ class BaseRemoteMachine(BaseMachine):
         self.uname = self._get_uname()
         self.env = RemoteEnv(self)
         self._python = None
+        self._cwd = None
 
     def _get_uname(self):
         rc, out, _ = self._session.run("uname", retcode = None)

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -298,6 +298,7 @@ class RemoteWorkdir(RemotePath):
     def chdir(self, newdir):
         """Changes the current working directory to the given one"""
         self.remote._session.run("cd %s" % (shquote(newdir),))
+        self.remote._cwd = None
         return self.__class__(self.remote)
 
     def getpath(self):

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -36,7 +36,12 @@ class RemotePath(Path):
             raise TypeError("At least one path part is required (none given)")
         windows = (remote.uname.lower() == "windows")
         normed = []
-        parts = (remote._session.run("pwd")[1].strip(),) + parts
+
+        # Simple skip if path is absolute
+        if parts[0][0] not in ("/","\\"):
+            cwd = (remote._cwd if hasattr(remote, '_cwd') else remote._session.run("pwd")[1].strip())
+            parts = (cwd,) + parts
+
         for p in parts:
             if windows:
                 plist = str(p).replace("\\", "/").split("/")
@@ -298,7 +303,7 @@ class RemoteWorkdir(RemotePath):
     def chdir(self, newdir):
         """Changes the current working directory to the given one"""
         self.remote._session.run("cd %s" % (shquote(newdir),))
-        self.remote._cwd = None
+        del self.remote._cwd
         return self.__class__(self.remote)
 
     def getpath(self):


### PR DESCRIPTION
This is a proposed fix for #236, absolute paths now shortcut to being used without calling pwd directly.

This also uses `._cwd` to stash the current working directory. If the attribute exists, that is used instead of the cwd. I think this is the only allowed way to change the path; if `('cd', ...)` is called directly through the machine it will not change the stash here. This is similar to the old behavior in < 1.6.0, but still keeping the immutable nature of the 1.6.0 paths.