### PR TITLE
Fix name of fspath

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -84,7 +84,7 @@ class Path(str, six.ABC):
 
     __bool__ = __nonzero__
 
-    def __fpath__(self):
+    def __fspath__(self):
         """Added for Python 3.6 support"""
         return str(self)
 


### PR DESCRIPTION
Not critical, since Plumbum's path inherit from str. Found in #396.