### PR TITLE
Implement mode argument for LocalPath.mkdir

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -268,12 +268,15 @@ class Path(str, six.ABC):
         """
         Creates a directory at this path.
 
-        :param mode: **Not implemented yet,** just here to keep the order of arguments
-        backwards-compatible once it is.
+        :param mode: **Currently only implemented for local paths!** Numeric mode to use for directory
+                     creation, which may be ignored on some systems. The current implementation
+                     reproduces the behavior of ``os.mkdir`` (i.e., the current umask is first masked
+                     out), but this may change for remote paths. As with ``os.mkdir``, it is recommended
+                     to call :func:`chmod` explicitly if you need to be sure.
         :param parents: If this is true (the default), the directory's parents will also be created if
-        necessary.
+                        necessary.
         :param exist_ok: If this is true (the default), no exception will be raised if the directory
-        already exists (otherwise ``OSError``).
+                         already exists (otherwise ``OSError``).
 
         Note that the defaults for ``parents`` and ``exist_ok`` are the opposite of what they are in
         Python's own ``pathlib`` - this is to maintain backwards-compatibility with Plumbum's behaviour

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -214,9 +214,9 @@ class LocalPath(Path):
         if not self.exists() or not exist_ok:
             try:
                 if parents:
-                    os.makedirs(str(self))
+                    os.makedirs(str(self), mode)
                 else:
-                    os.mkdir(str(self))
+                    os.mkdir(str(self), mode)
             except OSError:  # pragma: no cover
                 # directory might already exist (a race with other threads/processes)
                 _, ex, _ = sys.exc_info()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -138,6 +138,32 @@ class TestRemotePath:
                 assert (tmp / "b" / "bb").is_dir()
             assert not tmp.exists()
 
+    @pytest.mark.xfail(reason="mkdir's mode argument is not yet implemented "\
+        "for remote paths", strict=True)
+    def test_mkdir_mode(self):
+        # (identical to test_local.TestLocalPath.test_mkdir_mode)
+        with self._connect() as rem:
+            with rem.tempdir() as tmp:
+                # just verify that mode argument works the same way it does for
+                # Python's own os.mkdir, which takes into account the umask
+                # (different from shell mkdir mode argument!); umask on my
+                # system is 022 by default, so 033 is ok for testing this
+                try:
+                    (tmp / "pb_333").mkdir(exist_ok=False, parents=False,
+                        mode=0o333)
+                    rem.python('-c', 'import os; os.mkdir("{0}", 0o333)'.format(
+                        (tmp / "py_333")))
+                    pb_final_mode = oct((tmp / "pb_333").stat().st_mode)
+                    py_final_mode = oct((tmp / "py_333").stat().st_mode)
+                    assert pb_final_mode == py_final_mode
+                finally:
+                    # we have to revert this so the tempdir deletion works
+                    if (tmp / "pb_333").exists():
+                        (tmp / "pb_333").chmod(0o777)
+                    if (tmp / "py_333").exists():
+                        (tmp / "py_333").chmod(0o777)
+            assert not tmp.exists()
+
 class BaseRemoteMachineTest(object):
     TUNNEL_PROG = r"""import sys, socket
 s = socket.socket()


### PR DESCRIPTION
As a continuation of #410, this PR implements the "mode" argument for ``LocalPath.mkdir``, which turned out to be trivial, as the umask stuff that is mentioned in ``pathlib.Path.mkdir``'s docs also applies to ordinary ``os.mkdir`` (it actually goes back to the ``mkdir`` syscall).

It's still not implemented for ``RemotePath.mkdir``, because the ``mkdir`` shell command (used by Plumbum's remote mkdir implementation) handles the ``--mode`` argument differently, namely without the umask transformation done by the ``mkdir`` syscall, so it's a bit more involved. We'd have to retrieve the umask of the remote process manually in order to do that transformation, but I'm not sure whether one should then also be able to set the remote umask and how that should work in detail. So I'll look into it again later.

The docstring is formulated in such a way that it leaves open the possibility of just not implementing the umask handling for remote paths (only local ones), if it turns out that it doesn't make sense.