### PR TITLE
Add convenience flag for reverse ssh tunnels

### DIFF
--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -220,7 +220,7 @@ class SshMachine(BaseRemoteMachine):
         )
 
     def tunnel(
-        self, lport, dport, lhost="localhost", dhost="localhost", connect_timeout=5
+        self, lport, dport, lhost="localhost", dhost="localhost", connect_timeout=5, reverse=False
     ):
         r"""Creates an SSH tunnel from the TCP port (``lport``) of the local machine
         (``lhost``, defaults to ``"localhost"``, but it can be any IP you can ``bind()``)
@@ -276,6 +276,9 @@ class SshMachine(BaseRemoteMachine):
         ssh_opts = [
             "-L",
             "{}{}:{}{}".format(formatted_lhost, lport, formatted_dhost, dport),
+        ] if not reverse else [
+            "-R",
+            "{}{}:{}{}".format(formatted_dhost, dport, formatted_lhost, lport),
         ]
         proc = self.popen((), ssh_opts=ssh_opts, new_session=True)
         return SshTunnel(


### PR DESCRIPTION
SSH supports the creation of reverse tunnels using a very similar syntax to normal tunnels. From the man pages:
```
     -R [bind_address:]port:host:hostport
     -R [bind_address:]port:local_socket
     -R remote_socket:host:hostport
     -R remote_socket:local_socket
     -R [bind_address:]port
```
This PR adds a flag to the `.tunnel()` method of `SshMachine` that allows for easy creation of a reversed SSH tunnel