### PR TITLE
Allow passing kwargs to paramiko client

### DIFF
--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -228,9 +228,9 @@ class ParamikoMachine(BaseRemoteMachine):
         gss_host=None,
         get_pty=False,
         load_system_ssh_config=False,
+        **kwargs
     ):
         self.host = host
-        kwargs = {}
         if user:
             self._fqhost = "{}@{}".format(user, host)
             kwargs["username"] = user


### PR DESCRIPTION
Currently it's impossible to pass a socks proxy to a ParamikoMachine, even though paramiko supports that.

By chaining kwargs through to the paramiko client, we expose the full functionality of paramiko to the user.