### PR TITLE
Escape filename spaces on remotes, fixes #322

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.6.4 (in progress)
+-------------------
+
+* Fixes for globbing with spaces in filename on a remote server (`#322 <https://github.com/tomerfiliba/plumbum/issues/322>`_)
+
 1.6.3
 -----
 * Python 3.6 is now supported, critical bug fixed  (`#302 <https://github.com/tomerfiliba/plumbum/issues/302>`_)

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -321,7 +321,10 @@ class BaseRemoteMachine(BaseMachine):
         files.remove("..")
         return files
     def _path_glob(self, fn, pattern):
-        matches = self._session.run("for fn in %s/%s; do echo $fn; done" % (fn, pattern))[1].splitlines()
+        # shquote does not work here due to the way bash loops use space as a seperator
+        pattern = pattern.replace(" ", r"\ ")
+        fn = fn.replace(" ", r"\ ")
+        matches = self._session.run(r'for fn in {0}/{1}; do echo $fn; done'.format(fn,pattern))[1].splitlines()
         if len(matches) == 1 and not self._path_stat(matches[0]):
             return []  # pattern expansion failed
         return matches

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -319,6 +319,14 @@ class TestLocalMachine:
         assert found
 
     @skip_on_windows
+    def test_glob_spaces(self):
+        fileloc = local.cwd / 'file with space.txt'
+        assert fileloc.exists()
+
+        assert local.cwd // "*space.txt"
+        assert local.cwd // "file with*"
+
+    @skip_on_windows
     def test_env(self):
         assert "PATH" in local.env
         assert "FOOBAR72" not in local.env

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -158,6 +158,15 @@ s.close()
                 assert "test_remote.py" in filenames
                 assert "slow_process.bash" in filenames
 
+    def test_glob_spaces(self):
+        with self._connect() as rem:
+            with rem.cwd(os.path.dirname(os.path.abspath(__file__))):
+                filenames = [f.name for f in rem.cwd // ("*space.txt")]
+                assert "file with space.txt" in filenames
+
+                filenames = [f.name for f in rem.cwd // ("*with space.txt")]
+                assert "file with space.txt" in filenames
+
     @pytest.mark.usefixtures("testdir")
     def test_download_upload(self):
         with self._connect() as rem:


### PR DESCRIPTION
This fixes globbing a remote filesystem with spaces, fixes #322. These had to be manually escaped, since the for loop in bash uses space as a separator.