### PR TITLE
Fix bug #395.

### DIFF
--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -192,25 +192,43 @@ class _TEE(ExecutionModifier):
             err = p.stderr
             buffers = {out: outbuf, err: errbuf}
             tee_to = {out: sys.stdout, err: sys.stderr}
-            while p.poll() is None:
-                ready, _, _ = select((out, err), (), ())
-                for fd in ready:
-                    buf = buffers[fd]
-                    data, text = read_fd_decode_safely(fd, 4096)
-                    if not data:  # eof
-                        continue
+            done = False
+            while not done:
+                # After the process exits, we have to do one more
+                # round of reading in order to drain any data in the
+                # pipe buffer. Thus, we check poll() here,
+                # unconditionally enter the read loop, and only then
+                # break out of the outer loop if the process has
+                # exited.
+                done = (p.poll() is not None)
 
-                    # Python conveniently line-buffers stdout and stderr for
-                    # us, so all we need to do is write to them
+                # We continue this loop until we've done a full
+                # `select()` call without collecting any input. This
+                # ensures that our final pass -- after process exit --
+                # actually drains the pipe buffers, even if it takes
+                # multiple calls to read().
+                progress = True
+                while progress:
+                    progress = False
+                    ready, _, _ = select((out, err), (), ())
+                    for fd in ready:
+                        buf = buffers[fd]
+                        data, text = read_fd_decode_safely(fd, 4096)
+                        if not data:  # eof
+                            continue
+                        progress = True
 
-                    # This will automatically add up to three bytes if it cannot be decoded
-                    tee_to[fd].write(text)
+                        # Python conveniently line-buffers stdout and stderr for
+                        # us, so all we need to do is write to them
 
-                    # And then "unbuffered" is just flushing after each write
-                    if not self.buffered:
-                        tee_to[fd].flush()
+                        # This will automatically add up to three bytes if it cannot be decoded
+                        tee_to[fd].write(text)
 
-                    buf.append(data)
+                        # And then "unbuffered" is just flushing after each write
+                        if not self.buffered:
+                            tee_to[fd].flush()
+
+                        buf.append(data)
 
             stdout = ''.join([x.decode('utf-8') for x in outbuf])
             stderr = ''.join([x.decode('utf-8') for x in errbuf])

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -529,6 +529,15 @@ class TestLocalMachine:
         assert result[1] == 'This is fun\n'
         assert 'This is fun\n' == capfd.readouterr()[0]
 
+    @skip_on_windows
+    def test_tee_race(sef, capfd):
+        from plumbum.cmd import seq
+        EXPECT = "".join("{}\n".format(i) for i in range(1, 5001))
+        for _ in range(5):
+            result = seq['1', '5000'] & TEE
+            assert result[1] == EXPECT
+            assert EXPECT == capfd.readouterr()[0]
+
     def test_arg_expansion(self):
         from plumbum.cmd import ls
         args = [ '-l', '-F' ]

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -530,7 +530,7 @@ class TestLocalMachine:
         assert 'This is fun\n' == capfd.readouterr()[0]
 
     @skip_on_windows
-    def test_tee_race(sef, capfd):
+    def test_tee_race(self, capfd):
         from plumbum.cmd import seq
         EXPECT = "".join("{}\n".format(i) for i in range(1, 5001))
         for _ in range(5):


### PR DESCRIPTION
Even if the child process has exited, it may have written data that is
still in the pipe buffer. We need to make sure to drain it with one
final round of `select()`ing.

Note that this differs from the shell semantics of `| tee file.out`;
In a shell pipeline, the right-hand-side has no direct reference to
the left-hand-side, and so `tee` reads until it gets an `EOF` on the
pipe, normally caused by all write-side ends being closed. We can
demonstrate this with a pipeline that causes the write end to outlive
the left-hand child:

```
( sleep 500 & disown; echo hi ) | tee out.log
```

After the `hi` is printed, we can observe that the left-hand `bash` is
dead, but `tee` still has not returned:

```
$ pstree -p 7273
bash(7273)───tee(1790)
```

Killing the `sleep` makes the whole pipeline exit.

I chose to preserve the original `plumbum` semantics of "exit on child
exit" instead of the shell semantics, but wanted to call out the
difference.