### PR TITLE
Ensure fair error attribution of pipelined return codes

### DIFF
--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -20,18 +20,7 @@ except ImportError:
 # utility functions
 #===================================================================================================
 def _check_process(proc, retcode, timeout, stdout, stderr):
-    if getattr(proc, "_timed_out", False):
-        raise ProcessTimedOut("Process did not terminate within %s seconds" % (timeout,),
-            getattr(proc, "argv", None))
-
-    if retcode is not None:
-        if hasattr(retcode, "__contains__"):
-            if proc.returncode not in retcode:
-                raise ProcessExecutionError(getattr(proc, "argv", None), proc.returncode,
-                    stdout, stderr)
-        elif proc.returncode != retcode:
-            raise ProcessExecutionError(getattr(proc, "argv", None), proc.returncode,
-                stdout, stderr)
+    proc.verify(retcode, timeout, stdout, stderr)
     return proc.returncode, stdout, stderr
 
 def _iter_lines(proc, decode, linesize):

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -1,6 +1,22 @@
 from plumbum.commands.processes import CommandNotFound
 
 
+class PopenAddons(object):
+    def verify(self, retcode, timeout, stdout, stderr):
+        if getattr(self, "_timed_out", False):
+            raise ProcessTimedOut("Process did not terminate within %s seconds" % (timeout,),
+                getattr(self, "argv", None))
+
+        if retcode is not None:
+            if hasattr(retcode, "__contains__"):
+                if self.returncode not in retcode:
+                    raise ProcessExecutionError(getattr(self, "argv", None), self.returncode,
+                        stdout, stderr)
+            elif self.returncode != retcode:
+                raise ProcessExecutionError(getattr(self, "argv", None), self.returncode,
+                    stdout, stderr)
+
+
 class BaseMachine(object):
     """This is a base class for other machines. It contains common code to
     all machines in Plumbum."""

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -1,5 +1,6 @@
 from plumbum.commands.processes import CommandNotFound
-
+from plumbum.commands.processes import ProcessExecutionError
+from plumbum.commands.processes import ProcessTimedOut
 
 class PopenAddons(object):
     def verify(self, retcode, timeout, stdout, stderr):

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -11,11 +11,9 @@ from tempfile import mkdtemp
 from contextlib import contextmanager
 from plumbum.path.remote import RemotePath
 from plumbum.commands import CommandNotFound, ConcreteCommand
-from plumbum.commands.processes import ProcessExecutionError
 from plumbum.machines.session import ShellSession
 from plumbum.lib import ProcInfo, IS_WIN32, six, StaticProperty
 from plumbum.commands.daemons import win32_daemonize, posix_daemonize
-from plumbum.commands.processes import ProcessTimedOut
 from plumbum.commands.processes import iter_lines
 from plumbum.machines.base import BaseMachine
 from plumbum.machines.base import PopenAddons

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -17,6 +17,7 @@ from plumbum.lib import ProcInfo, IS_WIN32, six, StaticProperty
 from plumbum.commands.daemons import win32_daemonize, posix_daemonize
 from plumbum.commands.processes import iter_lines
 from plumbum.machines.base import BaseMachine
+from plumbum.machines.base import PopenAddons
 from plumbum.machines.env import BaseEnv
 
 if sys.version_info >= (3, 2):
@@ -32,24 +33,11 @@ else:
         from subprocess import Popen, PIPE
         has_new_subprocess = False
 
-class IterablePopen(Popen):
+class IterablePopen(Popen, PopenAddons):
     iter_lines = iter_lines
     def __iter__(self):
         return self.iter_lines()
 
-    def verify(self, retcode, timeout, stdout, stderr):
-        if getattr(self, "_timed_out", False):
-            raise ProcessTimedOut("Process did not terminate within %s seconds" % (timeout,),
-                getattr(self, "argv", None))
-
-        if retcode is not None:
-            if hasattr(retcode, "__contains__"):
-                if self.returncode not in retcode:
-                    raise ProcessExecutionError(getattr(self, "argv", None), self.returncode,
-                        stdout, stderr)
-            elif self.returncode != retcode:
-                raise ProcessExecutionError(getattr(self, "argv", None), self.returncode,
-                    stdout, stderr)
 
 logger = logging.getLogger("plumbum.local")
 

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -11,6 +11,7 @@ from tempfile import mkdtemp
 from contextlib import contextmanager
 from plumbum.path.remote import RemotePath
 from plumbum.commands import CommandNotFound, ConcreteCommand
+from plumbum.commands.processes import ProcessExecutionError
 from plumbum.machines.session import ShellSession
 from plumbum.lib import ProcInfo, IS_WIN32, six, StaticProperty
 from plumbum.commands.daemons import win32_daemonize, posix_daemonize
@@ -35,6 +36,20 @@ class IterablePopen(Popen):
     iter_lines = iter_lines
     def __iter__(self):
         return self.iter_lines()
+
+    def verify(self, retcode, timeout, stdout, stderr):
+        if getattr(self, "_timed_out", False):
+            raise ProcessTimedOut("Process did not terminate within %s seconds" % (timeout,),
+                getattr(self, "argv", None))
+
+        if retcode is not None:
+            if hasattr(retcode, "__contains__"):
+                if self.returncode not in retcode:
+                    raise ProcessExecutionError(getattr(self, "argv", None), self.returncode,
+                        stdout, stderr)
+            elif self.returncode != retcode:
+                raise ProcessExecutionError(getattr(self, "argv", None), self.returncode,
+                    stdout, stderr)
 
 logger = logging.getLogger("plumbum.local")
 

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -15,6 +15,7 @@ from plumbum.commands.processes import ProcessExecutionError
 from plumbum.machines.session import ShellSession
 from plumbum.lib import ProcInfo, IS_WIN32, six, StaticProperty
 from plumbum.commands.daemons import win32_daemonize, posix_daemonize
+from plumbum.commands.processes import ProcessTimedOut
 from plumbum.commands.processes import iter_lines
 from plumbum.machines.base import BaseMachine
 from plumbum.machines.base import PopenAddons

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -2,6 +2,7 @@ import logging
 import errno
 import stat
 import socket
+from plumbum.machines.base import PopenAddons
 from plumbum.machines.remote import BaseRemoteMachine
 from plumbum.machines.session import ShellSession
 from plumbum.lib import _setdoc, six
@@ -23,7 +24,7 @@ except ImportError:
 
 logger = logging.getLogger("plumbum.paramiko")
 
-class ParamikoPopen(object):
+class ParamikoPopen(PopenAddons):
     def __init__(self, argv, stdin, stdout, stderr, encoding, stdin_file = None,
             stdout_file = None, stderr_file = None):
         self.argv = argv

--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -4,6 +4,7 @@ import logging
 import threading
 from plumbum.commands import BaseCommand, run_proc
 from plumbum.lib import six
+from plumbum.machines.base import PopenAddons
 
 
 class ShellSessionError(Exception):
@@ -53,7 +54,7 @@ class MarkedPipe(object):
         return line
 
 
-class SessionPopen(object):
+class SessionPopen(PopenAddons):
     """A shell-session-based ``Popen``-like object (has the following attributes: ``stdin``,
     ``stdout``, ``stderr``, ``returncode``)"""
     def __init__(self, argv, isatty, stdin, stdout, stderr, encoding):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -310,7 +310,7 @@ class LocalMachineTest(unittest.TestCase):
         true = LocalCommand('true')
         try:
             (false | true) & FG
-        except ProcessExecutionError, e:
+        except ProcessExecutionError as e:
             self.assertEqual(e.argv, ['false'])
         else:
             self.fail("Expected a ProcessExecutionError")

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -7,6 +7,7 @@ from plumbum import (local, LocalPath, FG, BG, TF, RETCODE, ERROUT,
                     CommandNotFound, ProcessExecutionError, ProcessTimedOut)
 from plumbum.lib import six, IS_WIN32
 from plumbum.fs.atomic import AtomicFile, AtomicCounterFile, PidFile
+from plumbum.machines.local import LocalCommand
 from plumbum.path import RelativePath
 import plumbum
 from plumbum._testtools import (skipIf, skip_on_windows,
@@ -301,6 +302,19 @@ class LocalMachineTest(unittest.TestCase):
     def test_timeout(self):
         from plumbum.cmd import sleep
         self.assertRaises(ProcessTimedOut, sleep, 10, timeout = 5)
+
+    @skip_on_windows
+    def test_fair_error_attribution(self):
+        # use LocalCommand directly for predictable argv
+        false = LocalCommand('false')
+        true = LocalCommand('true')
+        try:
+            (false | true) & FG
+        except ProcessExecutionError, e:
+            self.assertEqual(e.argv, ['false'])
+        else:
+            self.fail("Expected a ProcessExecutionError")
+
 
     @skip_on_windows
     def test_iter_lines_timeout(self):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -296,7 +296,7 @@ class LocalMachineTest(unittest.TestCase):
     def test_run(self):
         from plumbum.cmd import ls, grep
 
-        rc, out, err = (ls | grep["non_exist1N9"]).run(retcode = 1)
+        rc, out, err = (ls | grep["non_exist1N9"]).run(retcode = (0, 1))
         self.assertEqual(rc, 1)
 
     def test_timeout(self):


### PR DESCRIPTION
Fixes #241 by making the (new) verify method on command objects responsible for determining whether to raise an exception.