### PR TITLE
Implement RemotePath.open for ParamikoMachine-associated paths

### DIFF
--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -293,8 +293,18 @@ class RemotePath(Path):
                 "got %r" % (dst, ))
         self.remote._path_link(self, dst, True)
 
-    def open(self):
-        pass
+    def open(self, mode="r", bufsize=-1):
+        """
+        Opens this path as a file.
+
+        Only works for ParamikoMachine-associated paths for now.
+        """
+        if hasattr(self.remote, "sftp") and hasattr(self.remote.sftp, "open"):
+            return self.remote.sftp.open(self, mode, bufsize)
+        else:
+            raise NotImplementedError(
+                "RemotePath.open only works for ParamikoMachine-associated "
+                "paths for now")
 
     @_setdoc(Path)
     def as_uri(self, scheme='ssh'):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -374,3 +374,42 @@ class TestParamikoMachine(BaseRemoteMachineTest):
 
             ret = list(rem['bash']["-c", 'echo -e "\xC2\xBD"'].popen())
             assert ret == [["%s\n" % unicode_half, None]]
+
+    def test_path_open_remote_write_local_read(self):
+        with self._connect() as rem:
+            # TODO: once Python 2.6 support is dropped, the nested
+            # with-statements below can be combined using "with x as a, y as b"
+            with rem.tempdir() as remote_tmpdir:
+                with local.tempdir() as tmpdir:
+                    assert remote_tmpdir.is_dir()
+                    assert tmpdir.is_dir()
+                    data = six.b("hello world")
+                    with (remote_tmpdir / "bar.txt").open("wb") as f:
+                        f.write(data)
+                    rem.download(
+                        (remote_tmpdir / "bar.txt"),
+                        (tmpdir / "bar.txt")
+                    )
+                    assert (tmpdir / "bar.txt").open("rb").read() == data
+
+            assert not remote_tmpdir.exists()
+            assert not tmpdir.exists()
+
+    def test_path_open_local_write_remote_read(self):
+        with self._connect() as rem:
+            # TODO: cf. note on Python 2.6 support above
+            with rem.tempdir() as remote_tmpdir:
+                with local.tempdir() as tmpdir:
+                    assert remote_tmpdir.is_dir()
+                    assert tmpdir.is_dir()
+                    data = six.b("hello world")
+                    with (tmpdir / "bar.txt").open("wb") as f:
+                        f.write(data)
+                    rem.upload(
+                        (tmpdir / "bar.txt"),
+                        (remote_tmpdir / "bar.txt")
+                    )
+                    assert (remote_tmpdir / "bar.txt").open("rb").read() == data
+
+            assert not remote_tmpdir.exists()
+            assert not tmpdir.exists()


### PR DESCRIPTION
While ``LocalPath.open`` [is implemented](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/local.py#L223-L225) and works fine, ``RemotePath.open`` is currently an [empty placeholder method](https://github.com/tomerfiliba/plumbum/blob/22db2e82b114c02592716530241448bb66b76fdf/plumbum/path/remote.py#L296-L297). However, for ``ParamikoMachine``-associated paths, an implementation is trivial due to the existence of [``SFTPClient.file``](http://docs.paramiko.org/en/latest/api/sftp.html#paramiko.sftp_client.SFTPClient.file), which does pretty much exactly what we want.

This PR exploits that fact and offers a simple implementation of ``RemotePath.open`` which uses ``SFTPClient.file`` for ``ParamikoMachine``-associated paths<sup>1</sup> and raises ``NotImplementedError`` otherwise (a change from the previous behaviour of just returning ``None``).

<sup>1</sup> technically also anything else which has a ``sftp.file`` attribute on its ``remote``