### PR TITLE
Make sure skip is passed a string

### DIFF
--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -291,7 +291,7 @@ s.close()
                     print("err:", err)
             except NotImplementedError:
                 try:
-                    pytest.skip(sys.exc_info()[1])
+                    pytest.skip(str(sys.exc_info()[1]))
                 except AttributeError:
                     return
             except ProcessTimedOut:


### PR DESCRIPTION
Hoping to fix macOS test failure.