### PR TITLE
Docs: update remark on required parentheses

### DIFF
--- a/docs/local_commands.rst
+++ b/docs/local_commands.rst
@@ -107,8 +107,10 @@ the output to a file named ``tmp.txt``::
     ''
 
 .. note::
-   Parenthesis are required here! ``grep["world"] < sys.stdin > "tmp.txt"`` would 
-   result in ``False``...
+   Parentheses are required here! ``grep["world"] < sys.stdin > "tmp.txt"`` would be evaluated
+   according to the `rules for chained comparison operators
+   <https://docs.python.org/reference/expressions.html#comparisons>`_ and result in ``False``
+   (Python 2) or raise an exception (Python 3).
 
 Right after ``foo``, Ctrl+D was pressed, which caused ``grep`` to finish. The empty string
 at the end is the command's ``stdout`` (and it's empty because it actually went to a file).


### PR DESCRIPTION
Mention Python 3 behavior, explain in more detail what is going on, and fix typo.

Fixes #412.