### PR TITLE
Towards pathlib.Path.mkdir compatibility

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -380,8 +380,10 @@ class BaseRemoteMachine(BaseMachine):
     def _path_copy(self, src, dst):
         self._session.run("cp -r %s %s" % (shquote(src), shquote(dst)))
 
-    def _path_mkdir(self, fn):
-        self._session.run("mkdir -p %s" % (shquote(fn), ))
+    def _path_mkdir(self, fn, mode=None, minus_p=True):
+        p_str = "-p " if minus_p else ""
+        cmd = "mkdir %s%s" % (p_str, shquote(fn))
+        self._session.run(cmd)
 
     def _path_chmod(self, mode, fn):
         self._session.run("chmod %o %s" % (mode, shquote(fn)))

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -264,8 +264,21 @@ class Path(str, six.ABC):
         dst exists and override is False."""
 
     @abstractmethod
-    def mkdir(self):
-        """Creates a directory at this path; if the directory already exists, silently ignore"""
+    def mkdir(self, mode=0o777, parents=True, exist_ok=True):
+        """
+        Creates a directory at this path.
+
+        :param mode: **Not implemented yet,** just here to keep the order of arguments
+        backwards-compatible once it is.
+        :param parents: If this is true (the default), the directory's parents will also be created if
+        necessary.
+        :param exist_ok: If this is true (the default), no exception will be raised if the directory
+        already exists (otherwise ``OSError``).
+
+        Note that the defaults for ``parents`` and ``exist_ok`` are the opposite of what they are in
+        Python's own ``pathlib`` - this is to maintain backwards-compatibility with Plumbum's behaviour
+        from before they were implemented.
+        """
 
     @abstractmethod
     def open(self, mode="r"):

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -210,14 +210,17 @@ class LocalPath(Path):
         return dst
 
     @_setdoc(Path)
-    def mkdir(self):
-        if not self.exists():
+    def mkdir(self, mode=0o777, parents=True, exist_ok=True):
+        if not self.exists() or not exist_ok:
             try:
-                os.makedirs(str(self))
+                if parents:
+                    os.makedirs(str(self))
+                else:
+                    os.mkdir(str(self))
             except OSError:  # pragma: no cover
                 # directory might already exist (a race with other threads/processes)
                 _, ex, _ = sys.exc_info()
-                if ex.errno != errno.EEXIST:
+                if ex.errno != errno.EEXIST or not exist_ok:
                     raise
 
     @_setdoc(Path)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -225,6 +225,23 @@ class TestLocalPath:
     def test_path_dir(self):
         assert local.path(__file__).dirname == SDIR
 
+    def test_mkdir(self):
+        # (identical to test_remote.TestRemotePath.test_mkdir)
+        with local.tempdir() as tmp:
+            (tmp / "a").mkdir(exist_ok=False, parents=False)
+            assert (tmp / "a").exists()
+            assert (tmp / "a").is_dir()
+            (tmp / "a").mkdir(exist_ok=True, parents=False)
+            (tmp / "a").mkdir(exist_ok=True, parents=True)
+            with pytest.raises(OSError):
+                (tmp / "a").mkdir(exist_ok=False, parents=False)
+            with pytest.raises(OSError):
+                (tmp / "a").mkdir(exist_ok=False, parents=True)
+            (tmp / "b" / "bb").mkdir(exist_ok=False, parents=True)
+            assert (tmp / "b" / "bb").exists()
+            assert (tmp / "b" / "bb").is_dir()
+        assert not tmp.exists()
+
 
 @pytest.mark.usefixtures("testdir")
 class TestLocalMachine:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -120,6 +120,24 @@ class TestRemotePath:
         p2 = p1.parent
         assert str(p2) == "/some/long/path/to"
 
+    def test_mkdir(self):
+        # (identical to test_local.TestLocalPath.test_mkdir)
+        with self._connect() as rem:
+            with rem.tempdir() as tmp:
+                (tmp / "a").mkdir(exist_ok=False, parents=False)
+                assert (tmp / "a").exists()
+                assert (tmp / "a").is_dir()
+                (tmp / "a").mkdir(exist_ok=True, parents=False)
+                (tmp / "a").mkdir(exist_ok=True, parents=True)
+                with pytest.raises(OSError):
+                    (tmp / "a").mkdir(exist_ok=False, parents=False)
+                with pytest.raises(OSError):
+                    (tmp / "a").mkdir(exist_ok=False, parents=True)
+                (tmp / "b" / "bb").mkdir(exist_ok=False, parents=True)
+                assert (tmp / "b" / "bb").exists()
+                assert (tmp / "b" / "bb").is_dir()
+            assert not tmp.exists()
+
 class BaseRemoteMachineTest(object):
     TUNNEL_PROG = r"""import sys, socket
 s = socket.socket()


### PR DESCRIPTION
This PR aims to make the ``mkdir`` method of Plumbum's path classes (local & remote) more compatible with [``pathlib.Path.mkdir``](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir) by implementing the arguments ``parents`` and ``exist_ok`` that are present in the latter. The ``mode`` argument has also been added to the argument list to match the signature of pathlib's method and preserve backwards-compatibility once it is implemented in the future, but I haven't implemented it yet, because pathlib does some umask-voodoo that I'd have to look into in more detail. I might add it later.

Should be backwards-compatible with earlier Plumbum ``mkdir`` behavior (which unfortunately required choosing defaults different from pathlib's, however) and of course comes with tests.