### PR TITLE
Speeding up the "BaseRemoteMachine:which" command

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -219,10 +219,14 @@ class BaseRemoteMachine(BaseMachine):
             alternatives.append(progname.replace("_", "-"))
             alternatives.append(progname.replace("_", "."))
         for name in alternatives:
-            for p in self.env.path:
-                fn = p / name
-                if fn.access("x") and not fn.is_dir():
-                    return fn
+            rc, stdout, stderr = self._session.run(
+                "stat -c '%n' {0}".format(
+                    " ".join([ str(_ / name) for _ in self.env.path ])   
+                ),
+                retcode = None
+            )
+            if stdout:
+                return self.path(stdout.strip())
 
         raise CommandNotFound(progname, self.env.path)
 


### PR DESCRIPTION
In a worst case sceanrio Plumbum will perform a "stat" command for each directory on the user's path. This pull request rolls up those requests into one single "stat" command with multiple arguments and inspects the output to locate the command.

###### Log of a worst case scenario

```
DEBUG:plumbum.local:Running ['/usr/bin/ssh', '-q', '-tt', '-T', 'server']
DEBUG:plumbum.shell:Running "true ; echo $? ; echo '--.END1174540856.6.--' ; echo '--.END1174540856.6.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "uname ; echo $? ; echo '--.END1418649494.22.--' ; echo '--.END1418649494.22.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> 'Linux\n'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "pwd ; echo $? ; echo '--.END1071788067.65.--' ; echo '--.END1071788067.65.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> '/home/user\n'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "env -0; echo ; echo $? ; echo '--.END378678799.079.--' ; echo '--.END378678799.079.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> '[...]'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /usr/lib64/qt-3.3/bin/route ; echo $? ; echo '--.END1412466484.92.--' ; echo '--.END1412466484.92.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/lib64/qt-3.3/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /usr/local/bin/route ; echo $? ; echo '--.END813014207.443.--' ; echo '--.END813014207.443.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/local/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /bin/route ; echo $? ; echo '--.END1394987719.34.--' ; echo '--.END1394987719.34.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /usr/bin/route ; echo $? ; echo '--.END827869470.579.--' ; echo '--.END827869470.579.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /usr/local/sbin/route ; echo $? ; echo '--.END85419273.6995.--' ; echo '--.END85419273.6995.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/local/sbin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /usr/sbin/route ; echo $? ; echo '--.END612866116.3.--' ; echo '--.END612866116.3.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/sbin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%F,%f,%i,%d,%h,%u,%g,%s,%X,%Y,%Z' /sbin/route ; echo $? ; echo '--.END465547698.485.--' ; echo '--.END465547698.485.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> 'regular file,81ed,523764,64768,1,0,0,59784,1448876446,1314287117,1443550975\n'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
/sbin/route
```

###### Log of same scenario, but with change

```
DEBUG:plumbum.local:Running ['/usr/bin/ssh', '-q', '-tt', '-T', 'server']
DEBUG:plumbum.shell:Running "true ; echo $? ; echo '--.END1311069518.76.--' ; echo '--.END1311069518.76.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "uname ; echo $? ; echo '--.END919787830.523.--' ; echo '--.END919787830.523.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> 'Linux\n'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "pwd ; echo $? ; echo '--.END1307021385.56.--' ; echo '--.END1307021385.56.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> '/home/user\n'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "env -0; echo ; echo $? ; echo '--.END297795758.881.--' ; echo '--.END297795758.881.--' 1>&2"
DEBUG:plumbum.shell:2> ''
DEBUG:plumbum.shell:1> '[...]'
DEBUG:plumbum.shell:1> '0\n'
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:Running "stat -c '%n' /usr/lib64/qt-3.3/bin/route /usr/local/bin/route /bin/route /usr/bin/route /usr/local/sbin/route /usr/sbin/route /sbin/route ; echo $? ; echo '--.END443168584.788.--' ; echo '--.END443168584.788.--' 1>&2"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/lib64/qt-3.3/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '/sbin/route\n'
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/local/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> '1\n'
DEBUG:plumbum.shell:2> "stat: cannot stat `/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:1> ''
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/bin/route': No such file or directory\n"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/local/sbin/route': No such file or directory\n"
DEBUG:plumbum.shell:2> "stat: cannot stat `/usr/sbin/route': No such file or directory\n"
DEBUG:plumbum.shell:2> ''
/sbin/route
```