### PR TITLE
Show default value msg as help msg when default value is supplied without explicit help msg

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -2,11 +2,14 @@
 
 echo $TRAVIS_PYTHON_VERSION
 
+# Listed twice to workaround Python 2.6
 if [[ "$(uname -s)" == 'Darwin' ]]; then
+    python$PY3 -m pip install --upgrade pip
     python$PY3 -m pip install -r dev-requirements.txt
     python$PY3 -m pip install coveralls
     python$PY3 -m pip install -e .
 else
+    pip install --upgrade pip
     pip install -r dev-requirements.txt
     pip install coveralls
     pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: required
 language: python
-dist: trusty
+dist: xenial
 matrix:
   include:
     - python: 2.6
+      dist: trusty
       env: PYV=2.6
       before_install:
         -  pip install pycparser==2.17
@@ -17,20 +18,20 @@ matrix:
       env: PYV=3.6
     - python: 3.7
       env: PYV=3.7
-      dist: xenial
 #    - python: nightly
     - python: pypy
     - language: generic
       env: PY3=2 PYV=Mac2
       os: osx
       before_install:
-        - python2 -m ensurepip --upgrade
+        - python2 -m ensurepip
     - language: generic
       os: osx
       env: PY3=3 PYV=Mac3
-      before_install:
-        - brew update || echo "Already updated"
-        - brew upgrade python@3 || echo "Python3 already installed"
+      addons:
+        homebrew:
+          packages:
+            - python
 
 install: .ci/travis.sh
 script: python$PY3 setup.py test -c

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,6 @@ idna<2.8 ; python_version < '2.7'
 pycparser<2.18 ; python_version < '2.7'
 paramiko<2.4 ; python_version < '2.7'
 paramiko ; python_version >= '2.7'
+setuptools
+wheel ; python_version >= '2.7'
 psutil

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -231,8 +231,12 @@ class SwitchAttr(object):
                  argname=_("VALUE"),
                  **kwargs):
         self.__doc__ = "Sets an attribute"  # to prevent the help message from showing SwitchAttr's docstring
-        if "help" in kwargs and default and argtype is not None:
-            kwargs["help"] += _("; the default is {0}").format(default)
+        if default and argtype is not None:
+            defaultmsg = _("; the default is {0}").format(default)
+            if "help" in kwargs:
+                kwargs["help"] += defaultmsg
+            else:
+                kwargs["help"] = defaultmsg.lstrip('; ')
 
         switch(
             names, argtype=argtype, argname=argname, list=list, **kwargs)(self)

--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,6 @@ setup(name = "plumbum",
     keywords = "path, local, remote, ssh, shell, pipe, popen, process, execution, color, cli",
     cmdclass = {'test':PyTest,
                 'docs':PyDocs},
-    # use_2to3 = False,
-    # zip_safe = True,
     long_description = open(os.path.join(HERE, "README.rst"), "r").read(),
     classifiers = [
         "Development Status :: 5 - Production/Stable",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -290,7 +290,7 @@ s.close()
                 for i, lines in enumerate(rem["ls"]["--bla"].popen()):
                     pass
                 assert i == 1
-            assert ex.value.stderr.startswith("/bin/ls: ")
+            assert "/bin/ls: " in ex.value.stderr
 
     def test_touch(self):
         with self._connect() as rem:


### PR DESCRIPTION
If no help msg is provided to switchattr, but a default is, give it a help msg that's the default msg with the leading '; ' stripped; fixes #433