### PR TITLE
make iter_lines deal with decoding errors during iteration; Also...

### DIFF
--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -354,11 +354,8 @@ def iter_lines(proc,
 
     assert mode in (BY_POSITION, BY_TYPE)
 
-    encoding = getattr(proc, "custom_encoding", None)
-    if encoding:
-        decode = lambda s: s.decode(encoding).rstrip()
-    else:
-        decode = lambda s: s
+    encoding = getattr(proc, "custom_encoding", None) or 'utf-8'
+    decode = lambda s: s.decode(encoding, errors='replace').rstrip()
 
     _register_proc_timeout(proc, timeout)
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -755,6 +755,9 @@ class TestLocalMachine:
         assert p.poll() is None
         p.terminate()
 
+    # Hangs sometimes on Windows
+    @skip_on_windows
+    @pytest.mark.timeout(20)
     def test_local_daemon(self):
         from plumbum.cmd import sleep
         proc = local.daemonic_popen(sleep[5])


### PR DESCRIPTION
remove broken support for no-decoding