### PR TITLE
Fix context manager for LocalCommand.popen()

### DIFF
--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -42,6 +42,12 @@ class PlumbumLocalPopen(PopenAddons):
     def __iter__(self):
         return self.iter_lines()
 
+    def __enter__(self):
+        return self._proc.__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        return self._proc.__exit__(*args, **kwargs)
+
     def __getattr__(self, name):
         return getattr(self._proc, name)
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -8,7 +8,7 @@ from plumbum import (local, LocalPath, FG, BG, TF, RETCODE, ERROUT, TEE,
                     CommandNotFound, ProcessExecutionError, ProcessTimedOut, ProcessLineTimedOut)
 from plumbum.lib import six, IS_WIN32
 from plumbum.fs.atomic import AtomicFile, AtomicCounterFile, PidFile
-from plumbum.machines.local import LocalCommand
+from plumbum.machines.local import LocalCommand, PlumbumLocalPopen
 from plumbum.path import RelativePath
 import plumbum
 
@@ -21,6 +21,16 @@ from plumbum._testtools import (
 
 # This is a string since we are testing local paths
 SDIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestLocalPopen:
+    def test_contextmanager(self):
+        if IS_WIN32:
+            command = ['dir']
+        else:
+            command = ['ls']
+        with PlumbumLocalPopen(command):
+            pass
 
 
 class TestLocalPath:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -24,6 +24,8 @@ SDIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestLocalPopen:
+    @pytest.mark.skipif(sys.version_info < (3, 2),
+                        reason="Context Manager was introduced in Python 3.2")
     def test_contextmanager(self):
         if IS_WIN32:
             command = ['dir']


### PR DESCRIPTION
This fixes a regression introduced in 108342ad9f7580bd0ada0cf100ddf7620bf73f9e.

It appears that this commit tried to implement a transparent proxy object for `subprocess.Popen`. Unfortunately, special method calls  (e.g. of context manager methods by the `with` statement) generally circumvent the `__getattribute__` machinery and perform direct lookup.

This leads to an exception when calling LocalCommand.popen() within a with statement:

``` python
>>> from plumbum import local
>>> ls = local['ls']
>>> with ls.popen():
...     print("yay")
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: __enter__
```

This broke some code of mine. I have not found any documentation regarding this change, so I assume dropping the context manager functionality was an accident.

This PR restores the context manager functionality for `local[...].popen()` calls.