### PR TITLE
Fix #327

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 -------------------
 
 * Fixes for globbing with spaces in filename on a remote server (`#322 <https://github.com/tomerfiliba/plumbum/issues/322>`_)
+* Terminal: Changed ``prompt()``'s default value for ``type`` parameter from ``int`` to ``str`` to match existing docs (`#327 <https://github.com/tomerfiliba/plumbum/issues/327>`_)
 
 1.6.3
 -----
@@ -47,7 +48,7 @@
 * Added support for Python 3.5, PyPy, and better Windows and Mac support, with CI testing (`#218 <https://github.com/tomerfiliba/plumbum/pull/218>`_, `#217 <https://github.com/tomerfiliba/plumbum/pull/217>`_, `#226 <https://github.com/tomerfiliba/plumbum/pull/226>`_)
 * Colors: Added colors module, support for colors added to cli (`#213 <https://github.com/tomerfiliba/plumbum/pull/213>`_)
 * Machines: Added ``.get()`` method for checking several commands. (`#205 <https://github.com/tomerfiliba/plumbum/pull/205>`_)
-* Machines: ``local.cwd`` now is the current directory even if you change the directory with non-Plumbum methods (fixes unexpected behavior). (`#207 <https://github.com/tomerfiliba/plumbum/pull/207>`_) 
+* Machines: ``local.cwd`` now is the current directory even if you change the directory with non-Plumbum methods (fixes unexpected behavior). (`#207 <https://github.com/tomerfiliba/plumbum/pull/207>`_)
 * SSHMachine: Better error message for SSH (`#211 <https://github.com/tomerfiliba/plumbum/pull/211>`_)
 * SSHMachine: Support for FreeBSD remote (`#220 <https://github.com/tomerfiliba/plumbum/pull/220>`_)
 * Paths: Now a subclass of ``str``, can be opened directly (`#228 <https://github.com/tomerfiliba/plumbum/pull/228>`_)
@@ -81,7 +82,7 @@
 
 1.4.2
 -----
-* Paramiko now supports Python 3, enabled support in Plumbum 
+* Paramiko now supports Python 3, enabled support in Plumbum
 * Terminal: added ``prompt()``, bugfix to ``get_terminal_size()`` (`#113 <https://github.com/tomerfiliba/plumbum/pull/113>`_)
 * CLI: added ``cleanup()``, which is called after ``main()`` returns
 * CLI: bugfix to ``CountOf`` (`#118 <https://github.com/tomerfiliba/plumbum/pull/118>`_)
@@ -111,11 +112,11 @@
 
 1.3
 ---
-* ``Command.popen``: a new argument, ``new_session`` may be passed to ``Command.popen``, which runs the given 
-  in a new session (``setsid`` on POSIX, ``CREATE_NEW_PROCESS_GROUP`` on Windows) 
-* ``Command.Popen``: args can now also be a list (previously, it was required to be a tuple). See 
+* ``Command.popen``: a new argument, ``new_session`` may be passed to ``Command.popen``, which runs the given
+  in a new session (``setsid`` on POSIX, ``CREATE_NEW_PROCESS_GROUP`` on Windows)
+* ``Command.Popen``: args can now also be a list (previously, it was required to be a tuple). See
 * ``local.daemonize``: run commands as full daemons (double-fork and ``setsid``) on POSIX systems, or
-  detached from their controlling console and parent (on Windows).   
+  detached from their controlling console and parent (on Windows).
 * ``list_processes``: return a list of running process (local/remote machines)
 * ``SshMachine.nohup``: "daemonize" remote commands via ``nohup`` (not really a daemon, but good enough)
 * ``atomic``: Atomic file operations (``AtomicFile``, ``AtomicCounterFile`` and ``PidFile``)
@@ -126,12 +127,12 @@
 * terminal: initial commit (``get_terminal_size``)
 * packaging: the package was split into subpackages; it grew too big for a flat namespace.
   imports are not expected to be broken by this change
-* SshMachine: added ``password`` parameter, which relies on `sshpass <http://linux.die.net/man/1/sshpass>`_ to feed the 
+* SshMachine: added ``password`` parameter, which relies on `sshpass <http://linux.die.net/man/1/sshpass>`_ to feed the
   password to ``ssh``. This is a security risk, but it's occasionally necessary. Use this with caution!
 * Commands now have a ``machine`` attribute that points to the machine they run on
 * Commands gained ``setenv``, which creates a command with a bound environment
 * Remote path: several fixes to ``stat`` (``StatRes``)
-* cli: add lazily-loaded subcommands (e.g., ``MainApp.subcommand("foo", "my.package.foo.FooApp")``), which are imported 
+* cli: add lazily-loaded subcommands (e.g., ``MainApp.subcommand("foo", "my.package.foo.FooApp")``), which are imported
   on demand
 * Paths: added `relative_to and split <https://github.com/tomerfiliba/plumbum/blob/c224058bcefaf5c00fe2295389887c7ebc9d5132/tests/test_local.py#L53>`_,
   which (respectively) computes the difference between two paths and splits paths into lists of nodes
@@ -145,21 +146,21 @@
 * Path: ``walk()`` now applies filter recursively (`#64 <https://github.com/tomerfiliba/plumbum/issues/64>`_)
 * Commands: added `Append redirect <https://github.com/tomerfiliba/plumbum/pull/54>`_
 * Commands: fix ``_subprocess`` issue (`#59 <https://github.com/tomerfiliba/plumbum/issues/59>`_)
-* Commands: add ``__file__`` to module hack (`#66 <https://github.com/tomerfiliba/plumbum/issues/66>`_)  
-* Paramiko: add `'username' and 'password' <https://github.com/tomerfiliba/plumbum/pull/52>`_ 
+* Commands: add ``__file__`` to module hack (`#66 <https://github.com/tomerfiliba/plumbum/issues/66>`_)
+* Paramiko: add `'username' and 'password' <https://github.com/tomerfiliba/plumbum/pull/52>`_
 * Paramiko: add `'timeout' and 'look_for_keys' <https://github.com/tomerfiliba/plumbum/pull/67>`_
 * Python 3: fix `#56 <https://github.com/tomerfiliba/plumbum/issues/56>`_ and `#55 <https://github.com/tomerfiliba/plumbum/pull/55>`_
 
 1.1
 ---
-* `Paramiko <http://pypi.python.org/pypi/paramiko/1.8.0>`_ integration 
+* `Paramiko <http://pypi.python.org/pypi/paramiko/1.8.0>`_ integration
   (`#10 <https://github.com/tomerfiliba/plumbum/issues/10>`_)
 * CLI: now with built-in support for `sub-commands <https://plumbum.readthedocs.io/en/latest/cli.html#sub-commands>`_.
   See also: `#43 <https://github.com/tomerfiliba/plumbum/issues/43>`_
 * The "import hack" has moved to the package's ``__init__.py``, to make it importable directly
   (`#45 <https://github.com/tomerfiliba/plumbum/issues/45>`_)
 * Paths now support ``chmod`` (on POSIX platform) (`#49 <https://github.com/tomerfiliba/plumbum/pull/49>`_)
-* The argument name of a ``SwitchAttr`` can now be given to it (defaults to ``VALUE``) 
+* The argument name of a ``SwitchAttr`` can now be given to it (defaults to ``VALUE``)
   (`#46 <https://github.com/tomerfiliba/plumbum/pull/46>`_)
 
 1.0.1
@@ -168,7 +169,7 @@
   the lower-cased result (`#38 <https://github.com/tomerfiliba/plumbum/issues/38>`_)
 * Properly handle empty strings in the argument list (`#41 <https://github.com/tomerfiliba/plumbum/issues/41>`_)
 * Relaxed type-checking of ``LocalPath`` and ``RemotePath`` (`#35 <https://github.com/tomerfiliba/plumbum/issues/35>`_)
-* Added ``PuttyMachine`` for Windows users that relies on ``plink`` and ``pscp`` 
+* Added ``PuttyMachine`` for Windows users that relies on ``plink`` and ``pscp``
   (instead of ``ssh`` and ``scp``) `(#37 <https://github.com/tomerfiliba/plumbum/issues/37>`_)
 
 1.0.0

--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -108,7 +108,7 @@ def choose(question, options, default = None):
             continue
         return choices[choice]
 
-def prompt(question, type = int, default = NotImplemented, validator = lambda val: True):
+def prompt(question, type = str, default = NotImplemented, validator = lambda val: True):
 
     """
     Presents the user with a validated question, keeps asking if validation does not pass.


### PR DESCRIPTION
Fix #327 in one of two obvious ways. prompt type defaults to str, to match docs.