### PR TITLE
image.py: fix old-style(?) relative import statement

### DIFF
--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from plumbum import colors
 from .termsize import get_terminal_size
-import . as cli
+from .. import cli
 import sys
 
 class Image(object):

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -2,6 +2,8 @@ import pytest
 from plumbum.colorlib.styles import ANSIStyle, Color, AttributeNotFound, ColorNotFound
 from plumbum.colorlib.names import color_html, FindNearest
 
+# Just check to see if this file is importable
+from plumbum.cli.image import Image
 
 class TestNearestColor:
     def test_exact(self):


### PR DESCRIPTION
This fixes #365. I can't actually find when this syntax became illegal, but this replacement works both in Python 2.7 and 3.6 whereas the original doesn't.

As I wrote in #365, this patch unbreaks installs under versions of `pip` that have a hard dependency on the `py->pyc` step succeeding.