### PR TITLE
Fix mkdir mode tests on Windows

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -252,8 +252,8 @@ class TestLocalPath:
             try:
                 (tmp / "pb_333").mkdir(exist_ok=False, parents=False,
                     mode=0o333)
-                local.python('-c', 'import os; os.mkdir("{0}", 0o333)'.format(
-                    (tmp / "py_333")))
+                local.python('-c', 'import os; os.mkdir({0}, 0o333)'.format(
+                    repr(str(tmp / "py_333"))))
                 pb_final_mode = oct((tmp / "pb_333").stat().st_mode)
                 py_final_mode = oct((tmp / "py_333").stat().st_mode)
                 assert pb_final_mode == py_final_mode

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -151,8 +151,8 @@ class TestRemotePath:
                 try:
                     (tmp / "pb_333").mkdir(exist_ok=False, parents=False,
                         mode=0o333)
-                    rem.python('-c', 'import os; os.mkdir("{0}", 0o333)'.format(
-                        (tmp / "py_333")))
+                    rem.python('-c', 'import os; os.mkdir({0}, 0o333)'.format(
+                        repr(str(tmp / "py_333"))))
                     pb_final_mode = oct((tmp / "pb_333").stat().st_mode)
                     py_final_mode = oct((tmp / "py_333").stat().st_mode)
                     assert pb_final_mode == py_final_mode


### PR DESCRIPTION
The tests I introduced in #420 fail [on Windows](https://ci.appveyor.com/project/smheidrich/plumbum/builds/19830972) due to some improper handling of directory paths. This PR [should fix that](https://ci.appveyor.com/project/smheidrich/plumbum/builds/19832738).