### PR TITLE
Apply retcode=None to the whole Pipeline tree (ie. when >2 commands in pipeline)

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -305,7 +305,10 @@ class Pipeline(BaseCommand):
             try:
                 or_retcode = [0] + list(retcode)
             except TypeError:
-                or_retcode = [0, retcode]
+                if (retcode is None):
+                    or_retcode = None # no-retcode-verification acts "greedily"
+                else:
+                    or_retcode = [0, retcode]
             proc.srcproc.verify(or_retcode, timeout, stdout, stderr)
             dstproc_verify(retcode, timeout, stdout, stderr)
         dstproc.verify = MethodType(verify, dstproc)


### PR DESCRIPTION
Hi!

I've noticed, that current implementation does not allow to disable returncode verification for the whole pipeline (Pipeline tree),
eg. `(netstat["-tnlp"] | grep[pid] | grep[port])(retcode = None)` fails at grep[pid]: nonzero returncode
while `(netstat["-tnlp"] | grep[pid])(retcode = None)` works as expected

Am I missing something?

Thanks! :)