### PR TITLE
Fix RemotePath.parents (and thereby e.g. RemotePath.parent)

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -404,7 +404,7 @@ class Path(str, six.ABC):
     @property
     def parents(self):
         """Pathlib like sequence of ancestors"""
-        join = lambda x, y: self.__class__(x) / y
+        join = lambda x, y: self._form(x) / y
         as_list = (reduce(join, self.parts[:i], self.parts[0])
                    for i in range(len(self.parts) - 1, 0, -1))
         return tuple(as_list)

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -115,6 +115,11 @@ class TestRemotePath:
                 p.chown(p.uid.name)
                 assert p.uid == os.getuid()
 
+    def test_parent(self):
+        p1 = RemotePath(self._connect(), "/some/long/path/to/file.txt")
+        p2 = p1.parent
+        assert str(p2) == "/some/long/path/to"
+
 class BaseRemoteMachineTest(object):
     TUNNEL_PROG = r"""import sys, socket
 s = socket.socket()


### PR DESCRIPTION
``RemotePath.parents`` and dependent properties such as ``RemotePath.parent`` don't work (cf. tests added in first commit and [their results in CI](https://travis-ci.org/smheidrich/plumbum/builds/426517903)) because [the method that is used](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/base.py#L404-L410) (actually from ``base.Path``) uses a single argument for ``__class__`` to construct the new path objects, while [``RemotePath`` needs at least two ](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/remote.py#L37) (the first one being the remote machine, not present in ``base.Path``).

The 2nd commit aims to fix this by using the ``_form`` method instead of ``__class__`` to construct new path objects, which has the same signature for [``base.Path``](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/base.py#L98-L100), [``LocalPath``](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/local.py#L68-L69) and [``RemotePath``](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/remote.py#L75-L76), and adds the correct remote machine for the latter.

Note that tests for ``LocalPath.parent`` [already exist](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/tests/test_local.py#L162-L163) and are unaffacted by these changes.