### PR TITLE
Revert "Scrap redundant encoding"

### DIFF
--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -188,14 +188,6 @@ class LocalMachine(BaseMachine):
             parts2.append(self.env.expanduser(str(p)))
         return LocalPath(os.path.join(*parts2))
 
-    def __contains__(self, cmd):
-        try:
-            self[cmd]
-        except CommandNotFound:
-            return False
-        else:
-            return True
-
     def __getitem__(self, cmd):
         """Returns a `Command` object representing the given program. ``cmd`` can be a string or
         a :class:`LocalPath <plumbum.path.local.LocalPath>`; if it is a path, a command

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -94,8 +94,8 @@ class ParamikoPopen(PopenAddons):
             else:
                 coll.append(line)
         self.wait()
-        stdout = "".join(s for s in stdout).encode(self.custom_encoding)
-        stderr = "".join(s for s in stderr).encode(self.custom_encoding)
+        stdout = six.b("").join(six.b(s) for s in stdout)
+        stderr = six.b("").join(six.b(s) for s in stderr)
         return stdout, stderr
 
     def iter_lines(self, timeout=None, **kwargs):
@@ -381,13 +381,13 @@ def _iter_lines(proc, decode, linesize):
 
     for _ in selector():
         if proc.stdout.channel.recv_ready():
-            yield 0, proc.stdout.readline(linesize)
+            yield 0, decode(six.b(proc.stdout.readline(linesize)))
         if proc.stdout.channel.recv_stderr_ready():
-            yield 1, proc.stderr.readline(linesize)
+            yield 1, decode(six.b(proc.stderr.readline(linesize)))
         if proc.poll() is not None:
             break
 
     for line in proc.stdout:
-        yield 0, line
+        yield 0, decode(six.b(line))
     for line in proc.stderr:
-        yield 1, line
+        yield 1, decode(six.b(line))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -355,12 +355,4 @@ class TestParamikoMachine(BaseRemoteMachineTest):
             else:
                 pytest.fail("Should not pipe")
 
-    def test_encoding(self):
-        with self._connect() as rem:
-            unicode_half = b"\xc2\xbd".decode("utf8")
 
-            ret = rem['bash']("-c", 'echo -e "\xC2\xBD"')
-            assert ret == "%s\n" % unicode_half
-
-            ret = list(rem['bash']["-c", 'echo -e "\xC2\xBD"'].popen())
-            assert ret == [["%s\n" % unicode_half, None]]

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -355,12 +355,12 @@ class TestParamikoMachine(BaseRemoteMachineTest):
             else:
                 pytest.fail("Should not pipe")
 
-def test_encoding(self):
-    with self._connect() as rem:
-        unicode_half = b"\xc2\xbd".decode("utf8")
+    def test_encoding(self):
+        with self._connect() as rem:
+            unicode_half = b"\xc2\xbd".decode("utf8")
 
-        ret = rem['bash']("-c", 'echo -e "\xC2\xBD"')
-        assert ret == "%s\n" % unicode_half
+            ret = rem['bash']("-c", 'echo -e "\xC2\xBD"')
+            assert ret == "%s\n" % unicode_half
 
-        ret = list(rem['bash']["-c", 'echo -e "\xC2\xBD"'].popen())
-        assert ret == [["%s\n" % unicode_half, None]]
+            ret = list(rem['bash']["-c", 'echo -e "\xC2\xBD"'].popen())
+            assert ret == [["%s\n" % unicode_half, None]]

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -355,4 +355,12 @@ class TestParamikoMachine(BaseRemoteMachineTest):
             else:
                 pytest.fail("Should not pipe")
 
+def test_encoding(self):
+    with self._connect() as rem:
+        unicode_half = b"\xc2\xbd".decode("utf8")
 
+        ret = rem['bash']("-c", 'echo -e "\xC2\xBD"')
+        assert ret == "%s\n" % unicode_half
+
+        ret = list(rem['bash']["-c", 'echo -e "\xC2\xBD"'].popen())
+        assert ret == [["%s\n" % unicode_half, None]]

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -355,6 +355,7 @@ class TestParamikoMachine(BaseRemoteMachineTest):
             else:
                 pytest.fail("Should not pipe")
 
+    @pytest.mark.xfail(message="Not working yet")
     def test_encoding(self):
         with self._connect() as rem:
             unicode_half = b"\xc2\xbd".decode("utf8")


### PR DESCRIPTION
Reverts tomerfiliba/plumbum#308

I added the `__contains__` method to `base.py` a few months ago, and the encoding changes break all travis tests.

Leaving the new encoding test.