### PR TITLE
Fix 36

### DIFF
--- a/experiments/parallel.py
+++ b/experiments/parallel.py
@@ -24,7 +24,7 @@ class ConcurrentPopen(object):
         self.stdin = None
         self.stdout = None
         self.stderr = None
-        self.encoding = None
+        self.custom_encoding = None
         self.returncode = None
     @property
     def argv(self):

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -46,7 +46,7 @@ def shquote_list(seq):
 class BaseCommand(object):
     """Base of all command objects"""
 
-    __slots__ = ["cwd", "env", "encoding", "__weakref__"]
+    __slots__ = ["cwd", "env", "custom_encoding", "__weakref__"]
 
     def __str__(self):
         return " ".join(self.formulate())
@@ -135,7 +135,7 @@ class BaseCommand(object):
         :returns: A ``Popen``-like object
         """
         raise NotImplementedError()
-        
+
     def nohup(self, command, cwd='.', stdout='nohup.out', stderr=None, append=True):
         """Runs a command detached."""
         return self.machine.daemonic_popen(self, cwd, stdout, stderr, append)
@@ -417,21 +417,21 @@ class StdinDataRedirection(BaseCommand):
 
 class ConcreteCommand(BaseCommand):
     QUOTE_LEVEL = None
-    __slots__ = ["executable", "encoding"]
+    __slots__ = ["executable", "custom_encoding"]
     def __init__(self, executable, encoding):
         self.executable = executable
-        self.encoding = encoding
+        self.custom_encoding = encoding
         self.cwd = None
         self.env = None
-        
+
     def __str__(self):
         return str(self.executable)
-        
+
     def __repr__(self):
-        return "{0}({1})".format(type(self).__name__, self.executable)        
-    
+        return "{0}({1})".format(type(self).__name__, self.executable)
+
     def _get_encoding(self):
-        return self.encoding
+        return self.custom_encoding
 
     def formulate(self, level = 0, args = ()):
         argv = [str(self.executable)]
@@ -447,12 +447,12 @@ class ConcreteCommand(BaseCommand):
                 argv.extend(shquote(b) if level >= self.QUOTE_LEVEL else str(b) for b in a)
             else:
                 argv.append(shquote(a) if level >= self.QUOTE_LEVEL else str(a))
-        # if self.encoding:
-        #    argv = [a.encode(self.encoding) for a in argv if isinstance(a, six.string_types)]
+        # if self.custom_encoding:
+        #    argv = [a.encode(self.custom_encoding) for a in argv if isinstance(a, six.string_types)]
         return argv
 
-        
-        
+
+
 
 
 

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -199,9 +199,9 @@ def run_proc(proc, retcode, timeout = None):
         stdout = six.b("")
     if not stderr:
         stderr = six.b("")
-    if getattr(proc, "encoding", None):
-        stdout = stdout.decode(proc.encoding, "ignore")
-        stderr = stderr.decode(proc.encoding, "ignore")
+    if getattr(proc, "custom_encoding", None):
+        stdout = stdout.decode(proc.custom_encoding, "ignore")
+        stderr = stderr.decode(proc.custom_encoding, "ignore")
 
     return _check_process(proc, retcode, timeout, stdout, stderr)
 
@@ -229,7 +229,7 @@ def iter_lines(proc, retcode = 0, timeout = None, linesize = -1, _iter_lines = _
     :returns: An iterator of (out, err) line tuples.
     """
 
-    encoding = getattr(proc, "encoding", None)
+    encoding = getattr(proc, "custom_encoding", None)
     if encoding:
         decode = lambda s: s.decode(encoding).rstrip()
     else:

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -61,6 +61,14 @@ class BaseMachine(object):
             return False
         else:
             return True
+
+    @property
+    def encoding(self):
+        'This is a wrapper for custom_encoding'
+        return self.custom_encoding
+    @encoding.setter
+    def encoding(self, value):
+        self.custom_encoding = value
             
     def daemonic_popen(self, command, cwd = "/", stdout=None, stderr=None, append=True):
         raise NotImplementedError("This is not implemented on this machine!")

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -95,7 +95,7 @@ class LocalCommand(ConcreteCommand):
 
     def __init__(self, executable, encoding = "auto"):
         ConcreteCommand.__init__(self, executable,
-            local.encoding if encoding == "auto" else encoding)
+            local.custom_encoding if encoding == "auto" else encoding)
 
     @property
     def machine(self):
@@ -122,13 +122,13 @@ class LocalMachine(BaseMachine):
 
     * ``cwd`` - the local working directory
     * ``env`` - the local environment
-    * ``encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
+    * ``custom_encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
     """
 
     cwd = StaticProperty(LocalWorkdir)
     env = LocalEnv()
 
-    encoding = sys.getfilesystemencoding()
+    custom_encoding = sys.getfilesystemencoding()
     uname = platform.uname()[0]
 
     def __init__(self):
@@ -258,7 +258,7 @@ class LocalMachine(BaseMachine):
         proc = IterablePopen(argv, executable = str(executable), stdin = stdin, stdout = stdout,
             stderr = stderr, cwd = str(cwd), env = env, **kwargs)  # bufsize = 4096
         proc._start_time = time.time()
-        proc.encoding = self.encoding
+        proc.custom_encoding = self.custom_encoding
         proc.argv = argv
         return proc
 
@@ -377,7 +377,7 @@ class LocalMachine(BaseMachine):
         """A shorthand for :func:`as_user("root") <plumbum.machines.local.LocalMachine.as_user>`"""
         return self.as_user()
 
-    python = LocalCommand(sys.executable, encoding)
+    python = LocalCommand(sys.executable, custom_encoding)
     """A command that represents the current python interpreter (``sys.executable``)"""
 
 local = LocalMachine()
@@ -389,5 +389,5 @@ Attributes:
 
 * ``cwd`` - the local working directory
 * ``env`` - the local environment
-* ``encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
+* ``custom_encoding`` - the local machine's default encoding (``sys.getfilesystemencoding()``)
 """

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -32,7 +32,7 @@ class ParamikoPopen(PopenAddons):
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr
-        self.encoding = encoding
+        self.custom_encoding = encoding
         self.returncode = None
         self.pid = None
         self.stdin_file = stdin_file
@@ -219,8 +219,8 @@ class ParamikoMachine(BaseRemoteMachine):
         stdin = chan.makefile('wb', -1)
         stdout = chan.makefile('rb', -1)
         stderr = chan.makefile_stderr('rb', -1)
-        proc = ParamikoPopen(["<shell>"], stdin, stdout, stderr, self.encoding)
-        return ShellSession(proc, self.encoding, isatty)
+        proc = ParamikoPopen(["<shell>"], stdin, stdout, stderr, self.custom_encoding)
+        return ShellSession(proc, self.custom_encoding, isatty)
 
     @_setdoc(BaseRemoteMachine)
     def popen(self, args, stdin = None, stdout = None, stderr = None, new_session = False, cwd = None):
@@ -235,7 +235,7 @@ class ParamikoMachine(BaseRemoteMachine):
         cmdline = " ".join(argv)
         logger.debug(cmdline)
         si, so, se = streams = self._client.exec_command(cmdline, 1)
-        return ParamikoPopen(argv, si, so, se, self.encoding, stdin_file = stdin,
+        return ParamikoPopen(argv, si, so, se, self.custom_encoding, stdin_file = stdin,
             stdout_file = stdout, stderr_file = stderr)
 
     @_setdoc(BaseRemoteMachine)
@@ -313,8 +313,8 @@ class ParamikoMachine(BaseRemoteMachine):
         f.close()
         return data
     def _path_write(self, fn, data):
-        if self.encoding and isinstance(data, six.unicode_type):
-            data = data.encode(self.encoding)
+        if self.custom_encoding and isinstance(data, six.unicode_type):
+            data = data.encode(self.custom_encoding)
         f = self.sftp.open(str(fn), 'wb')
         f.write(data)
         f.close()

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -106,7 +106,7 @@ class RemoteCommand(ConcreteCommand):
     def __init__(self, remote, executable, encoding = "auto"):
         self.remote = remote
         ConcreteCommand.__init__(self, executable,
-            remote.encoding if encoding == "auto" else encoding)
+            remote.custom_encoding if encoding == "auto" else encoding)
     @property
     def machine(self):
         return self.remote
@@ -140,7 +140,7 @@ class BaseRemoteMachine(BaseMachine):
 
     * ``cwd`` - the remote working directory
     * ``env`` - the remote environment
-    * ``encoding`` - the remote machine's default encoding (assumed to be UTF8)
+    * ``custom_encoding`` - the remote machine's default encoding (assumed to be UTF8)
     * ``connect_timeout`` - the connection timeout
 
 
@@ -149,7 +149,7 @@ class BaseRemoteMachine(BaseMachine):
 
     # allow inheritors to override the RemoteCommand class
     RemoteCommand = RemoteCommand
-    
+
     @property
     def cwd(self):
         if not hasattr(self, '_cwd'):
@@ -157,7 +157,7 @@ class BaseRemoteMachine(BaseMachine):
         return self._cwd
 
     def __init__(self, encoding = "utf8", connect_timeout = 10, new_session = False):
-        self.encoding = encoding
+        self.custom_encoding = encoding
         self.connect_timeout = connect_timeout
         self._session = self.session(new_session = new_session)
         self.uname = self._get_uname()
@@ -373,12 +373,12 @@ class BaseRemoteMachine(BaseMachine):
 
     def _path_read(self, fn):
         data = self["cat"](fn)
-        if self.encoding and isinstance(data, six.unicode_type):
-            data = data.encode(self.encoding)
+        if self.custom_encoding and isinstance(data, six.unicode_type):
+            data = data.encode(self.custom_encoding)
         return data
     def _path_write(self, fn, data):
-        if self.encoding and isinstance(data, six.unicode_type):
-            data = data.encode(self.encoding)
+        if self.custom_encoding and isinstance(data, six.unicode_type):
+            data = data.encode(self.custom_encoding)
         with NamedTemporaryFile() as f:
             f.write(data)
             f.flush()

--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -70,7 +70,7 @@ class SessionPopen(PopenAddons):
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr
-        self.encoding = encoding
+        self.custom_encoding = encoding
         self.returncode = None
         self._done = False
     def poll(self):
@@ -157,7 +157,7 @@ class ShellSession(object):
     """
     def __init__(self, proc, encoding = "auto", isatty = False, connect_timeout = 5):
         self.proc = proc
-        self.encoding = proc.encoding if encoding == "auto" else encoding
+        self.custom_encoding = proc.custom_encoding if encoding == "auto" else encoding
         self.isatty = isatty
         self._current = None
         if connect_timeout:
@@ -230,14 +230,14 @@ class ShellSession(object):
         full_cmd += "echo $? ; echo '%s'" % (marker,)
         if not self.isatty:
             full_cmd += " ; echo '%s' 1>&2" % (marker,)
-        if self.encoding:
-            full_cmd = full_cmd.encode(self.encoding)
+        if self.custom_encoding:
+            full_cmd = full_cmd.encode(self.custom_encoding)
         shell_logger.debug("Running %r", full_cmd)
         self.proc.stdin.write(full_cmd + six.b("\n"))
         self.proc.stdin.flush()
         self._current = SessionPopen(self.proc, full_cmd, self.isatty, self.proc.stdin,
             MarkedPipe(self.proc.stdout, marker), MarkedPipe(self.proc.stderr, marker),
-            self.encoding)
+            self.custom_encoding)
         return self._current
 
     def run(self, cmd, retcode = 0):

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -169,7 +169,7 @@ class SshMachine(BaseRemoteMachine):
     @_setdoc(BaseRemoteMachine)
     def session(self, isatty = False, new_session = False):
         return ShellSession(self.popen(["/bin/sh"], (["-tt"] if isatty else ["-T"]), new_session = new_session),
-            self.encoding, isatty, self.connect_timeout)
+            self.custom_encoding, isatty, self.connect_timeout)
 
     def tunnel(self, lport, dport, lhost = "localhost", dhost = "localhost", connect_timeout = 5):
         r"""Creates an SSH tunnel from the TCP port (``lport``) of the local machine
@@ -220,7 +220,7 @@ class SshMachine(BaseRemoteMachine):
         """
         ssh_opts = ["-L", "[%s]:%s:[%s]:%s" % (lhost, lport, dhost, dport)]
         proc = self.popen((), ssh_opts = ssh_opts, new_session = True)
-        return SshTunnel(ShellSession(proc, self.encoding, connect_timeout = self.connect_timeout))
+        return SshTunnel(ShellSession(proc, self.custom_encoding, connect_timeout = self.connect_timeout))
 
     def _translate_drive_letter(self, path):
         # replace c:\some\path with /c/some/path
@@ -291,6 +291,6 @@ class PuttyMachine(SshMachine):
     @_setdoc(BaseRemoteMachine)
     def session(self, isatty = False, new_session = False):
         return ShellSession(self.popen((), (["-t"] if isatty else ["-T"]), new_session = new_session),
-            self.encoding, isatty, self.connect_timeout)
+            self.custom_encoding, isatty, self.connect_timeout)
 
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -392,7 +392,7 @@ class TestLocalMachine:
         p = ls.popen(["-a"])
         out, _ = p.communicate()
         assert p.returncode == 0
-        assert "test_local.py" in out.decode(local.custom_encoding).splitlines()
+        assert "test_local.py" in out.decode(local.encoding).splitlines()
 
     def test_run(self):
         from plumbum.cmd import ls, grep

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -392,7 +392,7 @@ class TestLocalMachine:
         p = ls.popen(["-a"])
         out, _ = p.communicate()
         assert p.returncode == 0
-        assert "test_local.py" in out.decode(local.encoding).splitlines()
+        assert "test_local.py" in out.decode(local.custom_encoding).splitlines()
 
     def test_run(self):
         from plumbum.cmd import ls, grep


### PR DESCRIPTION
Fixing plumbum for Python 3.6, as reported in #302. Python 3.6 has been added for testing on both linux and Mac for Travis in the master branch already; this should fix all failing tests. This is a critical bug fix, and will cause the next version of Plumbum to be released soon.

The key change is `encoding -> custom_encoding` for all attributes. Commands have a property wrapper that allows the old syntax to work as before (use of `local.encoding`, for example).