### PR TITLE
Raise exception on attempted redirect to RemotePath and mention this in docs

### DIFF
--- a/docs/remote.rst
+++ b/docs/remote.rst
@@ -151,6 +151,15 @@ Which is even more efficient (no need to send data back and forth over SSH).
 
 .. _guide-paramiko-machine:
 
+Redirection
+^^^^^^^^^^^
+
+Redirection to and from remote paths is not currently supported, but you can redirect to and from
+local paths, with the familiar syntax explained in
+:ref:`the corresponding section for local commands <guide-local-commands-redir>`.
+Note that if the redirection target/source is given as a string, it is automatically interpreted
+as a path on the local machine.
+
 Paramiko Machine
 ----------------
 .. versionadded:: 1.1

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -448,10 +448,10 @@ class BaseRedirection(BaseCommand):
 
         if self.KWARG in kwargs and kwargs[self.KWARG] not in (PIPE, None):
             raise RedirectionError("%s is already redirected" % (self.KWARG, ))
+        if isinstance(self.file, RemotePath):
+            raise TypeError("Cannot redirect to/from remote paths")
         if isinstance(self.file, six.string_types + (LocalPath, )):
             f = kwargs[self.KWARG] = open(str(self.file), self.MODE)
-        elif isinstance(self.file, RemotePath):
-            raise TypeError("Cannot redirect to/from remote paths")
         else:
             kwargs[self.KWARG] = self.file
             f = None


### PR DESCRIPTION
This concerns #390.

From [the way redirection is implemented](https://github.com/tomerfiliba/plumbum/blob/9c66164972d48de47961f6264b4495fab45e0e57/plumbum/commands/base.py#L449-L457), it seems to me that it's not supposed to work for ``RemotePath``s, but the check for whether the destination path is an instance of ``RemotePath`` doesn't get called anymore ever since it was made a subclass of ``str`` in 7536e40d.

This PR flips the order of the checks around so the ``RemotePath``-check happens first and raises the appropriate exception again (one issue in #390 was that it silently redirected to a local path instead, leading to confusion).

It also adds a section to the docs explaining that redirection to ``RemotePath``s is not currently supported.

It would actually be trivial to implement it at least for ``ParamikoMachine``-associated paths since #406, but perhaps it would be better to first try and implement ``open`` for ``SshMachine``-associated paths as well, so that it would just work across the board for all ``RemotePath``s.