### PR TITLE
machine.cmd

### DIFF
--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -81,3 +81,18 @@ class BaseMachine(object):
                        stderr=None,
                        append=True):
         raise NotImplementedError("This is not implemented on this machine!")
+
+    class Cmd(object):
+
+        def __init__(self, machine):
+            self._machine = machine
+
+        def __getattr__(self, name):
+            try:
+                return self._machine[name]
+            except CommandNotFound:
+                raise AttributeError(name)
+
+    @property
+    def cmd(self):
+        return self.Cmd(self)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -785,6 +785,9 @@ for _ in range(%s):
         with pytest.raises(ProcessExecutionError):
             (ls["--no-such-option"] | head)()
 
+    def test_cmd(self):
+        local.cmd.ls("/tmp")
+
     def test_pipeline_retcode(self):
         "From PR #288"
         from plumbum.cmd import echo, grep

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -216,6 +216,10 @@ s.close()
                 filenames = [f.name for f in rem.cwd // ("*with space.txt")]
                 assert "file with space.txt" in filenames
 
+    def test_cmd(self):
+        with self._connect() as rem:
+            rem.cmd.ls("/tmp")
+
     @pytest.mark.usefixtures("testdir")
     def test_download_upload(self):
         with self._connect() as rem:


### PR DESCRIPTION
Provide a more elegant syntax for running commands:
`machine.cmd.ls("-la")`