### PR TITLE
chore: intensify warning for eventual removals

### DIFF
--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -164,9 +164,7 @@ class SshMachine(BaseRemoteMachine):
         allowing the command to run "detached" from its controlling TTY or parent.
         Does not return anything. Depreciated (use command.nohup or daemonic_popen).
         """
-        warnings.warn(
-            "Use .nohup on the command or use daemonic_popen)", DeprecationWarning
-        )
+        warnings.warn("Use .nohup on the command or use daemonic_popen)", FutureWarning)
         self.daemonic_popen(command, cwd=".", stdout=None, stderr=None, append=False)
 
     def daemonic_popen(self, command, cwd=".", stdout=None, stderr=None, append=True):

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -135,7 +135,7 @@ class Path(str, six.ABC):
     @property
     def basename(self):
         """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use .name instead", DeprecationWarning)
+        warnings.warn("Use .name instead", FutureWarning)
         return self.name
 
     @abstractproperty
@@ -200,7 +200,7 @@ class Path(str, six.ABC):
 
     def isdir(self):
         """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use .is_dir() instead", DeprecationWarning)
+        warnings.warn("Use .is_dir() instead", FutureWarning)
         return self.is_dir()
 
     @abstractmethod
@@ -209,12 +209,12 @@ class Path(str, six.ABC):
 
     def isfile(self):
         """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use .is_file() instead", DeprecationWarning)
+        warnings.warn("Use .is_file() instead", FutureWarning)
         return self.is_file()
 
     def islink(self):
         """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use is_symlink instead", DeprecationWarning)
+        warnings.warn("Use is_symlink instead", FutureWarning)
         return self.is_symlink()
 
     @abstractmethod


### PR DESCRIPTION
After the next release, let's bump these up to the final level of warning. 2.0 will remove these old aliases.
