### PR TITLE
chore: drop codecs from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import codecs
-import os
-
 from setuptools import setup
-
-# Fix for building on non-Windows systems
-try:
-    codecs.lookup("mbcs")
-except LookupError:
-    ascii = codecs.lookup("ascii")
-    func = lambda name, enc=ascii: {True: enc}.get(name == "mbcs")
-    codecs.register(func)
 
 setup()


### PR DESCRIPTION
Shouldn’t be needed anymore.