### PR TITLE
Support PuttyMachine file upload and download using non-default port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ matrix:
       env: PYV=3.6
 #    - python: nightly
     - python: pypy
-    - language: generic
-      env: PY3=2 PYV=Mac2
-      os: osx
-      before_install: python2 -m ensurepip --upgrade
-    - language: generic
-      os: osx
-      env: PY3=3 PYV=Mac3
+    # - language: generic
+    #   env: PY3=2 PYV=Mac2
+    #   os: osx
+    #   before_install: python2 -m ensurepip --upgrade
+    # - language: generic
+    #   os: osx
+    #   env: PY3=3 PYV=Mac3
 
 install: .ci/travis.sh
 script: python$PY3 setup.py test -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ matrix:
       env: PYV=3.6
 #    - python: nightly
     - python: pypy
-    # - language: generic
-    #   env: PY3=2 PYV=Mac2
-    #   os: osx
-    #   before_install: python2 -m ensurepip --upgrade
-    # - language: generic
-    #   os: osx
-    #   env: PY3=3 PYV=Mac3
+    - language: generic
+      env: PY3=2 PYV=Mac2
+      os: osx
+      before_install: python2 -m ensurepip --upgrade
+    - language: generic
+      os: osx
+      env: PY3=3 PYV=Mac3
 
 install: .ci/travis.sh
 script: python$PY3 setup.py test -c

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
+pytest-mock
 pycparser<2.18 ; python_version < '2.7'
 paramiko<2.4 ; python_version < '2.7'
 paramiko ; python_version >= '2.7'

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -276,6 +276,7 @@ class PuttyMachine(SshMachine):
             user = local.env.user
         if port is not None:
             ssh_opts.extend(["-P", str(port)])
+            scp_opts = list(scp_opts) + ["-P", str(port)]
             port = None
         SshMachine.__init__(self, host, user, port, keyfile = keyfile, ssh_command = ssh_command,
             scp_command = scp_command, ssh_opts = ssh_opts, scp_opts = scp_opts, encoding = encoding,
@@ -292,5 +293,3 @@ class PuttyMachine(SshMachine):
     def session(self, isatty = False, new_session = False):
         return ShellSession(self.popen((), (["-t"] if isatty else ["-T"]), new_session = new_session),
             self.custom_encoding, isatty, self.connect_timeout)
-
-

--- a/tests/test_putty.py
+++ b/tests/test_putty.py
@@ -1,0 +1,66 @@
+"""Test that PuttyMachine initializes its SshMachine correctly"""
+
+import pytest
+from plumbum import PuttyMachine, SshMachine
+
+
+@pytest.fixture(params=['default', '322'])
+def ssh_port(request):
+    return request.param
+
+
+class TestPuttyMachine:
+    def test_putty_command(self, mocker, ssh_port):
+        local = mocker.patch('plumbum.machines.ssh_machine.local')
+        init = mocker.spy(SshMachine, '__init__')
+        mocker.patch('plumbum.machines.ssh_machine.BaseRemoteMachine')
+
+        host = mocker.MagicMock()
+        user = local.env.user
+        port = keyfile = None
+        ssh_command = local["plink"]
+        scp_command = local["pscp"]
+        ssh_opts = ["-ssh"]
+        if ssh_port == 'default':
+            putty_port = None
+            scp_opts = ()
+        else:
+            putty_port = int(ssh_port)
+            ssh_opts.extend(['-P', ssh_port])
+            scp_opts = ['-P', ssh_port]
+        encoding = mocker.MagicMock()
+        connect_timeout = 20
+        new_session = True
+
+        PuttyMachine(
+            host,
+            port=putty_port,
+            connect_timeout=connect_timeout,
+            new_session=new_session,
+            encoding=encoding,
+        )
+
+        init.assert_called_with(
+            mocker.ANY,
+            host,
+            user,
+            port,
+            keyfile=keyfile,
+            ssh_command=ssh_command,
+            scp_command=scp_command,
+            ssh_opts=ssh_opts,
+            scp_opts=scp_opts,
+            encoding=encoding,
+            connect_timeout=connect_timeout,
+            new_session=new_session,
+        )
+
+    def test_putty_str(self, mocker):
+        local = mocker.patch('plumbum.machines.ssh_machine.local')
+        mocker.patch('plumbum.machines.ssh_machine.BaseRemoteMachine')
+
+        host = mocker.MagicMock()
+        user = local.env.user
+
+        machine = PuttyMachine(host)
+        assert str(machine) == 'putty-ssh://{}@{}'.format(user, host)

--- a/tests/test_putty.py
+++ b/tests/test_putty.py
@@ -1,5 +1,6 @@
 """Test that PuttyMachine initializes its SshMachine correctly"""
 
+import platform
 import pytest
 from plumbum import PuttyMachine, SshMachine
 
@@ -10,6 +11,8 @@ def ssh_port(request):
 
 
 class TestPuttyMachine:
+    @pytest.mark.skipif(platform.python_implementation() == 'PyPy',
+                        reason='could not make work on pypy')
     def test_putty_command(self, mocker, ssh_port):
         local = mocker.patch('plumbum.machines.ssh_machine.local')
         init = mocker.spy(SshMachine, '__init__')

--- a/tests/test_putty.py
+++ b/tests/test_putty.py
@@ -63,4 +63,4 @@ class TestPuttyMachine:
         user = local.env.user
 
         machine = PuttyMachine(host)
-        assert str(machine) == 'putty-ssh://{}@{}'.format(user, host)
+        assert str(machine) == 'putty-ssh://{0}@{1}'.format(user, host)

--- a/tests/test_putty.py
+++ b/tests/test_putty.py
@@ -1,8 +1,9 @@
 """Test that PuttyMachine initializes its SshMachine correctly"""
 
-import platform
 import pytest
 from plumbum import PuttyMachine, SshMachine
+
+from plumbum._testtools import xfail_on_pypy
 
 
 @pytest.fixture(params=['default', '322'])
@@ -11,8 +12,7 @@ def ssh_port(request):
 
 
 class TestPuttyMachine:
-    @pytest.mark.skipif(platform.python_implementation() == 'PyPy',
-                        reason='could not make work on pypy')
+    @xfail_on_pypy
     def test_putty_command(self, mocker, ssh_port):
         local = mocker.patch('plumbum.machines.ssh_machine.local')
         init = mocker.spy(SshMachine, '__init__')


### PR DESCRIPTION
This is a fix for issue #369. If a PuttyMachine instance is created to an ssh server that is running on the non-default port, then the upload and download methods fail, because `pscp` is still using the default port instead of the actual port.

I have added some tests. The tests verify:
- PuttyMachine calls the `__init__` of SshMachine with the correct parameters
- PuttyMachine includes the correct port option for pscp with non-default ports
- `PuttyMachine.__str__` has the expected message.

The tests can run on any system even without Putty installed. One of the test fails on PyPy, but it is marked with `@xfail_on_pypy`. It fails on PyPy because the feature of `pytest-mock` used in that test does not work on PyPy.