### PR TITLE
setDaemon is deprecated in python 3.10

### DIFF
--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -265,7 +265,7 @@ def _timeout_thread_func():
 
 
 bgthd = Thread(target=_timeout_thread_func, name="PlumbumTimeoutThread")
-bgthd.setDaemon(True)
+bgthd.daemon = True
 bgthd.start()
 
 


### PR DESCRIPTION
Setting the python property is supported python 2.6+