### PR TITLE
fixes RemotePath.copy()

### DIFF
--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -225,7 +225,7 @@ class RemotePath(Path):
         if override:
             if isinstance(dst, six.string_types):
                 dst = RemotePath(self.remote, dst)
-            dst.remove()
+            dst.delete()
         else:
             if isinstance(dst, six.string_types):
                 dst = RemotePath(self.remote, dst)


### PR DESCRIPTION
call RemotePath.delete (a method) instead of RemotePath.remove (not a method)