### PR TITLE
ssh: better error reporting on SshSession errors

### DIFF
--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -127,8 +127,9 @@ class ProcessExecutionError(EnvironmentError):
     well as the command line used to create the process (``argv``)
     """
 
-    def __init__(self, argv, retcode, stdout, stderr):
+    def __init__(self, argv, retcode, stdout, stderr, message=None):
         Exception.__init__(self, argv, retcode, stdout, stderr)
+        self.message = message
         self.argv = argv
         self.retcode = retcode
         if six.PY3 and isinstance(stdout, six.bytes):
@@ -139,11 +140,18 @@ class ProcessExecutionError(EnvironmentError):
         self.stderr = stderr
 
     def __str__(self):
+        # avoid an import cycle
         from plumbum.commands.base import shquote_list
         stdout =      "\n              | ".join(str(self.stdout).splitlines())
         stderr =      "\n              | ".join(str(self.stderr).splitlines())
         cmd = " ".join(shquote_list(self.argv))
-        lines = ["Unexpected exit code: ", str(self.retcode)]
+        lines = []
+        if self.message:
+            lines = [
+                self.message,
+                      "\nReturn code:  | ", str(self.retcode)]
+        else:
+            lines = ["Unexpected exit code: ", str(self.retcode)]
         cmd =         "\n              | ".join(cmd.splitlines())
         lines +=     ["\nCommand line: | ", cmd]
         if stdout:


### PR DESCRIPTION
We fail so frequently on various ssh configuration problems, and yet the error messages are mostly uninformative:

```
01:59:07 | No stderr result detected. Does the remote have Bash as the default shell?
...
01:59:07 |   */plumbum/machines/session.py:277 ................................ run >> return run_proc(self.popen(cmd), retcode)
01:59:07 |   */plumbum/commands/processes.py:292 ......................... run_proc >> stdout, stderr = proc.communicate()
01:59:07 |   */plumbum/machines/session.py:136 ........................ communicate >> msgerr) if name == "2" else SSHCommsError(msg)
```

It seems that the code was not ready for various other return codes