### PR TITLE
make ShellSession thread-safe when using .run()

### DIFF
--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -175,6 +175,7 @@ class ShellSession(object):
         self.proc = proc
         self.custom_encoding = proc.custom_encoding if encoding == "auto" else encoding
         self.isatty = isatty
+        self._lock = threading.RLock()
         self._current = None
         if connect_timeout:
 
@@ -274,4 +275,5 @@ class ShellSession(object):
                         ignore erroneous return codes
         :returns: A tuple of (return code, stdout, stderr)
         """
-        return run_proc(self.popen(cmd), retcode)
+        with self._lock:
+            return run_proc(self.popen(cmd), retcode)


### PR DESCRIPTION
(Not sure if there's some philosophy against dealing with concurrency in plumbum?...)