### PR TITLE
Directly reference pywin32 in requirements 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ provides = plumbum
 [options]
 packages = find:
 install_requires =
-    pypiwin32;platform_system=='Windows' and platform_python_implementation!="PyPy"
+    pywin32;platform_system=='Windows' and platform_python_implementation!="PyPy"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 
 [options.packages.find]


### PR DESCRIPTION
`pypiwin32` is an unmaintained redirect to `pywin32`

This PR changes the requires to point directly at the `pywin32` package

It also means that pywin32 will correctly have the `platform_system=='Windows'` markers, which is important for projects using Pipenv