### PR TITLE
Fix file handle leak in NOHUP / posix_daemonize

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ pytest-mock
 pycparser<2.18 ; python_version < '2.7'
 paramiko<2.4 ; python_version < '2.7'
 paramiko ; python_version >= '2.7'
+psutil

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -59,6 +59,7 @@ def posix_daemonize(command, cwd, stdout=None, stderr=None, append=True):
         os.close(wfd)
         _, rc = os.waitpid(firstpid, 0)
         output = os.read(rfd, MAX_SIZE)
+        os.close(rfd)
         try:
             output = output.decode("utf8")
         except UnicodeError:

--- a/tests/test_nohup.py
+++ b/tests/test_nohup.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import sys
 import time
+import psutil
 from plumbum import local, NOHUP
 try:
     from plumbum.cmd import bash, echo
@@ -62,3 +63,10 @@ class TestNohupLocal:
         assert self.read_file('nohup.out') == 'This is output\n'
         delete('nohup.out')
 
+    def test_closed_filehandles(self):
+        proc = psutil.Process()
+        file_handles_prior = (proc.num_fds())
+        sleep_proc = (local['sleep']['1'] & NOHUP)
+        sleep_proc.wait()
+        file_handles_after = proc.num_fds()
+        assert file_handles_prior == file_handles_after


### PR DESCRIPTION
posix_daemonize failed to close a file handle, which lead to resource exhaustion if you NOHUP'd many thousands of subprocesses.

This commit adds a test demonstrating the leak and closes the appropriate file.