### PR TITLE
Utilopen

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -31,4 +31,4 @@ imported into the namespace of ``plumbum`` directly, and you have to explicitly 
     from plumbum.path.utils import delete
     delete(local.cwd // "*/*.pyc", local.cwd // "*/__pycache__")
 
-* :func:`xdg_open(path) <plumbum.path.utils.xdg_open>` - Opens a file in the default editor on Windows, Mac, or Linux. Uses `os.startfile` if available (Windows), `xdg_open` (GNU), or `open` (Mac). 
+* :func:`gui_open(path) <plumbum.path.utils.xdg_open>` - Opens a file in the default editor on Windows, Mac, or Linux. Uses `os.startfile` if available (Windows), `xdg_open` (GNU), or `open` (Mac). 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -31,3 +31,4 @@ imported into the namespace of ``plumbum`` directly, and you have to explicitly 
     from plumbum.path.utils import delete
     delete(local.cwd // "*/*.pyc", local.cwd // "*/__pycache__")
 
+* :func:`xdg_open(path) <plumbum.path.utils.xdg_open>` - Opens a file in the default editor on Windows, Mac, or Linux. Uses `os.startfile` if available (Windows), `xdg_open` (GNU), or `open` (Mac). 

--- a/plumbum/path/utils.py
+++ b/plumbum/path/utils.py
@@ -99,3 +99,10 @@ def copy(src, dst):
         return dst
 
 
+def xdg_open(filename):
+    """This selects the proper gui open function. This can
+       also be achieved with webbrowser, but that is not supported."""
+    if(hasattr(os, "startfile")):
+        os.startfile(filename)
+    else:
+        local.get('xgd-open', 'open')(filename)

--- a/plumbum/path/utils.py
+++ b/plumbum/path/utils.py
@@ -1,6 +1,7 @@
 from plumbum.path.base import Path
 from plumbum.lib import six
 from plumbum.machines.local import local, LocalPath
+import os
 
 
 def delete(*paths):
@@ -99,7 +100,7 @@ def copy(src, dst):
         return dst
 
 
-def xdg_open(filename):
+def gui_open(filename):
     """This selects the proper gui open function. This can
        also be achieved with webbrowser, but that is not supported."""
     if(hasattr(os, "startfile")):


### PR DESCRIPTION
This is a minor utility to allow opening files in the native viewer. This is similar to `webbroswer.open`, but according to the official docs:
> Note that on some platforms, trying to open a filename using this function, may work and start the operating system’s associated program. However, this is neither supported nor portable

This is a portable way to do it without abusing that module. It is in `plumbum.path.utils` and is called `gui_open`.

Works on Mac, Linux, Windows.