### PR TITLE
docs: remove recommonmark

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ dev =
     paramiko
     psutil
 docs =
-    recommonmark >=0.5.0
     Sphinx >=3.0.0
     sphinx_rtd_theme >=0.5.0
 


### PR DESCRIPTION
I don't think we use this anymore. CC https://github.com/readthedocs/recommonmark/issues/221
