### PR TITLE
Fixing after Python brew change on macOS

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -3,12 +3,6 @@
 echo $TRAVIS_PYTHON_VERSION
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-    if brew ls --versions python$PY3 > /dev/null; then
-        echo "Brew python is already installed"
-    else
-        brew update
-        brew install python$PY3
-    fi
     python$PY3 -m pip install -r dev-requirements.txt
     python$PY3 -m pip install coveralls
     python$PY3 -m pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,21 @@ matrix:
     - language: generic
       env: PY3=2 PYV=Mac2
       os: osx
-      before_install: python2 -m ensurepip --upgrade
+      before_install:
+        - python2 -m ensurepip --upgrade
     - language: generic
       os: osx
       env: PY3=3 PYV=Mac3
+      before_install:
+        - brew update || echo "Already updated"
+        - brew upgrade python@3 || echo "Python3 already installed"
 
 install: .ci/travis.sh
 script: python$PY3 setup.py test -c
 after_success:
-    - if [ -n "$PYV" ] ; then coveralls; fi
+  - if [ -n "$PYV" ] ; then coveralls; fi
 
 notifications:
-    email:
-        on_success: change
-        on_failure: change
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
Now `brew install python` installs python3.

Should fix the travis builds so PRs will start succeeding again.