### PR TITLE
Fix RemotePath.join for subclasses

### DIFF
--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -125,7 +125,7 @@ class RemotePath(Path):
 
     @_setdoc(Path)
     def join(self, *parts):
-        return RemotePath(self.remote, self, *parts)
+        return self.__class__(self.remote, self, *parts)
 
     @_setdoc(Path)
     def list(self):


### PR DESCRIPTION
This PR suggests a minor change to make ``RemotePath`` more subclassing-friendly by replacing an explicitly named class with ``self.__class__`` in the ``RemotePath.join`` method. Without this change, doing ``my_path / "some_file"`` always produces a ``RemotePath`` even when ``my_path`` is actually an instance of a subclass of the latter.

Note that it's already done like this in a lot of the other methods (e.g. [dirname](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/remote.py#L89-L94)), but not all of them for some reason. I'm not sure if something would break if you applied this change across the board for all methods in ``RemotePath``, but I'm reasonably sure nothing breaks in this one and it's the only one I care about, anyway, so I'll leave it at that for now.