### PR TITLE
Make it possible to write to stdin of a pipeline (try #2)

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,8 @@ requirements:
 
   run:
     - python
-    - paramiko
+    - paramiko<2.4 # [py26]
+    - paramiko # [not py26]
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -34,7 +35,8 @@ test:
   requires:
     # Put any additional test requirements here.  For example
     - pytest
-    - paramiko
+    - paramiko<2.4 # [py26]
+    - paramiko # [not py26]
 
 about:
   home: https://plumbum.readthedocs.io

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
-paramiko
 pytest
 pytest-cov
+paramiko<2.4 ; python_version < '2.7'
+paramiko ; python_version >= '2.7'

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -303,7 +303,7 @@ class Pipeline(BaseCommand):
             rc_src = srcproc.wait(*args, **kwargs)
             dstproc.returncode = rc_dst or rc_src
             return dstproc.returncode
-        dstproc.wait = wait2
+        dstproc._proc.wait = wait2
 
         dstproc_verify = dstproc.verify
         def verify(proc, retcode, timeout, stdout, stderr):

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -281,6 +281,8 @@ class Pipeline(BaseCommand):
     def popen(self, args = (), **kwargs):
         src_kwargs = kwargs.copy()
         src_kwargs["stdout"] = PIPE
+        if "stdin" in kwargs:
+            src_kwargs["stdin"] = kwargs["stdin"]
 
         srcproc = self.srccmd.popen(args, **src_kwargs)
         kwargs["stdin"] = srcproc.stdout
@@ -289,7 +291,7 @@ class Pipeline(BaseCommand):
         srcproc.stdout.close()
         if srcproc.stderr is not None:
             dstproc.stderr = srcproc.stderr
-        if srcproc.stdin:
+        if srcproc.stdin and src_kwargs.get('stdin') != PIPE:
             srcproc.stdin.close()
         dstproc.srcproc = srcproc
 
@@ -318,6 +320,7 @@ class Pipeline(BaseCommand):
             dstproc_verify(retcode, timeout, stdout, stderr)
         dstproc.verify = MethodType(verify, dstproc)
 
+        dstproc.stdin = srcproc.stdin
         return dstproc
 
 class BaseRedirection(BaseCommand):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -746,6 +746,12 @@ for _ in range(%s):
         print( (echo['one two three four'] | grep['two'] | grep['five'])(retcode=None))
         print( (echo['one two three four'] | grep['six'] | grep['five'])(retcode=None))
 
+    def test_pipeline_stdin(self):
+        from plumbum.cmd import cat
+        from subprocess import PIPE
+        with (cat | cat).bgrun(stdin=PIPE) as future:
+            future.stdin.write(b'foobar')
+            future.stdin.close()
 
 class TestLocalEncoding:
     try:


### PR DESCRIPTION
This enables the use-case where a Python function takes a file object as
argument. For instance (with boto3):

    with cmd.bgrun(stdin=PIPE) as f:
        boto3.download_fileobj(bucket, key, f.proc.stdin)

The first PR (#355) broke functionality because it changed the behavior of Popen objects. Specifically, the dstproc Popen object had a non-None stdin field that it didn't understand how to deal with. This change avoids that problem by not exposing a stdin to the underlying Popen object. The only way I could think to do this was by switching from inheritance (in IterablePopen) to composition.