### PR TITLE
chore: prepare for 1.7.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: fix-encoding-pragma
 
 - repo: https://github.com/psf/black
-  rev: "21.11b1"
+  rev: "21.12b0"
   hooks:
   - id: black
 
@@ -50,7 +50,7 @@ repos:
     stages: [manual]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v0.910-1"
+  rev: "v0.930"
   hooks:
   - id: mypy
     files: plumbum

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+1.7.2
+-----
+
+* Commands: avoid issue mktemp issue on some BSD variants (`#571 <https://github.com/tomerfiliba/plumbum/pull/571>`_)
+* Better specification of dependency on pywin32 (`#568 <https://github.com/tomerfiliba/plumbum/pull/568>`_)
+* Some DeprecationWarnings changed to FutureWarnings (`#567 <https://github.com/tomerfiliba/plumbum/pull/567>`_)
+
+
 1.7.1
 -----
 

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -18,7 +18,6 @@ if loc is None or loc.startswith("en"):
     def get_translation_for(package_name):
         return NullTranslation()
 
-
 else:
     import gettext
     import os

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -54,7 +54,6 @@ except ImportError:
         finally:
             UnlockFile(hndl, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF)
 
-
 else:
     if hasattr(fcntl, "lockf"):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,6 @@ select = C,E,F,W,B,B9
 
 [tool:isort]
 profile = black
-multi_line_output = 3
 
 [check-manifest]
 ignore =


### PR DESCRIPTION
This is expected to be the final (save for possible patch release) 2.7 & 3.5 compatible release.

- chore: bump pre-commit
- docs: update changelog
- chore: drop unneeded line
