### PR TITLE
Adding marker to ensure Paramiko is not installed on Python 2.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 
-paramiko = "*"
+paramiko = {version = "*", markers="python_version >= '2.7'"}
 
 
 [dev-packages]


### PR DESCRIPTION
This should fix Python 2.6 build failures.

Python 2.6 is still supported by Plumbum for now since it is the default Python on Scientific Linux 6 and CentOS/RHEL 6. (Technically, RHEL 5 is still supported, and that's Python 2.4, but enough is enough). 

This ought to fix the only  problem with #386, too.