### PR TITLE
allow switch abbrevations as an option

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -424,6 +424,27 @@ specify the validators. For example::
 
 Annotations are ignored if the positional decorator is present.
     
+Switch Abbreviations
+^^^^^^^^^^^^^^^^^^^^
+
+The cli supports switches which have been abbreviated by the user, for example, "--h", "--he", or
+"--hel" would all match an actual switch name of"--help", as long as no ambiguity arises from
+multiple switches that might match the same abbreviation. This behavior is disabled by default but
+can be enabled by defining the class-level attribute ``ALLOW_ABBREV`` to True. For example::
+
+    class MyApp(cli.Application):
+        ALLOW_ABBREV = True
+        cheese = cli.Flag(["cheese"], help = "cheese, please")
+        chives = cli.Flag(["chives"], help = "chives, instead")
+
+With the above definition, running the following will raise an error due to ambiguity::
+
+    $ python example.py --ch   # error! matches --cheese and --chives
+
+However, the following two lines are equivalent::
+
+    $ python example.py --che
+    $ python example.py --cheese
 
 
 .. _guide-subcommands:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,8 @@ class SimpleApp(cli.Application):
         print ("!!b", param)
 
     eggs = cli.SwitchAttr(["e"], str, help = "sets the eggs attribute", envname="PLUMBUM_TEST_EGGS")
+    cheese = cli.Flag(["--cheese"], help = "cheese, please")
+    chives = cli.Flag(["--chives"], help = "chives, instead")
     verbose = cli.CountOf(["v"], help = "increases the verbosity level")
     benedict = cli.CountOf(["--benedict"], help = """a very long help message with lots of
         useless information that nobody would ever want to read, but heck, we need to test
@@ -291,5 +293,15 @@ class TestCLI:
         stdout, stderr = capsys.readouterr()
         assert "bacon is mandatory" in stdout
 
+    def test_partial_switches(self, capsys):
+        app = SimpleApp
+        app.ALLOW_ABBREV = True
+        inst, rc = app.run(["foo", "--bacon=2", "--ch"], exit=False)
+        stdout, stderr = capsys.readouterr()
+        assert 'Ambiguous partial switch' in stdout
+        assert rc == 2
 
-
+        inst, rc = app.run(["foo", "--bacon=2", "--chee"], exit=False)
+        assert rc == 0
+        assert inst.cheese is True
+        assert inst.chives is False


### PR DESCRIPTION
One feature I missed from argparse is the ability to have abbreviations or partial switches (such as "--foo" matching "--foobar", assuming no ambiguous conflicts). This patch attempts to add that. I also added a unit test and it seems to pass. I'm not sure if the authors are in favor of this feature, but sharing it in case it would be beneficial to others.

P.S. I looked around in the code and docs for an already existing implementation, I hope I didn't miss it and do redundant work :-)