### PR TITLE
Fix quick translation bug

### DIFF
--- a/build.py
+++ b/build.py
@@ -25,7 +25,7 @@ class BuildProject(cli.Application):
             if twine is None:
                 print("Twine not installed, cannot securely upload. Install twine.")
             else:
-                twine['upload','dist/*gztar' 'dist/*.exe' '*.whl'] & FG
+                twine['upload', 'dist/*tar.gz', 'dist/*.exe', 'dist/*.whl'] & FG
 
 
 if __name__ == "__main__":

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -406,15 +406,13 @@ class Application(object):
                 ngettext(
                     "Expected at least {0} positional argument, got {1}",
                     "Expected at least {0} positional arguments, got {1}",
-                    min_args).format(
-                        min_args, tailargs))
+                    min_args).format(min_args, tailargs))
         elif len(tailargs) > max_args:
             raise PositionalArgumentsError(
                 ngettext(
                     "Expected at most {0} positional argument, got {1}",
                     "Expected at most {0} positional arguments, got {1}",
-                    max_args).format(
-                        max_args, tailargs))
+                    max_args).format(max_args, tailargs))
 
         # Positional arguement validataion
         if hasattr(self.main, 'positional'):

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -8,9 +8,9 @@ if loc is None or loc.startswith('en'):
             return str
         def ngettext(self, str1, strN, n):
             if n==1:
-                return str1.format(n)
+                return str1.replace("{0}", str(n))
             else:
-                return strN.format(n)
+                return strN.replace("{0}", str(n))
 
     def get_translation_for(package_name):
         return NullTranslation()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,9 @@ class SimpleApp(cli.Application):
         self.eggs = old
         self.tailargs = args
 
-
+class PositionalApp(cli.Application):
+    def main(self, one):
+        print("Got", one)
 
 class Geet(cli.Application):
     debug = cli.Flag("--debug")
@@ -122,6 +124,24 @@ class TestCLI:
 
         _, rc = SimpleApp.run(["foo", "--bacon=hello"], exit = False)
         assert rc == 2
+
+
+    # Testing #371
+    def test_extra_args(self, capsys):
+
+        _, rc = PositionalApp.run(["positionalapp"], exit = False)
+        assert rc != 0
+        stdout, stderr = capsys.readouterr()
+        assert "Expected at least" in stdout
+
+        _, rc = PositionalApp.run(["positionalapp", "one"], exit = False)
+        assert rc == 0
+        stdout, stderr = capsys.readouterr()
+
+        _, rc = PositionalApp.run(["positionalapp", "one", "two"], exit = False)
+        assert rc != 0
+        stdout, stderr = capsys.readouterr()
+        assert "Expected at most" in stdout
 
     def test_subcommands(self):
         _, rc = Geet.run(["geet", "--debug"], exit = False)


### PR DESCRIPTION
The accelerated translations if the language is English (for #364 in 1.6.5) broke one of the error messages #371. This fixes #371.