### PR TITLE
Try to avoid creating temp dirs in the current working directory

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -325,7 +325,9 @@ class BaseRemoteMachine(BaseMachine):
     def tempdir(self):
         """A context manager that creates a remote temporary directory, which is removed when
         the context exits"""
-        _, out, _ = self._session.run("mktemp -d tmp.XXXXXXXXXX")
+        _, out, _ = self._session.run(
+            "mktemp -d 2>/dev/null || mktemp -d tmp.XXXXXXXXXX"
+        )
         dir = self.path(out.strip())  # @ReservedAssignment
         try:
             yield dir


### PR DESCRIPTION
Try to use `mktemp -d` before falling back to calling mktemp with an explicit template (for compat. with some BSD variants of mktemp (see #176)).

Testing shows shows that this fixes temp dirs being created in the current working directory on systems using a recent current GNU coreutils mktemp variant and on systems using the mktemp variant packaged with some macOS versions (e.g. 10.15). This may also fix the issue on other systems as well (see https://stackoverflow.com/a/2792789).

(Oddly, this fixes the issue on macOS 10.15, but not on macOS 11.6, which does not have the issue in the first place despite mktemp having an identical man page on 10.15 and 11.6.)