### PR TITLE
Unicode fixes for Python 2 (and tests for Python 3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 1.6.4 (in progress)
 -------------------
 
+* Support for localization, with Russian provided (`#339 <https://github.com/tomerfiliba/plumbum/pull/339>`_). Pulls with more languages welcome!
+* Fixed unicode input/output on Python 2 (`#341 <https://github.com/tomerfiliba/plumbum/pull/341>`_)
 * Fixes for globbing with spaces in filename on a remote server (`#322 <https://github.com/tomerfiliba/plumbum/issues/322>`_)
 * Terminal: Changed ``prompt()``'s default value for ``type`` parameter from ``int`` to ``str`` to match existing docs (`#327 <https://github.com/tomerfiliba/plumbum/issues/327>`_)
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,15 @@
+# Contributing to Plumbum
+
+
+## General comments
+
+Pull requests welcome! Please make sure you add tests (in an easy `pytest` format) to the tests folder for your fix or features. Make sure you add documentation covering a new feature.
+
+## Adding a language
+
+Plumbum.cli prints various messages for the user. These can be localized into your local language; pull requests adding languages are welcome.
+
+To add a language, copy the file `plumbum/cli/i18n/messages.pot` to `plumbum/cli/i18n/locale/<lang>/LC_MESSAGES/<lang>.po`, and add your language. 
+
+
+See `gettext: PMOTW3 <https://pymotw.com/3/gettext/>`_ for more info.

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -23,7 +23,7 @@ def shquote(text):
     """Quotes the given text with shell escaping (assumes as syntax similar to ``sh``)"""
     if not text:
         return "''"
-    text = str(text)
+    text = six.str(text)
     if not text:
         return "''"
     for c in text:
@@ -33,8 +33,8 @@ def shquote(text):
         return text
     if "'" not in text:
         return "'" + text + "'"
-    res = "".join(('\\' + c if c in _funnychars else c) for c in text)
-    return '"' + res + '"'
+    res = six.str("").join((six.str('\\' + c) if c in _funnychars else c) for c in text)
+    return six.str('"') + res + six.str('"')
 
 def shquote_list(seq):
     return [shquote(item) for item in seq]
@@ -440,7 +440,7 @@ class ConcreteCommand(BaseCommand):
         return self.custom_encoding
 
     def formulate(self, level = 0, args = ()):
-        argv = [str(self.executable)]
+        argv = [six.str(self.executable)]
         for a in args:
             if a is None:
                 continue
@@ -450,18 +450,10 @@ class ConcreteCommand(BaseCommand):
                 else:
                     argv.extend(a.formulate(level + 1))
             elif isinstance(a, (list, tuple)):
-                argv.extend(shquote(b) if level >= self.QUOTE_LEVEL else str(b) for b in a)
+                argv.extend(shquote(b) if level >= self.QUOTE_LEVEL else six.str(b) for b in a)
             else:
-                argv.append(shquote(a) if level >= self.QUOTE_LEVEL else str(a))
+                argv.append(shquote(a) if level >= self.QUOTE_LEVEL else six.str(a))
         # if self.custom_encoding:
         #    argv = [a.encode(self.custom_encoding) for a in argv if isinstance(a, six.string_types)]
         return argv
-
-
-
-
-
-
-
-
 

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -71,6 +71,8 @@ class six(object):
         def get_method_function(m):
             return m.im_func
 
+    str = unicode_type
+
 # Try/except fails because io has the wrong StringIO in Python2
 # You'll get str/unicode errors
 if six.PY3:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -738,3 +738,30 @@ for _ in range(%s):
         print( (echo['one two three four'] | grep['two'] | grep['five'])(retcode=None))
         print( (echo['one two three four'] | grep['six'] | grep['five'])(retcode=None))
 
+
+class TestLocalEncoding:
+    try:
+        richstr = unichr(40960)
+    except NameError:
+        richstr = chr(40960)
+
+    def test_echo_rich(self):
+        from plumbum.cmd import echo
+        out = echo(self.richstr)
+        assert self.richstr in out
+
+    @pytest.mark.usefixtures("cleandir")
+    def test_infile_rich(self):
+        from plumbum.cmd import cat
+        import io
+
+        with io.open('temp.txt', 'w', encoding='utf8') as f:
+            f.write(self.richstr)
+        out = cat('temp.txt')
+        assert self.richstr in out
+
+    @pytest.mark.usefixtures("cleandir")
+    def test_runfile_rich(self):
+        from plumbum.cmd import echo
+        out = echo(self.richstr)
+        assert self.richstr in out


### PR DESCRIPTION
Python 2 Plumbum fails (for example, on Travis) if you have unicode in your output. This fixes that, and tests it.

It is still not supported to use a unicode path in Python 2 (and probably that limitation will remain until Python 2 dies).