### PR TITLE
Help on switches use the function's name

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -627,7 +627,7 @@ class Application(object):
                     swnames = ", ".join(("-" if len(n) == 1 else "--") + n for n in si.names
                         if n in self._switches_by_name and self._switches_by_name[n] == si)
                     if si.argtype:
-                        if isinstance(si.argtype, type):
+                        if hasattr(si.argtype, '__name__'):
                             typename = si.argtype.__name__
                         else:
                             typename = str(si.argtype)


### PR DESCRIPTION
With a switch defined like this,
```
    checkpoint_fname = cli.SwitchAttr('--checkpoint', argtype=local.path, default='/tmp/lm2d_to_pose.hd5')
```
on master, the output looks like this,
```
    --checkpoint VALUE:<bound method LocalMachine.path of <plumbum.machines.local.LocalMachine object at 0x10c9b1710>>
```

This PR makes it look like this,
```
    --checkpoint VALUE:path             Sets an attribute
```
