### PR TITLE
Fix TypeError:  'str' object is not callable in LocalPath.__fspath__

### DIFF
--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -58,9 +58,6 @@ class LocalPath(Path):
             cls, os.path.normpath(os.path.join(*(str(p) for p in parts))))
         return self
 
-    def __fspath__(self):
-        return self._path()
-
     @property
     def _path(self):
         return str(self)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -284,6 +284,10 @@ class TestLocalPath:
             assert str(tmp) == str(tmp[:])
             assert str(tmp)[0] == str(tmp[0])
 
+    def test_fspath(self):
+        with local.tempdir() as tmp:
+            assert tmp.__fspath__() == str(tmp)
+
 
 @pytest.mark.usefixtures("testdir")
 class TestLocalMachine:


### PR DESCRIPTION
So basically there was a bug in `LocalPath.__fspath__`: we tried to call `self._path()` where `_path` is a property.
I solved the problem by just inheriting the implementation from Path, as `Path.__fspath__` is implemented correctly:
```
    def __fspath__(self):                                                                                                                          
        """Added for Python 3.6 support"""                                                                                                         
        return str(self)    
```