### PR TITLE
Fixing project license in docs config file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,9 +43,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Plumbum Shell Combinators"
-copyright = u"%d, Tomer Filiba, licensed under Attribution-ShareAlike 3.0" % (
-    time.gmtime().tm_year,
-)
+copyright = u"%d, Tomer Filiba, licensed under MIT" % (time.gmtime().tm_year,)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
The documentation config file seems to identify the project license as CC-BY-SA 3.0; fixing it to say MIT instead, as that is the actual license.