### PR TITLE
Make argument type error messages use `__str__` method of `Predicate`s

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -349,8 +349,8 @@ class Application(object):
                 return argtype(val)
             except (TypeError, ValueError):
                 ex = sys.exc_info()[1]  # compat
-                raise WrongArgumentType("Argument of %s expected to be %r, not %r:\n    %r" % (
-                    name, str(argtype), val, ex))
+                raise WrongArgumentType("Argument of {name} expected to be {argtype}, not {val!r}:\n    {ex!r}".format(
+                    name=name, argtype=argtype, val=val, ex=ex))
         else:
             return NotImplemented
 

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -350,7 +350,7 @@ class Application(object):
             except (TypeError, ValueError):
                 ex = sys.exc_info()[1]  # compat
                 raise WrongArgumentType("Argument of %s expected to be %r, not %r:\n    %r" % (
-                    name, argtype, val, ex))
+                    name, str(argtype), val, ex))
         else:
             return NotImplemented
 
@@ -711,4 +711,3 @@ class Application(object):
         ver = self._get_prog_version()
         ver_name = ver if ver is not None else "(version not set)"
         print('{0} {1}'.format(self.PROGNAME, ver_name))
-


### PR DESCRIPTION
Previous behavior looks like this
```
Error: Argument of output expected to be <plumbum.cli.switches.Predicate object at 0x10ce91c10>, not 'requirements.txt':
        ValueError('output is a file, should be a directory',)
```
now looks like this
```
    Error: Argument of output expected to be 'MakeDirectory', not 'requirements.txt':
        ValueError('output is a file, should be a directory',)
```
when checking a `Predicate`.
