### PR TITLE
fix: glob characters in local paths

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ def tests(session):
     Run the unit and regular tests.
     """
     session.install("-e", ".[dev]")
-    session.run("pytest", "--cov", *session.posargs)
+    session.run("pytest", *session.posargs)
 
 
 @nox.session(reuse_venv=True)

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import inspect
 import os
+import re
 import sys
 from contextlib import contextmanager
 
@@ -101,6 +102,20 @@ if sys.version_info >= (3, 0):
     from io import StringIO
 else:
     from StringIO import StringIO
+
+if sys.version_info >= (3,):
+    from glob import escape as glob_escape
+else:
+    _magic_check = re.compile(u"([*?[])")
+    _magic_check_bytes = re.compile(b"([*?[])")
+
+    def glob_escape(pathname):
+        drive, pathname = os.path.splitdrive(pathname)
+        if isinstance(pathname, str):
+            pathname = _magic_check_bytes.sub(r"[\1]", pathname)
+        else:
+            pathname = _magic_check.sub(u"[\\1]", pathname)
+        return drive + pathname
 
 
 @contextmanager

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -170,7 +170,7 @@ class LocalPath(Path):
 
     @_setdoc(Path)
     def glob(self, pattern):
-        fn = lambda pat: [LocalPath(m) for m in glob.glob(str(self / pat))]
+        fn = lambda pat: [LocalPath(m) for m in glob.glob(os.path.join(glob.escape(str(self)), pat))]
         return self._glob(pattern, fn)
 
     @_setdoc(Path)

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 from contextlib import contextmanager
 
-from plumbum.lib import IS_WIN32, _setdoc, six
+from plumbum.lib import IS_WIN32, _setdoc, glob_escape, six
 from plumbum.path.base import FSUser, Path
 from plumbum.path.remote import RemotePath
 
@@ -170,7 +170,9 @@ class LocalPath(Path):
 
     @_setdoc(Path)
     def glob(self, pattern):
-        fn = lambda pat: [LocalPath(m) for m in glob.glob(os.path.join(glob.escape(str(self)), pat))]
+        fn = lambda pat: [
+            LocalPath(m) for m in glob.glob(os.path.join(glob_escape(str(self)), pat))
+        ]
         return self._glob(pattern, fn)
 
     @_setdoc(Path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,16 +71,15 @@ def pytest_addoption(parser):
         default=None,
         help="Optional test markers to run, multiple and/or comma separated okay",
     )
+    parser.addini(
+        "optional_tests", "list of optional markers", type="linelist", default=""
+    )
 
 
 def pytest_configure(config):
     # register all optional tests declared in ini file as markers
     # https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers
-    ot_ini = config.inicfg.get("optional_tests")  # None if NA
-    if ot_ini:
-        ot_ini = ot_ini.split("\n")
-    else:
-        ot_ini = []
+    ot_ini = config.inicfg.get("optional_tests").splitlines()
     for ot in ot_ini:
         # ot should be a line like "optmarker: this is an opt marker", as with markers section
         config.addinivalue_line("markers", ot)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1073,3 +1073,14 @@ class TestLocalEncoding:
         os.chmod(name, st.st_mode | stat.S_IEXEC)
 
         assert "yes" in local[local.cwd / name]()
+
+
+def test_local_glob_path(tmpdir):
+    p = tmpdir.mkdir("a*b?c")
+    p2 = tmpdir.mkdir("aanythingbxc")
+    p2.join("something.txt").write("content")
+    p.join("hello.txt").write("content")
+    p.join("other.txt").write("content")
+
+    pp = LocalPath(str(p))
+    assert len(pp // "*.txt") == 2

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1075,6 +1075,9 @@ class TestLocalEncoding:
         assert "yes" in local[local.cwd / name]()
 
 
+@pytest.mark.skipif(
+    IS_WIN32, reason="Windows does not support these weird paths, so unambiguous there"
+)
 def test_local_glob_path(tmpdir):
     p = tmpdir.mkdir("a*b?c")
     p2 = tmpdir.mkdir("aanythingbxc")


### PR DESCRIPTION
Addresses only the local part of https://github.com/tomerfiliba/plumbum/issues/481 with minimal changes and no new dependencies. I haven't worked with the remote parts of plumbum, sorry.