### PR TITLE
Fix incorrect __getitem__ method in Path

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -38,7 +38,11 @@ class Path(str, six.ABC):
         return self.join(other)
 
     __truediv__ = __div__
-    __getitem__ = __div__
+
+    def __getitem__(self, key):
+        if type(key) == str or isinstance(key, Path):
+            return self / key
+        return str(self)[key]
 
     def __floordiv__(self, expr):
         """Returns a (possibly empty) list of paths that matched the glob-pattern under this path"""

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -279,6 +279,11 @@ class TestLocalPath:
                     (tmp / "py_333").chmod(0o777)
         assert not tmp.exists()
 
+    def test_str_getitem(self):
+        with local.tempdir() as tmp:
+            assert str(tmp) == str(tmp[:])
+            assert str(tmp)[0] == str(tmp[0])
+
 
 @pytest.mark.usefixtures("testdir")
 class TestLocalMachine:


### PR DESCRIPTION
Plumbum doesn't support PathLike logics, because Path class is inherited from str and therefore considered as str in python libraries (`__fspath__ `method is never called). Before #455 everything was fine, but after the corresponding commit libraries are unable to use plumbum Path as string, because `__getitem__` returns strange thinks for int and slice keys.

Consider the following example:

```
import os
import plumbum

print(os.path.splitext(plumbum.local.path('/test/file.ext')))
```

Before #455 the output is as expected:

>('/test/file', '.ext')

But after the commit it is meaningless:

> (<LocalPath /test/file.ext/slice(None, 10, None)>, <LocalPath /test/file.ext/slice(10, None, None)>)


I fix this bug by returning the old `__getitem__` behaviour for `int` and `slice` keys.