### PR TITLE
chore: drop Python 2.7 & 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.7", "3.10"]
+        python-version: ["3.6", "3.8", "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-        - python-version: 'pypy-2.7'
-          os: ubuntu-latest
         - python-version: 'pypy-3.7'
           os: ubuntu-latest
         - python-version: 'pypy-3.8'
@@ -82,7 +80,6 @@ jobs:
       run: pytest --cov --run-optional-tests=ssh,sudo
 
     - name: Upload coverage
-      if: matrix.python-version != '2.7' && matrix.python-version != 'pypy-2.7'
       run: coveralls --service=github
       env:
         COVERALLS_PARALLEL: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
   hooks:
   - id: mypy
     files: plumbum
-    stages: [manual]
-    additional_dependencies: [typed-ast, types-paramiko]
+    args: [--show-error-codes]
+    additional_dependencies: [typed-ast, types-paramiko, types-setuptools]
 
 # This wants the .mo files removed
 - repo: https://github.com/mgedmin/check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,8 @@ repos:
   hooks:
   - id: check-manifest
     stages: [manual]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.1.0
+  hooks:
+  - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
   - id: mixed-line-ending
   - id: requirements-txt-fixer
   - id: trailing-whitespace
-  - id: fix-encoding-pragma
 
 - repo: https://github.com/psf/black
   rev: "21.12b0"
@@ -34,12 +33,12 @@ repos:
   rev: "v2.29.1"
   hooks:
   - id: pyupgrade
+    args: ["--py36-plus"]
 
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: "v1.20.0"
   hooks:
   - id: setup-cfg-fmt
-    args: [--min-py3-version=3.5]
 
 - repo: https://github.com/pycqa/flake8
   rev: "4.0.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,13 +40,19 @@ repos:
   hooks:
   - id: setup-cfg-fmt
 
+- repo: https://github.com/hadialqattan/pycln
+  rev: v1.1.0
+  hooks:
+  - id: pycln
+    args: [--config=pyproject.toml]
+    stages: [manual]
+
 - repo: https://github.com/pycqa/flake8
   rev: "4.0.1"
   hooks:
   - id: flake8
     exclude: docs/conf.py
     additional_dependencies: [flake8-bugbear, flake8-print, flake8-2020]
-    stages: [manual]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: "v0.930"

--- a/conda.recipe/README.mkd
+++ b/conda.recipe/README.mkd
@@ -5,7 +5,7 @@ Change to the `conda.recipies` directory. Run
 ```bash
 $ conda install conda-build
 ```
-to aquire the conda build tools. Then you can build with
+to acquire the conda build tools. Then you can build with
 ```bash
 conda build --python 3.5 .
 ```

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,8 +12,7 @@ requirements:
 
   run:
     - python
-    - paramiko<2.4 # [py26]
-    - paramiko # [not py26]
+    - paramiko
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -35,8 +34,7 @@ test:
   requires:
     # Put any additional test requirements here.  For example
     - pytest
-    - paramiko<2.4 # [py26]
-    - paramiko # [not py26]
+    - paramiko
 
 about:
   home: https://plumbum.readthedocs.io

--- a/docs/_news.rst
+++ b/docs/_news.rst
@@ -1,3 +1,7 @@
+* **2021.12.23**: Version 1.7.2 released with very minor fixes, final version to support Python 2.7 and 3.5.
+
+* **2021.11.23**: Version 1.7.1 released with a few features like reverse tunnels, color group titles, and a glob path fix. Better Python 3.10 support.
+
 * **2021.02.08**: Version 1.7.0 released with a few new features like ``.with_cwd``, some useful bugfixes, and lots of cleanup.
 
 * **2020.03.23**: Version 1.6.9 released with several Path fixes, final version to support Python 2.6.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -572,10 +572,10 @@ Another common task of a cli application is provided by a configuration parser, 
 If no configuration file is present, this will create one and each call to ``.get`` will set the value with the given default.
 The file is created when the context manager exits.
 If the file is present, it is read and the values from the file are selected, and nothing is changed.
-You can also use ``[]`` syntax to forcably set a value, or to get a value with a standard ``ValueError`` if not present.
+You can also use ``[]`` syntax to forcibly set a value, or to get a value with a standard ``ValueError`` if not present.
 If you want to avoid the context manager, you can use ``.read`` and ``.write`` as well.
 
-The ini parser will default to using the ``[DEFAULT]`` section for values, just like Python's ConfigParser on which it is based. If you want to use a different section, simply seperate section and heading with a ``.`` in the key. ``conf['section.item']`` would place ``item`` under ``[section]``. All items stored in an ``ConfigINI`` are converted to ``str``, and ``str`` is always returned.
+The ini parser will default to using the ``[DEFAULT]`` section for values, just like Python's ConfigParser on which it is based. If you want to use a different section, simply separate section and heading with a ``.`` in the key. ``conf['section.item']`` would place ``item`` under ``[section]``. All items stored in an ``ConfigINI`` are converted to ``str``, and ``str`` is always returned.
 
 Terminal Utilities
 ------------------

--- a/docs/colorlib.rst
+++ b/docs/colorlib.rst
@@ -149,9 +149,7 @@ These produce strings that can be further manipulated or printed.
 
 
 Finally, you can also print a color to stdout directly using ``color.print("string")``. This
-has the same syntax as the Python 3 print function. In Python 2, if you do not have
-``from __future__ import print_function`` enabled, ``color.print_("string")`` is provided as
-an alternative, following the PyQT convention for method names that match reserved Python syntax.
+has the same syntax as the print function.
 
 An example of safe manipulations::
 

--- a/docs/colorlib.rst
+++ b/docs/colorlib.rst
@@ -119,7 +119,7 @@ An example of the usage of unsafe ``colors`` manipulations inside a context mana
         colors.green.now()
         print('This is green ' + colors.underline + 'and now also underlined!')
         print('Underlined' + colors.underline.reset + ' and not underlined but still red')
-    print('This is completly restored, even if an exception is thrown!')
+    print('This is completely restored, even if an exception is thrown!')
 
 Output:
 
@@ -128,7 +128,7 @@ Output:
     <p><font color="#800000">This is in red</font><br/>
     <font color="#008000">This is in green <span style="text-decoration: underline;">and now also underlined!</span></font><br/>
     <font color="#008000"><span style="text-decoration: underline;">Underlined</span> and not underlined but still green.</font><br/>
-    This is completly restored, even if an exception is thrown! </p>
+    This is completely restored, even if an exception is thrown! </p>
 
 We can use ``colors`` instead of ``colors.fg`` for foreground colors.  If we had used ``colors.fg``
 as the context manager, then non-foreground properties, such as ``colors.underline`` or

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -197,12 +197,12 @@ An example of the usage of unsafe ``colors`` manipulations inside a context mana
     <p><font color="#800000">This is in red</font><br/>
     <font color="#008000">This is in green <span style="text-decoration: underline;">and now also underlined!</span></font><br/>
     <font color="#008000"><span style="text-decoration: underline;">Underlined</span> and not underlined but still green.</font><br/>
-    This is completly restored, even if an exception is thrown! </p>
+    This is completely restored, even if an exception is thrown! </p>
 
         colors.green.now()
         print('This is green ' + colors.underline + 'and now also underlined!')
         print('Underlined' + colors.underline.reset + ' and not underlined but still red')
-    print('This is completly restored, even if an exception is thrown!')
+    print('This is completely restored, even if an exception is thrown!')
 
 Output:
 
@@ -211,7 +211,7 @@ Output:
     <p><font color="#800000">This is in red</font><br/>
     <font color="#008000">This is in green <span style="text-decoration: underline;">and now also underlined!</span></font><br/>
     <font color="#008000"><span style="text-decoration: underline;">Underlined</span> and not underlined but still green.</font><br/>
-    This is completly restored, even if an exception is thrown! </p>
+    This is completely restored, even if an exception is thrown! </p>
 
 We can use ``colors`` instead of ``colors.fg`` for foreground colors.  If we had used ``colors.fg``
 as the context manager, then non-foreground properties, such as ``colors.underline`` or
@@ -280,6 +280,7 @@ See Also
 ========
 
 * `colored <https://pypi.python.org/pypi/colored>`_ Another library with 256 color support
-* `colorful <https://github.com/timofurrer/colorful>`_ A fairly new libary with a similar feature set
+* `colorful <https://github.com/timofurrer/colorful>`_ A fairly new library with a similar feature set
 * `colorama <https://pypi.python.org/pypi/colorama>`_ A library that supports colored text on Windows,
     can be combined with Plumbum.colors (if you force ``use_color``, doesn't support all extended colors)
+* `rich <https://rich.readthedocs.io>`_ A very powerful modern library for all sorts of styling.

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -232,9 +232,7 @@ These produce strings that can be further manipulated or printed.
 
 Finally, you can also print a color to stdout directly using
 ``color.print("string")``. This
-has the same syntax as the Python 3 print function. In Python 2, if you do not have
-``from __future__ import print_function`` enabled, ``color.print_("string")`` is provided as
-an alternative, following the PyQT convention for method names that match reserved Python syntax.
+has the same syntax as the print function.
 
 An example of safe manipulations::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Plumbum Shell Combinators documentation build configuration file, created by
 # sphinx-quickstart on Sun Apr 29 16:24:32 2012.
@@ -42,8 +41,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Plumbum Shell Combinators"
-copyright = u"%d, Tomer Filiba, licensed under MIT" % (time.gmtime().tm_year,)
+project = "Plumbum Shell Combinators"
+copyright = "%d, Tomer Filiba, licensed under MIT" % (time.gmtime().tm_year,)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -191,8 +190,8 @@ latex_documents = [
     (
         "index",
         "PlumbumShellCombinators.tex",
-        u"Plumbum Shell Combinators Documentation",
-        u"Tomer Filiba",
+        "Plumbum Shell Combinators Documentation",
+        "Tomer Filiba",
         "manual",
     ),
 ]
@@ -226,8 +225,8 @@ man_pages = [
     (
         "index",
         "plumbumshellcombinators",
-        u"Plumbum Shell Combinators Documentation",
-        [u"Tomer Filiba"],
+        "Plumbum Shell Combinators Documentation",
+        ["Tomer Filiba"],
         1,
     )
 ]
@@ -245,8 +244,8 @@ texinfo_documents = [
     (
         "index",
         "PlumbumShellCombinators",
-        u"Plumbum Shell Combinators Documentation",
-        u"Tomer Filiba",
+        "Plumbum Shell Combinators Documentation",
+        "Tomer Filiba",
         "PlumbumShellCombinators",
         "One line description of project.",
         "Miscellaneous",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,7 +83,7 @@ you encounter or to request features. The library is released under the permissi
 Requirements
 ------------
 
-Plumbum supports **Python 2.7-3.9** and **PyPy** and is continually tested on
+Plumbum supports **Python 3.6-3.10** and **PyPy** and is continually tested on
 **Linux**, **Mac**, and **Windows** machines through `GitHub Actions
 <https://github.com/tomerfiliba/plumbum/actions>`_.  Any Unix-like machine
 should work fine out of the box, but on Windows, you'll probably want to

--- a/docs/local_commands.rst
+++ b/docs/local_commands.rst
@@ -288,7 +288,7 @@ In fact, you can nest even command-chains (i.e., pipes and redirections), e.g.,
 ``sudo[ls | grep["\\.py"]]``; however, that would require that the top-level program be able
 to handle these shell operators, and this is not the case for ``sudo``. ``sudo`` expects its
 argument to be an executable program, and it would complain about ``|`` not being one.
-So, there's a inherent differnce between between ``sudo[ls | grep["\\.py"]]``
+So, there's a inherent difference between between ``sudo[ls | grep["\\.py"]]``
 and ``sudo[ls] | grep["\\.py"]`` (where the pipe is unnested) -- the first would fail,
 the latter would work as expected.
 

--- a/docs/local_commands.rst
+++ b/docs/local_commands.rst
@@ -119,8 +119,7 @@ the output to a file named ``tmp.txt``::
 .. note::
    Parentheses are required here! ``grep["world"] < sys.stdin > "tmp.txt"`` would be evaluated
    according to the `rules for chained comparison operators
-   <https://docs.python.org/reference/expressions.html#comparisons>`_ and result in ``False``
-   (Python 2) or raise an exception (Python 3).
+   <https://docs.python.org/reference/expressions.html#comparisons>`_ and result an exception.
 
 Right after ``foo``, Ctrl+D was pressed, which caused ``grep`` to finish. The empty string
 at the end is the command's ``stdout`` (and it's empty because it actually went to a file).

--- a/docs/remote.rst
+++ b/docs/remote.rst
@@ -264,4 +264,4 @@ renaming paths, etc. ::
 .. note::
    See the :ref:`guide-utils` guide for copying, moving and deleting remote paths
 
-For futher information, see the :ref:`api docs <api-remote-machines>`.
+For further information, see the :ref:`api docs <api-remote-machines>`.

--- a/examples/SimpleColorCLI.py
+++ b/examples/SimpleColorCLI.py
@@ -1,4 +1,3 @@
-import plumbum
 from plumbum import cli, colors
 
 # from plumbum.colorlib import HTMLStyle, StyleFactory

--- a/examples/SimpleColorCLI.py
+++ b/examples/SimpleColorCLI.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import plumbum
 from plumbum import cli, colors
 

--- a/examples/alignment.py
+++ b/examples/alignment.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from plumbum import cli
 
 

--- a/examples/color.py
+++ b/examples/color.py
@@ -5,9 +5,9 @@ from plumbum import colors
 with colors.fg.red:
     print("This is in red")
 
-print("This is completly restored, even if an exception is thrown!")
+print("This is completely restored, even if an exception is thrown!")
 
-print("The library will restore color on exiting automatially.")
+print("The library will restore color on exiting automatically.")
 print(colors.bold["This is bold and exciting!"])
 print(colors.bg.cyan | "This is on a cyan background.")
 print(colors.fg[42] | "If your terminal supports 256 colors, this is colorful!")

--- a/examples/color.py
+++ b/examples/color.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 
 from plumbum import colors
 
@@ -15,7 +13,7 @@ print(colors.bg.cyan | "This is on a cyan background.")
 print(colors.fg[42] | "If your terminal supports 256 colors, this is colorful!")
 print()
 for c in colors:
-    print(c + u"\u2588", end="")
+    print(c + "\u2588", end="")
 colors.reset()
 print()
 print("Colors can be reset " + colors.underline["Too!"])

--- a/examples/filecopy.py
+++ b/examples/filecopy.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import logging
 
 from plumbum import cli, local

--- a/examples/fullcolor.py
+++ b/examples/fullcolor.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 
 from plumbum import colors
 
@@ -8,4 +6,4 @@ with colors:
     print("Do you believe in color, punk? DO YOU?")
     for i in range(0, 255, 10):
         for j in range(0, 255, 10):
-            print(u"".join(colors.rgb(i, j, k)[u"\u2588"] for k in range(0, 255, 10)))
+            print("".join(colors.rgb(i, j, k)["\u2588"] for k in range(0, 255, 10)))

--- a/examples/geet.py
+++ b/examples/geet.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Examples::
 
@@ -109,7 +108,7 @@ class GeetPush(cli.Application):
     tags = cli.Flag("--tags", help="whether to push tags (default is False)")
 
     def main(self, remote, branch="master"):
-        print("pushing to {}/{}...".format(remote, branch))
+        print(f"pushing to {remote}/{branch}...")
 
 
 if __name__ == "__main__":

--- a/examples/make_figures.py
+++ b/examples/make_figures.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 
 from plumbum import FG, cli, local
 from plumbum.cmd import convert, pdflatex

--- a/examples/simple_cli.py
+++ b/examples/simple_cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 $ python simple_cli.py --help
 simple_cli.py v1.0
@@ -35,7 +34,6 @@ Verbose: True
 Include dirs: ['foo/bar', 'spam/eggs']
 Compiling: ('x.cpp', 'y.cpp', 'z.cpp')
 """
-from __future__ import print_function
 
 import logging
 

--- a/experiments/parallel.py
+++ b/experiments/parallel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from plumbum.commands.base import BaseCommand
 from plumbum.commands.processes import CommandNotFound, ProcessExecutionError, run_proc
 
@@ -22,7 +21,7 @@ def make_concurrent(self, rhs):
 BaseCommand.__and__ = make_concurrent
 
 
-class ConcurrentPopen(object):
+class ConcurrentPopen:
     def __init__(self, procs):
         self.procs = procs
         self.stdin = None
@@ -87,7 +86,7 @@ class ConcurrentCommand(BaseCommand):
             return ConcurrentCommand(*(cmd[args] for cmd in self.commands))
 
 
-class Cluster(object):
+class Cluster:
     def __init__(self, *machines):
         self.machines = list(machines)
 
@@ -151,7 +150,7 @@ class Cluster(object):
         return ClusterSession(*(mach.session() for mach in self))
 
 
-class ClusterSession(object):
+class ClusterSession:
     def __init__(self, *sessions):
         self.sessions = sessions
 

--- a/experiments/parallel.py
+++ b/experiments/parallel.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     except ProcessExecutionError as ex:
         print(ex)
     else:
-        assert False
+        raise AssertionError("Expected an ProcessExecutionError")
 
     clst = Cluster(local, local, local)
     print(clst["ls"]())

--- a/experiments/test_parallel.py
+++ b/experiments/test_parallel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 from parallel import Cluster

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import nox
 
-ALL_PYTHONS = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 nox.options.sessions = ["lint", "tests"]
 

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -86,11 +86,7 @@ __all__ = (
 # ===================================================================================================
 import sys
 from types import ModuleType
-
-try:
-    from typing import List
-except ImportError:
-    pass
+from typing import List
 
 
 class LocalModule(ModuleType):

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Plumbum Shell Combinators
 -------------------------

--- a/plumbum/_testtools.py
+++ b/plumbum/_testtools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import platform
 import sys

--- a/plumbum/_testtools.py
+++ b/plumbum/_testtools.py
@@ -2,7 +2,7 @@ import os
 import platform
 import sys
 
-import pytest
+import pytest  # type: ignore[import]
 
 skip_without_chown = pytest.mark.skipif(
     not hasattr(os, "chown"), reason="os.chown not supported"

--- a/plumbum/cli/__init__.py
+++ b/plumbum/cli/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from .application import Application
 from .config import Config, ConfigINI
 from .switches import (

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -296,10 +296,10 @@ class Application:
 
     def _get_partial_matches(self, partialname):
         matches = []
-        for switch in self._switches_by_name:
-            if switch.startswith(partialname):
+        for switch_ in self._switches_by_name:
+            if switch_.startswith(partialname):
                 matches += [
-                    switch,
+                    switch_,
                 ]
         return matches
 
@@ -469,7 +469,7 @@ class Application:
         requirements = {}
         exclusions = {}
         for swinfo in self._switches_by_func.values():
-            if swinfo.mandatory and not swinfo.func in swfuncs:
+            if swinfo.mandatory and swinfo.func not in swfuncs:
                 raise MissingMandatorySwitch(
                     T_("Switch {0} is mandatory").format(
                         "/".join(
@@ -943,7 +943,7 @@ class Application:
                 )
 
             msg = indentation.join(
-                wrapper.wrap(" ".join(l.strip() for l in help.splitlines()))
+                wrapper.wrap(" ".join(ln.strip() for ln in help.splitlines()))
             )
 
             if len(prefix) + wrapper.width >= cols:
@@ -968,7 +968,7 @@ class Application:
                         help = doc if doc else ""  # @ReservedAssignment
 
                     msg = indentation.join(
-                        wrapper.wrap(" ".join(l.strip() for l in help.splitlines()))
+                        wrapper.wrap(" ".join(ln.strip() for ln in help.splitlines()))
                     )
 
                     if len(name) + wrapper.width >= cols:

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
-
 import functools
 import os
 import sys
@@ -42,7 +39,7 @@ class ShowVersion(SwitchError):
     pass
 
 
-class SwitchParseInfo(object):
+class SwitchParseInfo:
     __slots__ = ["swname", "val", "index", "__weakref__"]
 
     def __init__(self, swname, val, index):
@@ -51,7 +48,7 @@ class SwitchParseInfo(object):
         self.index = index
 
 
-class Subcommand(object):
+class Subcommand:
     def __init__(self, name, subapplication):
         self.name = name
         self.subapplication = subapplication
@@ -63,7 +60,7 @@ class Subcommand(object):
             try:
                 cls = getattr(mod, clsname)
             except AttributeError:
-                raise ImportError("cannot import name {}".format(clsname))
+                raise ImportError(f"cannot import name {clsname}")
             self.subapplication = cls
         return self.subapplication
 
@@ -80,7 +77,7 @@ _switch_groups_l10n = [T_("Switches"), T_("Meta-switches")]
 # ===================================================================================================
 
 
-class Application(object):
+class Application:
     """The base class for CLI applications; your "entry point" class should derive from it,
     define the relevant switch functions and attributes, and the ``main()`` function.
     The class defines two overridable "meta switches" for version (``-v``, ``--version``)
@@ -178,7 +175,7 @@ class Application(object):
             return cls.run()
             # This return value was not a class instance, so __init__ is never called
         else:
-            return super(Application, cls).__new__(cls)
+            return super().__new__(cls)
 
     def __init__(self, executable):
         # Filter colors
@@ -428,7 +425,7 @@ class Application(object):
                 continue  # skip if overridden by command line arguments
 
             val = self._handle_argument(envval, swinfo.argtype, env)
-            envname = "${}".format(env)
+            envname = f"${env}"
             if swinfo.list:
                 # multiple values over environment variables are not supported,
                 # this will require some sort of escaping and separator convention
@@ -461,11 +458,11 @@ class Application(object):
             return NotImplemented
 
     def _validate_args(self, swfuncs, tailargs):
-        if six.get_method_function(self.help) in swfuncs:
+        if self.help.__func__ in swfuncs:
             raise ShowHelp()
-        if six.get_method_function(self.helpall) in swfuncs:
+        if self.helpall.__func__ in swfuncs:
             raise ShowHelpAll()
-        if six.get_method_function(self.version) in swfuncs:
+        if self.version.__func__ in swfuncs:
             raise ShowVersion()
 
         requirements = {}
@@ -729,7 +726,7 @@ class Application(object):
 
         if self._subcommands:
             for name, subcls in sorted(self._subcommands.items()):
-                subapp = (subcls.get())("{} {}".format(self.PROGNAME, name))
+                subapp = (subcls.get())(f"{self.PROGNAME} {name}")
                 subapp.parent = self
                 for si in subapp._switches_by_func.values():
                     if si.group == "Meta-switches":
@@ -783,8 +780,7 @@ class Application(object):
 
                 if len(line) == 0:
                     # Starting a new paragraph
-                    for item in current():
-                        yield item
+                    yield from current()
                     yield "", "", ""
 
                     paragraph = None
@@ -803,8 +799,7 @@ class Application(object):
 
                     if is_list_item(line):
                         # Done with current paragraph
-                        for item in current():
-                            yield item
+                        yield from current()
 
                         if has_invisible_bullet(line):
                             line = line[1:]
@@ -827,8 +822,7 @@ class Application(object):
                             # Add to current paragraph
                             paragraph = paragraph + " " + line
 
-            for item in current():
-                yield item
+            yield from current()
 
         def wrapped_paragraphs(text, width):
             """Yields each line of each paragraph of text after wrapping them on 'width' number of columns.
@@ -848,8 +842,7 @@ class Application(object):
                     subsequent_indent=subsequent_indent,
                 )
                 w = wrapper.wrap(paragraph)
-                for line in w:
-                    yield line
+                yield from w
                 if len(w) == 0:
                     yield ""
 
@@ -861,7 +854,7 @@ class Application(object):
         tailargs = m.args[1:]  # skip self
         if m.defaults:
             for i, d in enumerate(reversed(m.defaults)):
-                tailargs[-i - 1] = "[{}={}]".format(tailargs[-i - 1], d)
+                tailargs[-i - 1] = f"[{tailargs[-i - 1]}={d}]"
         if m.varargs:
             tailargs.append(
                 "{}...".format(
@@ -911,7 +904,7 @@ class Application(object):
                             typename = si.argtype.__name__
                         else:
                             typename = str(si.argtype)
-                        argtype = " {}:{}".format(si.argname.upper(), typename)
+                        argtype = f" {si.argname.upper()}:{typename}"
                     else:
                         argtype = ""
                     prefix = swnames + argtype
@@ -1012,4 +1005,4 @@ class Application(object):
         """Prints the program's version and quits"""
         ver = self._get_prog_version()
         ver_name = ver if ver is not None else T_("(version not set)")
-        print("{} {}".format(self.PROGNAME, ver_name))
+        print(f"{self.PROGNAME} {ver_name}")

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import os
 import sys
 from collections import defaultdict
@@ -6,7 +7,7 @@ from textwrap import TextWrapper
 
 from plumbum import colors, local
 from plumbum.cli.i18n import get_translation_for
-from plumbum.lib import getdoc, six
+from plumbum.lib import getdoc
 
 from .switches import (
     CountOf,
@@ -503,8 +504,8 @@ class Application:
                     )
                 )
 
-        m = six.getfullargspec(self.main)
-        max_args = six.MAXSIZE if m.varargs else len(m.args) - 1
+        m = inspect.getfullargspec(self.main)
+        max_args = sys.maxsize if m.varargs else len(m.args) - 1
         min_args = len(m.args) - 1 - (len(m.defaults) if m.defaults else 0)
         if len(tailargs) < min_args:
             raise PositionalArgumentsError(
@@ -523,7 +524,7 @@ class Application:
                 ).format(max_args, tailargs)
             )
 
-        # Positional arguement validataion
+        # Positional argument validation
         if hasattr(self.main, "positional"):
             tailargs = self._positional_validate(
                 tailargs,
@@ -850,7 +851,7 @@ class Application:
         for line in wrapped_paragraphs(self.DESCRIPTION_MORE, cols):
             print(line)
 
-        m = six.getfullargspec(self.main)
+        m = inspect.getfullargspec(self.main)
         tailargs = m.args[1:]  # skip self
         if m.defaults:
             for i, d in enumerate(reversed(m.defaults)):

--- a/plumbum/cli/config.py
+++ b/plumbum/cli/config.py
@@ -1,16 +1,10 @@
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function
-
 import sys
 from abc import abstractmethod
 
 from plumbum import local
 from plumbum.lib import _setdoc, six
 
-if sys.version_info >= (3,):
-    from configparser import ConfigParser, NoOptionError, NoSectionError
-else:
-    from ConfigParser import ConfigParser, NoOptionError, NoSectionError
+from configparser import ConfigParser, NoOptionError, NoSectionError
 
 
 class ConfigBase(six.ABC):
@@ -90,19 +84,19 @@ class ConfigINI(ConfigBase):
     slots = "parser".split()
 
     def __init__(self, filename):
-        super(ConfigINI, self).__init__(filename)
+        super().__init__(filename)
         self.parser = ConfigParser()
 
     @_setdoc(ConfigBase)
     def read(self):
         self.parser.read(self.filename)
-        super(ConfigINI, self).read()
+        super().read()
 
     @_setdoc(ConfigBase)
     def write(self):
         with open(self.filename, "w") as f:
             self.parser.write(f)
-        super(ConfigINI, self).write()
+        super().write()
 
     @classmethod
     def _sec_opt(cls, option):
@@ -119,7 +113,7 @@ class ConfigINI(ConfigBase):
         try:
             return self.parser.get(sec, option)
         except (NoSectionError, NoOptionError):
-            raise KeyError("{sec}:{option}".format(sec=sec, option=option))
+            raise KeyError(f"{sec}:{option}")
 
     @_setdoc(ConfigBase)
     def _set(self, option, value):

--- a/plumbum/cli/config.py
+++ b/plumbum/cli/config.py
@@ -1,13 +1,11 @@
-import sys
-from abc import abstractmethod
-
-from plumbum import local
-from plumbum.lib import _setdoc, six
-
+from abc import ABC, abstractmethod
 from configparser import ConfigParser, NoOptionError, NoSectionError
 
+from plumbum import local
+from plumbum.lib import _setdoc
 
-class ConfigBase(six.ABC):
+
+class ConfigBase(ABC):
     """Base class for Config parsers.
 
     :param filename: The file to use

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -14,7 +14,7 @@ if loc is None or loc.startswith("en"):
             else:
                 return strN.replace("{0}", str(n))
 
-    def get_translation_for(package_name):
+    def get_translation_for(package_name: str) -> NullTranslation:
         return NullTranslation()
 
 else:
@@ -25,11 +25,11 @@ else:
     try:
         import pkg_resources
     except ImportError:
-        pkg_resources = None
+        pkg_resources = None  # type: ignore[assignment]
 
     local_dir = os.path.basename(__file__)
 
-    def get_translation_for(package_name):  # type: (str) -> gettext.NullTranslations
+    def get_translation_for(package_name: str) -> gettext.NullTranslations:  # type: ignore[misc]
         """Find and return gettext translation for package
         (Try to find folder manually if setuptools does not exist)
         """

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -27,8 +27,6 @@ else:
     except ImportError:
         pkg_resources = None
 
-    from typing import Callable, List, Tuple
-
     local_dir = os.path.basename(__file__)
 
     def get_translation_for(package_name):  # type: (str) -> gettext.NullTranslations

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -27,10 +27,7 @@ else:
     except ImportError:
         pkg_resources = None
 
-    try:
-        from typing import Callable, List, Tuple
-    except ImportError:
-        pass
+    from typing import Callable, List, Tuple
 
     local_dir = os.path.basename(__file__)
 

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 import locale
 
 # High performance method for English (no translation needed)
 loc = locale.getlocale()[0]
 if loc is None or loc.startswith("en"):
 
-    class NullTranslation(object):
+    class NullTranslation:
         def gettext(self, str):
             return str
 

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -1,5 +1,3 @@
-import sys
-
 from plumbum import colors
 
 from .. import cli

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -107,4 +107,4 @@ class ShowImageApp(cli.Application):
 
 
 if __name__ == "__main__":
-    ShowImageApp()
+    ShowImageApp.run()

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function
-
 import sys
 
 from plumbum import colors
@@ -9,7 +6,7 @@ from .. import cli
 from .termsize import get_terminal_size
 
 
-class Image(object):
+class Image:
 
     __slots__ = "size char_ratio".split()
 
@@ -77,7 +74,7 @@ class Image(object):
                 pixl = new_im.getpixel((x, y * 2 + 1))
                 print(
                     colors.bg.rgb(*pixl) & colors.fg.rgb(*pix),
-                    u"\u2580",
+                    "\u2580",
                     sep="",
                     end="",
                 )

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -6,13 +6,12 @@ Progress bar
 import datetime
 import sys
 import warnings
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from plumbum.cli.termsize import get_terminal_size
-from plumbum.lib import six
 
 
-class ProgressBase(six.ABC):
+class ProgressBase(ABC):
     """Base class for progress bars. Customize for types of progress bars.
 
     :param iterator: The iterator to wrap with a progress bar

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -265,7 +265,7 @@ def main():
     import time
 
     tst = Progress.range(20)
-    for i in tst:
+    for _ in tst:
         time.sleep(1)
 
 

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -232,7 +232,7 @@ class ProgressIPy(ProgressBase):  # pragma: no cover
 class ProgressAuto(ProgressBase):
     """Automatically selects the best progress bar (IPython HTML or text). Does not work with qtconsole
     (as that is correctly identified as identical to notebook, since the kernel is the same); it will still
-    iterate, but no graphical indication will be diplayed.
+    iterate, but no graphical indication will be displayed.
 
     :param iterator: The iterator to wrap with a progress bar
     :param length: The length of the iterator (will use ``__len__`` if None)

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 Progress bar
 ------------
 """
-from __future__ import division, print_function
 
 import datetime
 import sys
@@ -134,7 +132,7 @@ class ProgressBase(six.ABC):
 
 class Progress(ProgressBase):
     def start(self):
-        super(Progress, self).start()
+        super().start()
         self.display()
 
     def done(self):
@@ -155,21 +153,21 @@ class Progress(ProgressBase):
         ending = " " + (
             self.str_time_remaining()
             if self.timer
-            else "{} of {} complete".format(self.value, self.length)
+            else f"{self.value} of {self.length} complete"
         )
         if width - len(ending) < 10 or self.has_output:
             self.width = 0
             if self.timer:
-                return "{:.0%} complete: {}".format(percent, self.str_time_remaining())
+                return f"{percent:.0%} complete: {self.str_time_remaining()}"
             else:
-                return "{:.0%} complete".format(percent)
+                return f"{percent:.0%} complete"
 
         else:
             self.width = width - len(ending) - 2 - 1
             nstars = int(percent * self.width)
             pbar = "[" + "*" * nstars + " " * (self.width - nstars) + "]" + ending
 
-        str_percent = " {:.0%} ".format(percent)
+        str_percent = f" {percent:.0%} "
 
         return (
             pbar[: self.width // 2 - 2]
@@ -200,7 +198,7 @@ class ProgressIPy(ProgressBase):  # pragma: no cover
             except ImportError:  # Support IPython < 4.0
                 from IPython.html.widgets import HTML, HBox, IntProgress
 
-        super(ProgressIPy, self).__init__(*args, **kargs)
+        super().__init__(*args, **kargs)
         self.prog = IntProgress(max=self.length)
         self._label = HTML()
         self._box = HBox((self.prog, self._label))
@@ -209,7 +207,7 @@ class ProgressIPy(ProgressBase):  # pragma: no cover
         from IPython.display import display
 
         display(self._box)
-        super(ProgressIPy, self).start()
+        super().start()
 
     @property
     def value(self):
@@ -220,7 +218,7 @@ class ProgressIPy(ProgressBase):  # pragma: no cover
     def value(self, val):
         self._value = val
         self.prog.value = max(val, 0)
-        self.prog.description = "{:.2%}".format(self.value / self.length)
+        self.prog.description = f"{self.value / self.length:.2%}"
         if self.timer and val > 0:
             self._label.value = self.HTMLBOX.format(self.str_time_remaining())
 

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -235,9 +235,10 @@ class SwitchAttr:
     """
 
     ATTR_NAME = "__plumbum_switchattr_dict__"
+    VALUE = _("VALUE")
 
     def __init__(
-        self, names, argtype=str, default=None, list=False, argname=_("VALUE"), **kwargs
+        self, names, argtype=str, default=None, list=False, argname=VALUE, **kwargs
     ):
         self.__doc__ = "Sets an attribute"  # to prevent the help message from showing SwitchAttr's docstring
         if default and argtype is not None:

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -1,8 +1,9 @@
-from abc import abstractmethod
+import inspect
+from abc import ABC, abstractmethod
 
 from plumbum import local
 from plumbum.cli.i18n import get_translation_for
-from plumbum.lib import getdoc, six
+from plumbum.lib import getdoc
 
 _translation = get_translation_for(__name__)
 _, ngettext = _translation.gettext, _translation.ngettext
@@ -172,7 +173,7 @@ def switch(
 
     def deco(func):
         if argname is None:
-            argspec = six.getfullargspec(func).args
+            argspec = inspect.getfullargspec(func).args
             if len(argspec) == 2:
                 argname2 = argspec[1]
             else:
@@ -364,7 +365,7 @@ class positional:
         self.kargs = kargs
 
     def __call__(self, function):
-        m = six.getfullargspec(function)
+        m = inspect.getfullargspec(function)
         args_names = list(m.args[1:])
 
         positional = [None] * len(args_names)
@@ -388,7 +389,7 @@ class positional:
         return function
 
 
-class Validator(six.ABC):
+class Validator(ABC):
     __slots__ = ()
 
     @abstractmethod
@@ -497,14 +498,10 @@ class Set(Validator):
                 return opt(value)
             except ValueError:
                 pass
-        raise ValueError(
-            f"Invalid value: {value} (Expected one of {self.values})"
-        )
+        raise ValueError(f"Invalid value: {value} (Expected one of {self.values})")
 
     def choices(self, partial=""):
-        choices = {
-            opt if isinstance(opt, str) else f"({opt})" for opt in self.values
-        }
+        choices = {opt if isinstance(opt, str) else f"({opt})" for opt in self.values}
         if partial:
             choices = {opt for opt in choices if opt.lower().startswith(partial)}
         return choices
@@ -542,9 +539,7 @@ def ExistingDirectory(val):
 def MakeDirectory(val):
     p = local.path(val)
     if p.is_file():
-        raise ValueError(
-            f"{val} is a file, should be nonexistent, or a directory"
-        )
+        raise ValueError(f"{val} is a file, should be nonexistent, or a directory")
     elif not p.exists():
         p.mkdir()
     return p

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from abc import abstractmethod
 
 from plumbum import local
@@ -61,7 +60,7 @@ class SubcommandError(SwitchError):
 # ===================================================================================================
 # The switch decorator
 # ===================================================================================================
-class SwitchInfo(object):
+class SwitchInfo:
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -165,7 +164,7 @@ def switch(
 
     :returns: The decorated function (with a ``_switch_info`` attribute)
     """
-    if isinstance(names, six.string_types):
+    if isinstance(names, str):
         names = [names]
     names = [n.lstrip("-") for n in names]
     requires = [n.lstrip("-") for n in requires]
@@ -216,7 +215,7 @@ def autoswitch(*args, **kwargs):
 # ===================================================================================================
 # Switch Attributes
 # ===================================================================================================
-class SwitchAttr(object):
+class SwitchAttr:
     """
     A switch that stores its result in an attribute (descriptor). Usage::
 
@@ -331,7 +330,7 @@ class CountOf(SwitchAttr):
 # ===================================================================================================
 
 
-class positional(object):
+class positional:
     """
     Runs a validator on the main function for a class.
     This should be used like this::
@@ -408,7 +407,7 @@ class Validator(six.ABC):
             for prop in getattr(cls, "__slots__", ()):
                 if prop[0] != "_":
                     slots[prop] = getattr(self, prop)
-        mystrs = ("{} = {}".format(name, slots[name]) for name in slots)
+        mystrs = (f"{name} = {slots[name]}" for name in slots)
         return "{}({})".format(self.__class__.__name__, ", ".join(mystrs))
 
 
@@ -434,7 +433,7 @@ class Range(Validator):
         self.end = end
 
     def __repr__(self):
-        return "[{:d}..{:d}]".format(self.start, self.end)
+        return f"[{self.start:d}..{self.end:d}]"
 
     def __call__(self, obj):
         obj = int(obj)
@@ -499,12 +498,12 @@ class Set(Validator):
             except ValueError:
                 pass
         raise ValueError(
-            "Invalid value: {} (Expected one of {})".format(value, self.values)
+            f"Invalid value: {value} (Expected one of {self.values})"
         )
 
     def choices(self, partial=""):
         choices = {
-            opt if isinstance(opt, str) else "({})".format(opt) for opt in self.values
+            opt if isinstance(opt, str) else f"({opt})" for opt in self.values
         }
         if partial:
             choices = {opt for opt in choices if opt.lower().startswith(partial)}
@@ -514,7 +513,7 @@ class Set(Validator):
 CSV = Set(str, csv=True)
 
 
-class Predicate(object):
+class Predicate:
     """A wrapper for a single-argument function with pretty printing"""
 
     def __init__(self, func):
@@ -544,7 +543,7 @@ def MakeDirectory(val):
     p = local.path(val)
     if p.is_file():
         raise ValueError(
-            "{} is a file, should be nonexistent, or a directory".format(val)
+            f"{val} is a file, should be nonexistent, or a directory"
         )
     elif not p.exists():
         p.mkdir()

--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 Terminal-related utilities
 --------------------------
 """
 
-from __future__ import absolute_import, division, print_function
 
 import os
 import sys
@@ -108,7 +106,7 @@ def choose(question, options, default=None):
         sys.stdout.write("(%d) %s\n" % (i, text))
     if default is not None:
         if defindex is None:
-            msg = "Choice [{}]: ".format(default)
+            msg = f"Choice [{default}]: "
         else:
             msg = "Choice [%d]: " % (defindex,)
     else:
@@ -143,7 +141,7 @@ def prompt(question, type=str, default=NotImplemented, validator=lambda val: Tru
     """
     question = question.rstrip(" \t:")
     if default is not NotImplemented:
-        question += " [{}]".format(default)
+        question += f" [{default}]"
     question += ": "
     while True:
         try:
@@ -159,12 +157,12 @@ def prompt(question, type=str, default=NotImplemented, validator=lambda val: Tru
         try:
             ans = type(ans)
         except (TypeError, ValueError) as ex:
-            sys.stdout.write("Invalid value ({}), please try again\n".format(ex))
+            sys.stdout.write(f"Invalid value ({ex}), please try again\n")
             continue
         try:
             valid = validator(ans)
         except ValueError as ex:
-            sys.stdout.write("{}, please try again\n".format(ex))
+            sys.stdout.write(f"{ex}, please try again\n")
             continue
         if not valid:
             sys.stdout.write("Value not in specified range, please try again\n")
@@ -194,7 +192,7 @@ def hexdump(data_or_stream, bytes_per_line=16, aggregate=True):
     prev = None
     skipped = False
     for i, chunk in enumerate(read_chunk()):
-        hexd = " ".join("{:02x}".format(ord(ch)) for ch in chunk)
+        hexd = " ".join(f"{ord(ch):02x}" for ch in chunk)
         text = "".join(ch if 32 <= ord(ch) < 127 else "." for ch in chunk)
         if aggregate and prev == chunk:
             skipped = True
@@ -224,11 +222,11 @@ def pager(rows, pagercmd=None):  # pragma: no cover
     pg = pagercmd.popen(stdout=None, stderr=None)
     try:
         for row in rows:
-            line = "{}\n".format(row)
+            line = f"{row}\n"
             try:
                 pg.stdin.write(line)
                 pg.stdin.flush()
-            except IOError:
+            except OSError:
                 break
         pg.stdin.close()
         pg.wait()

--- a/plumbum/cli/termsize.py
+++ b/plumbum/cli/termsize.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 Terminal size utility
 ---------------------
 """
-from __future__ import absolute_import, division, print_function
 
 import os
 import platform

--- a/plumbum/cli/termsize.py
+++ b/plumbum/cli/termsize.py
@@ -8,6 +8,8 @@ import platform
 import warnings
 from struct import Struct
 
+from plumbum import local
+
 
 def get_terminal_size(default=(80, 25)):
     """

--- a/plumbum/colorlib/__init__.py
+++ b/plumbum/colorlib/__init__.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """\
 The ``ansicolor`` object provides ``bg`` and ``fg`` to access colors,
 and attributes like bold and
 underlined text. It also provides ``reset`` to recover the normal font.
 """
 
-from __future__ import absolute_import, print_function
 
 from .factories import StyleFactory
 from .styles import ANSIStyle, ColorNotFound, HTMLStyle, Style

--- a/plumbum/colorlib/__init__.py
+++ b/plumbum/colorlib/__init__.py
@@ -8,6 +8,18 @@ underlined text. It also provides ``reset`` to recover the normal font.
 from .factories import StyleFactory
 from .styles import ANSIStyle, ColorNotFound, HTMLStyle, Style
 
+__all__ = (
+    "ANSIStyle",
+    "ColorNotFound",
+    "HTMLStyle",
+    "Style",
+    "StyleFactory",
+    "ansicolors",
+    "htmlcolors",
+    "load_ipython_extension",
+    "main",
+)
+
 ansicolors = StyleFactory(ANSIStyle)
 htmlcolors = StyleFactory(HTMLStyle)
 

--- a/plumbum/colorlib/__main__.py
+++ b/plumbum/colorlib/__main__.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 This is provided as a quick way to recover your terminal. Simply run
 ``python -m plumbum.colorlib``
 to recover terminal color.
 """
 
-from __future__ import absolute_import
 
 from . import main
 

--- a/plumbum/colorlib/_ipython_ext.py
+++ b/plumbum/colorlib/_ipython_ext.py
@@ -1,16 +1,9 @@
-# -*- coding: utf-8 -*-
 import sys
 
 import IPython.display
 from IPython.core.magic import Magics, cell_magic, magics_class, needs_local_scope
 
-if sys.version_info >= (3,):
-    from io import StringIO
-else:
-    try:
-        from cStringIO import StringIO
-    except ImportError:
-        from StringIO import StringIO  # type: ignore
+from io import StringIO
 
 
 valid_choices = [x[8:] for x in dir(IPython.display) if "display_" == x[:8]]

--- a/plumbum/colorlib/_ipython_ext.py
+++ b/plumbum/colorlib/_ipython_ext.py
@@ -1,10 +1,8 @@
 import sys
+from io import StringIO
 
 import IPython.display
 from IPython.core.magic import Magics, cell_magic, magics_class, needs_local_scope
-
-from io import StringIO
-
 
 valid_choices = [x[8:] for x in dir(IPython.display) if "display_" == x[:8]]
 

--- a/plumbum/colorlib/factories.py
+++ b/plumbum/colorlib/factories.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 Color-related factories. They produce Styles.
 
 """
 
-from __future__ import absolute_import, print_function
 
 import sys
 from functools import reduce
@@ -15,7 +13,7 @@ from .styles import ColorNotFound
 __all__ = ["ColorFactory", "StyleFactory"]
 
 
-class ColorFactory(object):
+class ColorFactory:
     """This creates color names given fg = True/False. It usually will
     be called as part of a StyleFactory."""
 
@@ -119,7 +117,7 @@ class ColorFactory(object):
 
     def __repr__(self):
         """Simple representation of the class by name."""
-        return "<{}>".format(self.__class__.__name__)
+        return f"<{self.__class__.__name__}>"
 
 
 class StyleFactory(ColorFactory):
@@ -127,7 +125,7 @@ class StyleFactory(ColorFactory):
     imitates the FG ColorFactory to a large degree."""
 
     def __init__(self, style):
-        super(StyleFactory, self).__init__(True, style)
+        super().__init__(True, style)
 
         self.fg = ColorFactory(True, style)
         self.bg = ColorFactory(False, style)

--- a/plumbum/colorlib/names.py
+++ b/plumbum/colorlib/names.py
@@ -265,6 +265,8 @@ grey_85
 grey_89
 grey_93""".split()
 
+EMPTY_SLICE = slice(None, None, None)
+
 _greys = (
     3.4,
     7.4,
@@ -364,7 +366,7 @@ class FindNearest:
             + (self.b >= midlevel) * 4
         )
 
-    def all_slow(self, color_slice=slice(None, None, None)):
+    def all_slow(self, color_slice=EMPTY_SLICE):
         """This is a slow way to find the nearest color."""
         distances = [
             self._distance_to_color(color) for color in color_html[color_slice]

--- a/plumbum/colorlib/names.py
+++ b/plumbum/colorlib/names.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Names for the standard and extended color set.
 Extended set is similar to `vim wiki <http://vim.wikia.com/wiki/Xterm256_color_names_for_console_Vim>`_, `colored <https://pypi.python.org/pypi/colored>`_, etc. Colors based on `wikipedia <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>`_.
@@ -7,7 +6,6 @@ You can access the index of the colors with names.index(name). You can access th
 rgb values with ``r=int(html[n][1:3],16)``, etc.
 """
 
-from __future__ import division, print_function
 
 color_names = """\
 black
@@ -309,12 +307,12 @@ _normal_html = [
 _base_pattern = [(n // 4, n // 2 % 2, n % 2) for n in range(8)]
 _base_html = (
     [
-        "#{2:02x}{1:02x}{0:02x}".format(x[0] * 192, x[1] * 192, x[2] * 192)
+        f"#{x[2] * 192:02x}{x[1] * 192:02x}{x[0] * 192:02x}"
         for x in _base_pattern
     ]
     + ["#808080"]
     + [
-        "#{2:02x}{1:02x}{0:02x}".format(x[0] * 255, x[1] * 255, x[2] * 255)
+        f"#{x[2] * 255:02x}{x[1] * 255:02x}{x[0] * 255:02x}"
         for x in _base_pattern
     ][1:]
 )
@@ -347,7 +345,7 @@ default_styles = dict(
 # Functions to be used for color name operations
 
 
-class FindNearest(object):
+class FindNearest:
     """This is a class for finding the nearest color given rgb values.
     Different find methods are available."""
 
@@ -431,4 +429,4 @@ def from_html(color):
 
 def to_html(r, g, b):
     """Convert rgb to html hex code."""
-    return "#{:02x}{:02x}{:02x}".format(r, g, b)
+    return f"#{r:02x}{g:02x}{b:02x}"

--- a/plumbum/colorlib/names.py
+++ b/plumbum/colorlib/names.py
@@ -306,15 +306,9 @@ _normal_html = [
 
 _base_pattern = [(n // 4, n // 2 % 2, n % 2) for n in range(8)]
 _base_html = (
-    [
-        f"#{x[2] * 192:02x}{x[1] * 192:02x}{x[0] * 192:02x}"
-        for x in _base_pattern
-    ]
+    [f"#{x[2] * 192:02x}{x[1] * 192:02x}{x[0] * 192:02x}" for x in _base_pattern]
     + ["#808080"]
-    + [
-        f"#{x[2] * 255:02x}{x[1] * 255:02x}{x[0] * 255:02x}"
-        for x in _base_pattern
-    ][1:]
+    + [f"#{x[2] * 255:02x}{x[1] * 255:02x}{x[0] * 255:02x}" for x in _base_pattern][1:]
 )
 color_html = _base_html + _normal_html + _grey_html
 

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -472,7 +472,7 @@ class Style:
         return other + other.__class__(self)
 
     def wrap(self, wrap_this):
-        """Wrap a sting in this style and its inverse."""
+        """Wrap a string in this style and its inverse."""
         return self + wrap_this + ~self
 
     def __and__(self, other):
@@ -484,7 +484,7 @@ class Style:
             return self.wrap(other)
 
     def __rand__(self, other):
-        """This class supports ``"String:" & color`` syntax, excpet in Python 2.6 due to bug with that Python."""
+        """This class supports ``"String:" & color`` syntax."""
         return self.wrap(other)
 
     def __ror__(self, other):

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This file provides two classes, `Color` and `Style`.
 
@@ -8,7 +7,6 @@ but merely provides the workhorse for finding and manipulating colors.
 With the ``Style`` class, any color can be directly called or given to a with statement.
 """
 
-from __future__ import absolute_import, print_function
 
 import os
 import platform
@@ -26,14 +24,7 @@ from .names import (
     from_html,
 )
 
-if sys.version_info >= (3,):
-    from abc import ABC
-else:
-    from abc import ABCMeta
-
-    ABC = ABCMeta(
-        "ABC", (object,), {"__module__": __name__, "__slots__": ("__weakref__")}
-    )
+from abc import ABC
 
 try:
     from typing import IO, Dict, Union
@@ -355,7 +346,7 @@ class Color(ABC):
             return self.to_representation(val)
 
 
-class Style(object):
+class Style:
     """This class allows the color changes to be called directly
     to write them to stdout, ``[]`` calls to wrap colors (or the ``.wrap`` method)
     and can be called in a with statement.
@@ -684,7 +675,7 @@ class Style(object):
                     if filter_resets is False:
                         self.bg = self.color_class(fg=False)
                 else:
-                    raise ColorNotFound("The code {} is not recognised".format(value))
+                    raise ColorNotFound(f"The code {value} is not recognised")
         except StopIteration:
             return
 
@@ -785,9 +776,9 @@ class HTMLStyle(Style):
         result = ""
 
         if self.bg and not self.bg.isreset:
-            result += '<span style="background-color: {}">'.format(self.bg.hex_code)
+            result += f'<span style="background-color: {self.bg.hex_code}">'
         if self.fg and not self.fg.isreset:
-            result += '<font color="{}">'.format(self.fg.hex_code)
+            result += f'<font color="{self.fg.hex_code}">'
         for attr in sorted(self.attributes):
             if self.attributes[attr]:
                 result += "<" + self.attribute_names[attr] + ">"

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -12,8 +12,9 @@ import os
 import platform
 import re
 import sys
-from abc import ABCMeta, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from copy import copy
+from typing import IO, Dict, Union
 
 from .names import (
     FindNearest,
@@ -23,13 +24,6 @@ from .names import (
     color_names,
     from_html,
 )
-
-from abc import ABC
-
-try:
-    from typing import IO, Dict, Union
-except ImportError:
-    pass
 
 __all__ = [
     "Color",

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -12,7 +12,7 @@ import os
 import platform
 import re
 import sys
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from copy import copy
 from typing import IO, Dict, Union
 

--- a/plumbum/colors.py
+++ b/plumbum/colors.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 This module imitates a real module, providing standard syntax
 like from `plumbum.colors` and from `plumbum.colors.bg` to work alongside
 all the standard syntax for colors.
 """
 
-from __future__ import print_function
 
 import atexit
 import os

--- a/plumbum/colors.py
+++ b/plumbum/colors.py
@@ -6,7 +6,6 @@ all the standard syntax for colors.
 
 
 import atexit
-import os
 import sys
 
 from plumbum.colorlib import ansicolors, main

--- a/plumbum/colors.py
+++ b/plumbum/colors.py
@@ -16,7 +16,6 @@ if __name__ == "__main__":
 else:  # Don't register an exit if this is called using -m!
     atexit.register(_reset)
 
-# Oddly, the order here matters for Python2, but not Python3
 sys.modules[__name__ + ".fg"] = ansicolors.fg
 sys.modules[__name__ + ".bg"] = ansicolors.bg
-sys.modules[__name__] = ansicolors
+sys.modules[__name__] = ansicolors  # type: ignore[assignment]

--- a/plumbum/commands/__init__.py
+++ b/plumbum/commands/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from plumbum.commands.base import (
     ERROUT,
     BaseCommand,

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import functools
 import shlex
 import subprocess
@@ -29,12 +28,7 @@ _funnychars = '"`$\\'
 def shquote(text):
     """Quotes the given text with shell escaping (assumes as syntax similar to ``sh``)"""
     text = six.str(text)
-    if sys.version_info >= (3, 3):
-        return shlex.quote(text)
-    else:
-        import pipes
-
-        return pipes.quote(text)
+    return shlex.quote(text)
 
 
 def shquote_list(seq):
@@ -44,7 +38,7 @@ def shquote_list(seq):
 # ===================================================================================================
 # Commands
 # ===================================================================================================
-class BaseCommand(object):
+class BaseCommand:
     """Base of all command objects"""
 
     __slots__ = ("cwd", "env", "custom_encoding", "__weakref__")
@@ -300,7 +294,7 @@ class BoundCommand(BaseCommand):
         self.args = list(args)
 
     def __repr__(self):
-        return "BoundCommand({!r}, {!r})".format(self.cmd, self.args)
+        return f"BoundCommand({self.cmd!r}, {self.args!r})"
 
     def _get_encoding(self):
         return self.cmd._get_encoding()
@@ -313,7 +307,7 @@ class BoundCommand(BaseCommand):
         return self.cmd.machine
 
     def popen(self, args=(), **kwargs):
-        if isinstance(args, six.string_types):
+        if isinstance(args, str):
             args = [
                 args,
             ]
@@ -329,7 +323,7 @@ class BoundEnvCommand(BaseCommand):
         self.cwd = cwd
 
     def __repr__(self):
-        return "BoundEnvCommand({!r}, {!r})".format(self.cmd, self.env)
+        return f"BoundEnvCommand({self.cmd!r}, {self.env!r})"
 
     def _get_encoding(self):
         return self.cmd._get_encoding()
@@ -359,7 +353,7 @@ class Pipeline(BaseCommand):
         self.dstcmd = dstcmd
 
     def __repr__(self):
-        return "Pipeline({!r}, {!r})".format(self.srccmd, self.dstcmd)
+        return f"Pipeline({self.srccmd!r}, {self.dstcmd!r})"
 
     def _get_encoding(self):
         return self.srccmd._get_encoding() or self.dstcmd._get_encoding()
@@ -439,7 +433,7 @@ class BaseRedirection(BaseCommand):
         return self.cmd._get_encoding()
 
     def __repr__(self):
-        return "{}({!r}, {!r})".format(self.__class__.__name__, self.cmd, self.file)
+        return f"{self.__class__.__name__}({self.cmd!r}, {self.file!r})"
 
     def formulate(self, level=0, args=()):
         return self.cmd.formulate(level + 1, args) + [
@@ -456,10 +450,10 @@ class BaseRedirection(BaseCommand):
         from plumbum.machines.remote import RemotePath
 
         if self.KWARG in kwargs and kwargs[self.KWARG] not in (PIPE, None):
-            raise RedirectionError("{} is already redirected".format(self.KWARG))
+            raise RedirectionError(f"{self.KWARG} is already redirected")
         if isinstance(self.file, RemotePath):
             raise TypeError("Cannot redirect to/from remote paths")
-        if isinstance(self.file, six.string_types + (LocalPath,)):
+        if isinstance(self.file, (str,) + (LocalPath,)):
             f = kwargs[self.KWARG] = open(str(self.file), self.MODE)
         else:
             kwargs[self.KWARG] = self.file
@@ -523,7 +517,7 @@ class StdinDataRedirection(BaseCommand):
 
     def formulate(self, level=0, args=()):
         return [
-            "echo {}".format(shquote(self.data)),
+            f"echo {shquote(self.data)}",
             "|",
             self.cmd.formulate(level + 1, args),
         ]
@@ -564,7 +558,7 @@ class ConcreteCommand(BaseCommand):
         return str(self.executable)
 
     def __repr__(self):
-        return "{}({})".format(type(self).__name__, self.executable)
+        return f"{type(self).__name__}({self.executable})"
 
     def _get_encoding(self):
         return self.custom_encoding

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -1,7 +1,6 @@
 import functools
 import shlex
 import subprocess
-import sys
 from contextlib import contextmanager
 from subprocess import PIPE, Popen
 from tempfile import TemporaryFile
@@ -9,6 +8,26 @@ from types import MethodType
 
 import plumbum.commands.modifiers
 from plumbum.commands.processes import iter_lines, run_proc
+
+__all__ = (
+    "iter_lines",
+    "run_proc",
+    "shquote",
+    "shquote_list",
+    "RedirectionError",
+    "BaseCommand",
+    "Pipeline",
+    "BaseRedirection",
+    "BoundCommand",
+    "BoundEnvCommand",
+    "ConcreteCommand",
+    "ERROUT",
+    "StdinRedirection",
+    "StdoutRedirection",
+    "StderrRedirection",
+    "AppendingStdoutRedirection",
+    "StdinDataRedirection",
+)
 
 
 class RedirectionError(Exception):

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -9,7 +9,6 @@ from types import MethodType
 
 import plumbum.commands.modifiers
 from plumbum.commands.processes import iter_lines, run_proc
-from plumbum.lib import six
 
 
 class RedirectionError(Exception):
@@ -27,7 +26,7 @@ _funnychars = '"`$\\'
 
 def shquote(text):
     """Quotes the given text with shell escaping (assumes as syntax similar to ``sh``)"""
-    text = six.str(text)
+    text = str(text)
     return shlex.quote(text)
 
 
@@ -341,7 +340,7 @@ class BoundEnvCommand(BaseCommand):
             args,
             cwd=self.cwd if cwd is None else cwd,
             env=dict(self.env, **env),
-            **kwargs
+            **kwargs,
         )
 
 
@@ -530,7 +529,7 @@ class StdinDataRedirection(BaseCommand):
         if "stdin" in kwargs and kwargs["stdin"] != PIPE:
             raise RedirectionError("stdin is already redirected")
         data = self.data
-        if isinstance(data, six.unicode_type) and self._get_encoding() is not None:
+        if isinstance(data, str) and self._get_encoding() is not None:
             data = data.encode(self._get_encoding())
         f = TemporaryFile()
         while data:
@@ -564,7 +563,7 @@ class ConcreteCommand(BaseCommand):
         return self.custom_encoding
 
     def formulate(self, level=0, args=()):
-        argv = [six.str(self.executable)]
+        argv = [str(self.executable)]
         for a in args:
             if a is None:
                 continue
@@ -575,10 +574,10 @@ class ConcreteCommand(BaseCommand):
                     argv.extend(a.formulate(level + 1))
             elif isinstance(a, (list, tuple)):
                 argv.extend(
-                    shquote(b) if level >= self.QUOTE_LEVEL else six.str(b) for b in a
+                    shquote(b) if level >= self.QUOTE_LEVEL else str(b) for b in a
                 )
             else:
-                argv.append(shquote(a) if level >= self.QUOTE_LEVEL else six.str(a))
+                argv.append(shquote(a) if level >= self.QUOTE_LEVEL else str(a))
         # if self.custom_encoding:
-        #    argv = [a.encode(self.custom_encoding) for a in argv if isinstance(a, six.string_types)]
+        #    argv = [a.encode(self.custom_encoding) for a in argv if isinstance(a, str)]
         return argv

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import errno
 import os
 import signal
@@ -10,7 +9,7 @@ import traceback
 from plumbum.commands.processes import ProcessExecutionError
 
 
-class _fake_lock(object):
+class _fake_lock:
     """Needed to allow normal os.exit() to work without error"""
 
     def acquire(self, val):
@@ -37,7 +36,7 @@ def posix_daemonize(command, cwd, stdout=None, stderr=None, append=True):
         try:
             os.setsid()
             os.umask(0)
-            stdin = open(os.devnull, "r")
+            stdin = open(os.devnull)
             stdout = open(stdout, "a" if append else "w")
             stderr = open(stderr, "a" if append else "w")
             signal.signal(signal.SIGHUP, signal.SIG_IGN)
@@ -114,7 +113,7 @@ def win32_daemonize(command, cwd, stdout=None, stderr=None, append=True):
     if stderr is None:
         stderr = stdout
     DETACHED_PROCESS = 0x00000008
-    stdin = open(os.devnull, "r")
+    stdin = open(os.devnull)
     stdout = open(stdout, "a" if append else "w")
     stderr = open(stderr, "a" if append else "w")
     return command.popen(

--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -1,7 +1,4 @@
-import os
 import sys
-import time
-from itertools import chain
 from select import select
 from subprocess import PIPE
 

--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 import time
@@ -11,7 +10,7 @@ from plumbum.commands.processes import BY_TYPE, ProcessExecutionError, run_proc
 from plumbum.lib import read_fd_decode_safely
 
 
-class Future(object):
+class Future:
     """Represents a "future result" of a running process. It basically wraps a ``Popen``
     object and the expected exit code, and provides poll(), wait(), returncode, stdout,
     and stderr.
@@ -73,7 +72,7 @@ class Future(object):
 # ===================================================================================================
 
 
-class ExecutionModifier(object):
+class ExecutionModifier:
     __slots__ = ("__weakref__",)
 
     def __repr__(self):
@@ -87,7 +86,7 @@ class ExecutionModifier(object):
             for prop in slots_list:
                 if prop[0] != "_":
                     slots[prop] = getattr(self, prop)
-        mystrs = ("{} = {}".format(name, slots[name]) for name in slots)
+        mystrs = (f"{name} = {slots[name]}" for name in slots)
         return "{}({})".format(self.__class__.__name__, ", ".join(mystrs))
 
     @classmethod
@@ -446,7 +445,7 @@ class PipeToLoggerMixin:
         Optionally use `prefix` for each line.
         """
 
-        class LogPipe(object):
+        class LogPipe:
             def __rand__(_, cmd):
                 popen = cmd if hasattr(cmd, "iter_lines") else cmd.popen()
                 for typ, lines in popen.iter_lines(
@@ -457,7 +456,7 @@ class PipeToLoggerMixin:
                     level = levels[typ]
                     for line in lines.splitlines():
                         if prefix:
-                            line = "{}: {}".format(prefix, line)
+                            line = f"{prefix}: {line}"
                         self.log(level, line)
                 return popen.returncode
 

--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -247,7 +247,7 @@ class _TF(ExecutionModifier):
     This is useful for checking true/false bash commands.
 
     If you wish to expect a different return code (other than the normal success indicate by 0),
-    use ``TF(retcode)``. If you want to run the process in the forground, then use
+    use ``TF(retcode)``. If you want to run the process in the foreground, then use
     ``TF(FG=True)``.
 
     Example::
@@ -297,7 +297,7 @@ class _RETCODE(ExecutionModifier):
     This is useful for working with bash commands that have important retcodes but not very
     useful output.
 
-    If you want to run the process in the forground, then use ``RETCODE(FG=True)``.
+    If you want to run the process in the foreground, then use ``RETCODE(FG=True)``.
 
     Example::
 
@@ -343,7 +343,7 @@ class _NOHUP(ExecutionModifier):
         sleep[5] & NOHUP                       # Outputs to nohup.out
         sleep[5] & NOHUP(stdout=os.devnull)    # No output
 
-    The equivelent bash command would be
+    The equivalent bash command would be
 
     .. code-block:: bash
 

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -1,6 +1,5 @@
 import atexit
 import heapq
-import sys
 import time
 from io import StringIO
 from queue import Empty as QueueEmpty
@@ -34,7 +33,7 @@ def _iter_lines_posix(proc, decode, linesize, line_timeout=None):
                     getattr(proc, "argv", None),
                     getattr(proc, "machine", None),
                 )
-            for key, mask in ready:
+            for key, _mask in ready:
                 yield key.data, decode(key.fileobj.readline(linesize))
 
     for ret in selector():

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -198,7 +198,7 @@ class MinHeap:
         return self._items[0]
 
 
-_timeout_queue = Queue()
+_timeout_queue = Queue()  # type: ignore[var-annotated]
 _shutting_down = False
 
 

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import atexit
 import heapq
 import sys
@@ -7,14 +6,9 @@ from threading import Thread
 
 from plumbum.lib import IS_WIN32, six
 
-if sys.version_info >= (3,):
-    from io import StringIO
-    from queue import Empty as QueueEmpty
-    from queue import Queue
-else:
-    from cStringIO import StringIO
-    from Queue import Empty as QueueEmpty
-    from Queue import Queue
+from io import StringIO
+from queue import Empty as QueueEmpty
+from queue import Queue
 
 
 # ===================================================================================================
@@ -205,7 +199,7 @@ class CommandNotFound(AttributeError):
 # ===================================================================================================
 # Timeout thread
 # ===================================================================================================
-class MinHeap(object):
+class MinHeap:
     def __init__(self, items=()):
         self._items = list(items)
         heapq.heapify(self._items)
@@ -254,7 +248,7 @@ def _timeout_thread_func():
                     if proc.poll() is None:
                         proc.kill()
                         proc._timed_out = True
-                except EnvironmentError:
+                except OSError:
                     pass
     except Exception:
         if _shutting_down:
@@ -312,9 +306,9 @@ def run_proc(proc, retcode, timeout=None):
     stdout, stderr = proc.communicate()
     proc._end_time = time.time()
     if not stdout:
-        stdout = six.b("")
+        stdout = b""
     if not stderr:
-        stderr = six.b("")
+        stderr = b""
     if getattr(proc, "custom_encoding", None):
         stdout = stdout.decode(proc.custom_encoding, "ignore")
         stderr = stderr.decode(proc.custom_encoding, "ignore")

--- a/plumbum/fs/__init__.py
+++ b/plumbum/fs/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 file-system related operations
 """

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -10,14 +10,6 @@ from contextlib import contextmanager
 
 from plumbum.machines.local import local
 
-if not hasattr(threading, "get_ident"):
-    try:
-        import thread
-    except ImportError:
-        import _thread as thread
-    threading.get_ident = thread.get_ident
-    del thread
-
 try:
     import fcntl
 except ImportError:

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -8,7 +8,6 @@ import sys
 import threading
 from contextlib import contextmanager
 
-from plumbum.lib import six
 from plumbum.machines.local import local
 
 if not hasattr(threading, "get_ident"):
@@ -98,11 +97,7 @@ class AtomicFile:
         self.reopen()
 
     def __repr__(self):
-        return (
-            f"<AtomicFile: {self.path}>"
-            if self._fileobj
-            else "<AtomicFile: closed>"
-        )
+        return f"<AtomicFile: {self.path}>" if self._fileobj else "<AtomicFile: closed>"
 
     def __del__(self):
         self.close()

--- a/plumbum/fs/mounts.py
+++ b/plumbum/fs/mounts.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 import re
 
 
-class MountEntry(object):
+class MountEntry:
     """
     Represents a mount entry (device file, mount point and file system type)
     """

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -31,70 +31,8 @@ class ProcInfo:
         )
 
 
-class six:
-    """
-    A light-weight version of six (which works on IronPython)
-    """
-
-    PY3 = sys.version_info[0] >= 3
-    from abc import ABC
-
-    # Be sure to use named-tuple access, so that usage is not affected
-    try:
-        getfullargspec = staticmethod(inspect.getfullargspec)
-    except AttributeError:
-        getfullargspec = staticmethod(
-            inspect.getargspec
-        )  # extra fields will not be available
-
-    if PY3:
-        integer_types = (int,)
-        string_types = (str,)
-        MAXSIZE = sys.maxsize
-        ascii = ascii  # @UndefinedVariable
-        bytes = bytes  # @ReservedAssignment
-        unicode_type = str
-
-        @staticmethod
-        def b(s):
-            return s.encode("latin-1", "replace")
-
-        @staticmethod
-        def u(s):
-            return s
-
-        @staticmethod
-        def get_method_function(m):
-            return m.__func__
-
-    else:
-        integer_types = (int, long)
-        string_types = (str, unicode)
-        MAXSIZE = getattr(sys, "maxsize", sys.maxint)
-        ascii = repr  # @ReservedAssignment
-        bytes = str  # @ReservedAssignment
-        unicode_type = unicode
-
-        @staticmethod
-        def b(st):
-            return st
-
-        @staticmethod
-        def u(s):
-            return s.decode("unicode-escape")
-
-        @staticmethod
-        def get_method_function(m):
-            return m.im_func
-
-    str = unicode_type
-
-
-# Try/except fails because io has the wrong StringIO in Python2
-# You'll get str/unicode errors
-from io import StringIO
-
 from glob import escape as glob_escape
+from io import StringIO
 
 
 @contextmanager

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -1,8 +1,8 @@
 import inspect
 import os
-import re
 import sys
 from contextlib import contextmanager
+from io import StringIO
 
 IS_WIN32 = sys.platform == "win32"
 
@@ -29,10 +29,6 @@ class ProcInfo:
         return "ProcInfo({!r}, {!r}, {!r}, {!r})".format(
             self.pid, self.uid, self.stat, self.args
         )
-
-
-from glob import escape as glob_escape
-from io import StringIO
 
 
 @contextmanager

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -9,7 +9,7 @@ IS_WIN32 = sys.platform == "win32"
 
 def _setdoc(super):  # @ReservedAssignment
     """This inherits the docs on the current class. Not really needed for Python 3.5,
-    due to new behavoir of inspect.getdoc, but still doesn't hurt."""
+    due to new behavior of inspect.getdoc, but still doesn't hurt."""
 
     def deco(func):
         func.__doc__ = getattr(getattr(super, func.__name__, None), "__doc__", None)
@@ -75,7 +75,7 @@ def getdoc(object):
 
 def read_fd_decode_safely(fd, size=4096):
     """
-    This reads a utf-8 file descriptor and returns a chunck, growing up to
+    This reads a utf-8 file descriptor and returns a chunk, growing up to
     three bytes if needed to decode the character at the end.
 
     Returns the data and the decoded text.

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import inspect
 import os
 import re
@@ -19,7 +18,7 @@ def _setdoc(super):  # @ReservedAssignment
     return deco
 
 
-class ProcInfo(object):
+class ProcInfo:
     def __init__(self, pid, uid, stat, args):
         self.pid = pid
         self.uid = uid
@@ -32,18 +31,13 @@ class ProcInfo(object):
         )
 
 
-class six(object):
+class six:
     """
     A light-weight version of six (which works on IronPython)
     """
 
     PY3 = sys.version_info[0] >= 3
-    if sys.version_info >= (3, 4):
-        from abc import ABC
-    else:
-        from abc import ABCMeta
-
-        ABC = ABCMeta("ABC", (object,), {"__module__": __name__, "__slots__": ()})
+    from abc import ABC
 
     # Be sure to use named-tuple access, so that usage is not affected
     try:
@@ -98,24 +92,9 @@ class six(object):
 
 # Try/except fails because io has the wrong StringIO in Python2
 # You'll get str/unicode errors
-if sys.version_info >= (3, 0):
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
-if sys.version_info >= (3,):
-    from glob import escape as glob_escape
-else:
-    _magic_check = re.compile(u"([*?[])")
-    _magic_check_bytes = re.compile(b"([*?[])")
-
-    def glob_escape(pathname):
-        drive, pathname = os.path.splitdrive(pathname)
-        if isinstance(pathname, str):
-            pathname = _magic_check_bytes.sub(r"[\1]", pathname)
-        else:
-            pathname = _magic_check.sub(u"[\\1]", pathname)
-        return drive + pathname
+from glob import escape as glob_escape
 
 
 @contextmanager
@@ -125,7 +104,7 @@ def captured_stdout(stdin=""):
     """
     prevstdin = sys.stdin
     prevstdout = sys.stdout
-    sys.stdin = StringIO(six.u(stdin))
+    sys.stdin = StringIO(stdin)
     sys.stdout = StringIO()
     try:
         yield sys.stdout
@@ -134,7 +113,7 @@ def captured_stdout(stdin=""):
         sys.stdout = prevstdout
 
 
-class StaticProperty(object):
+class StaticProperty:
     """This acts like a static property, allowing access via class or object.
     This is a non-data descriptor."""
 

--- a/plumbum/machines/__init__.py
+++ b/plumbum/machines/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from plumbum.machines.local import LocalCommand, LocalMachine, local
 from plumbum.machines.remote import BaseRemoteMachine, RemoteCommand
 from plumbum.machines.ssh_machine import PuttyMachine, SshMachine

--- a/plumbum/machines/_windows.py
+++ b/plumbum/machines/_windows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import struct
 
 from plumbum.lib import six
@@ -12,12 +11,12 @@ IMAGE_SUBSYSTEM_WINDOWS_CUI = 3
 
 def get_pe_subsystem(filename):
     with open(filename, "rb") as f:
-        if f.read(2) != six.b("MZ"):
+        if f.read(2) != b"MZ":
             return None
         f.seek(LFANEW_OFFSET)
         lfanew = struct.unpack("L", f.read(4))[0]
         f.seek(lfanew)
-        if f.read(4) != six.b("PE\x00\x00"):
+        if f.read(4) != b"PE\x00\x00":
             return None
         f.seek(FILE_HEADER_SIZE + SUBSYSTEM_OFFSET, 1)
         subsystem = struct.unpack("H", f.read(2))[0]

--- a/plumbum/machines/_windows.py
+++ b/plumbum/machines/_windows.py
@@ -1,7 +1,5 @@
 import struct
 
-from plumbum.lib import six
-
 LFANEW_OFFSET = 30 * 2
 FILE_HEADER_SIZE = 5 * 4
 SUBSYSTEM_OFFSET = 17 * 4

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from plumbum.commands.processes import (
     CommandNotFound,
     ProcessExecutionError,
@@ -6,7 +5,7 @@ from plumbum.commands.processes import (
 )
 
 
-class PopenAddons(object):
+class PopenAddons:
     """This adds a verify to popen objects to that the correct command is attributed when
     an error is thrown."""
 
@@ -14,7 +13,7 @@ class PopenAddons(object):
         """This verifies that the correct command is attributed."""
         if getattr(self, "_timed_out", False):
             raise ProcessTimedOut(
-                "Process did not terminate within {} seconds".format(timeout),
+                f"Process did not terminate within {timeout} seconds",
                 getattr(self, "argv", None),
             )
 
@@ -30,7 +29,7 @@ class PopenAddons(object):
                 )
 
 
-class BaseMachine(object):
+class BaseMachine:
     """This is a base class for other machines. It contains common code to
     all machines in Plumbum."""
 
@@ -81,7 +80,7 @@ class BaseMachine(object):
     def daemonic_popen(self, command, cwd="/", stdout=None, stderr=None, append=True):
         raise NotImplementedError("This is not implemented on this machine!")
 
-    class Cmd(object):
+    class Cmd:
         def __init__(self, machine):
             self._machine = machine
 

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -58,7 +58,7 @@ class BaseMachine:
                 raise
 
     def __contains__(self, cmd):
-        """Tests for the existance of the command, e.g., ``"ls" in plumbum.local``.
+        """Tests for the existence of the command, e.g., ``"ls" in plumbum.local``.
         ``cmd`` can be anything acceptable by ``__getitem__``.
         """
         try:

--- a/plumbum/machines/env.py
+++ b/plumbum/machines/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from contextlib import contextmanager
 
@@ -35,7 +34,7 @@ class EnvPathList(list):
         return self._pathsep.join(str(p) for p in self)
 
 
-class BaseEnv(object):
+class BaseEnv:
     """The base class of LocalEnv and RemoteEnv"""
 
     __slots__ = ["_curr", "_path", "_path_factory", "__weakref__"]

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import os
 import platform
@@ -125,7 +124,7 @@ class LocalCommand(ConcreteCommand):
         return local
 
     def popen(self, args=(), cwd=None, env=None, **kwargs):
-        if isinstance(args, six.string_types):
+        if isinstance(args, str):
             args = (args,)
         return self.machine._popen(
             self.executable,
@@ -216,7 +215,7 @@ class LocalMachine(BaseMachine):
         parts2 = [str(self.cwd)]
         for p in parts:
             if isinstance(p, RemotePath):
-                raise TypeError("Cannot construct LocalPath from {!r}".format(p))
+                raise TypeError(f"Cannot construct LocalPath from {p!r}")
             parts2.append(self.env.expanduser(str(p)))
         return LocalPath(os.path.join(*parts2))
 
@@ -247,7 +246,7 @@ class LocalMachine(BaseMachine):
                 # search for command
                 return LocalCommand(self.which(cmd))
         else:
-            raise TypeError("cmd must not be a RemotePath: {!r}".format(cmd))
+            raise TypeError(f"cmd must not be a RemotePath: {cmd!r}")
 
     def _popen(
         self,
@@ -444,7 +443,7 @@ class LocalMachine(BaseMachine):
                     [
                         "runas",
                         "/savecred",
-                        "/user:{}".format(username),
+                        f"/user:{username}",
                         '"' + " ".join(str(a) for a in argv) + '"',
                     ],
                     self.which("runas"),

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -70,11 +70,11 @@ class LocalEnv(BaseEnv):
 
         :returns: The expanded string"""
         prev = os.environ
-        os.environ = self.getdict()
+        os.environ = self.getdict()  # noqa: B003
         try:
             output = os.path.expanduser(os.path.expandvars(expr))
         finally:
-            os.environ = prev
+            os.environ = prev  # noqa: B003
         return output
 
     def expanduser(self, expr):
@@ -84,11 +84,11 @@ class LocalEnv(BaseEnv):
 
         :returns: The expanded string"""
         prev = os.environ
-        os.environ = self.getdict()
+        os.environ = self.getdict()  # noqa: B003
         try:
             output = os.path.expanduser(expr)
         finally:
-            os.environ = prev
+            os.environ = prev  # noqa: B003
         return output
 
 

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -1,7 +1,6 @@
 import errno
 import logging
 import os
-import socket
 import stat
 
 from plumbum.commands.base import shquote
@@ -498,7 +497,7 @@ def _iter_lines(proc, decode, linesize, line_timeout=None):
                     getattr(proc, "argv", None),
                     getattr(proc, "machine", None),
                 )
-            for key, mask in ready:
+            for _key, _mask in ready:
                 yield
 
     for _ in selector():

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -188,7 +188,7 @@ class ParamikoMachine(BaseRemoteMachine):
     :param bool load_system_ssh_config: read system SSH config for ProxyCommand configuration. default: False
     """
 
-    class RemoteCommand(BaseRemoteMachine.RemoteCommand):
+    class RemoteCommand(BaseRemoteMachine.RemoteCommand):  # type: ignore[valid-type, misc]
         def __or__(self, *_):
             raise NotImplementedError("Not supported with ParamikoMachine")
 

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -342,7 +342,7 @@ class BaseRemoteMachine(BaseMachine):
         return files
 
     def _path_glob(self, fn, pattern):
-        # shquote does not work here due to the way bash loops use space as a seperator
+        # shquote does not work here due to the way bash loops use space as a separator
         pattern = pattern.replace(" ", r"\ ")
         fn = fn.replace(" ", r"\ ")
         matches = self._session.run(fr"for fn in {fn}/{pattern}; do echo $fn; done")[

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
 from plumbum.commands import CommandNotFound, ConcreteCommand, shquote
-from plumbum.lib import ProcInfo, _setdoc, six
+from plumbum.lib import ProcInfo, _setdoc
 from plumbum.machines.base import BaseMachine
 from plumbum.machines.env import BaseEnv
 from plumbum.machines.local import LocalPath
@@ -58,8 +58,7 @@ class RemoteEnv(BaseEnv):
     def update(self, *args, **kwargs):
         BaseEnv.update(self, *args, **kwargs)
         self.remote._session.run(
-            "export "
-            + " ".join(f"{k}={shquote(v)}" for k, v in self.getdict().items())
+            "export " + " ".join(f"{k}={shquote(v)}" for k, v in self.getdict().items())
         )
 
     def expand(self, expr):
@@ -346,9 +345,9 @@ class BaseRemoteMachine(BaseMachine):
         # shquote does not work here due to the way bash loops use space as a seperator
         pattern = pattern.replace(" ", r"\ ")
         fn = fn.replace(" ", r"\ ")
-        matches = self._session.run(
-            fr"for fn in {fn}/{pattern}; do echo $fn; done"
-        )[1].splitlines()
+        matches = self._session.run(fr"for fn in {fn}/{pattern}; do echo $fn; done")[
+            1
+        ].splitlines()
         if len(matches) == 1 and not self._path_stat(matches[0]):
             return []  # pattern expansion failed
         return matches
@@ -418,12 +417,12 @@ class BaseRemoteMachine(BaseMachine):
 
     def _path_read(self, fn):
         data = self["cat"](fn)
-        if self.custom_encoding and isinstance(data, six.unicode_type):
+        if self.custom_encoding and isinstance(data, str):
             data = data.encode(self.custom_encoding)
         return data
 
     def _path_write(self, fn, data):
-        if self.custom_encoding and isinstance(data, six.unicode_type):
+        if self.custom_encoding and isinstance(data, str):
             data = data.encode(self.custom_encoding)
         with NamedTemporaryFile() as f:
             f.write(data)

--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -5,7 +5,6 @@ import time
 
 from plumbum.commands import BaseCommand, run_proc
 from plumbum.commands.processes import ProcessExecutionError
-from plumbum.lib import six
 from plumbum.machines.base import PopenAddons
 
 
@@ -48,7 +47,7 @@ class MarkedPipe:
     def __init__(self, pipe, marker):
         self.pipe = pipe
         self.marker = marker
-        self.marker = six.bytes(self.marker, "ascii")
+        self.marker = bytes(self.marker, "ascii")
 
     def close(self):
         """'Closes' the marked pipe; following calls to ``readline`` will return """ ""

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import warnings
 
 from plumbum.commands import ProcessExecutionError, shquote
@@ -10,7 +9,7 @@ from plumbum.path.local import LocalPath
 from plumbum.path.remote import RemotePath
 
 
-class SshTunnel(object):
+class SshTunnel:
     """An object representing an SSH tunnel (created by
     :func:`SshMachine.tunnel <plumbum.machines.remote.SshMachine.tunnel>`)"""
 
@@ -21,7 +20,7 @@ class SshTunnel(object):
 
     def __repr__(self):
         if self._session.alive():
-            return "<SshTunnel {}>".format(self._session.proc)
+            return f"<SshTunnel {self._session.proc}>"
         else:
             return "<SshTunnel (defunct)>"
 
@@ -108,7 +107,7 @@ class SshMachine(BaseRemoteMachine):
         scp_args = []
         ssh_args = []
         if user:
-            self._fqhost = "{}@{}".format(user, host)
+            self._fqhost = f"{user}@{host}"
         else:
             self._fqhost = host
         if port:
@@ -130,7 +129,7 @@ class SshMachine(BaseRemoteMachine):
         )
 
     def __str__(self):
-        return "ssh://{}".format(self._fqhost)
+        return f"ssh://{self._fqhost}"
 
     @_setdoc(BaseRemoteMachine)
     def popen(self, args, ssh_opts=(), env=None, cwd=None, **kwargs):
@@ -150,7 +149,7 @@ class SshMachine(BaseRemoteMachine):
             if envdelta:
                 cmdline.append("env")
                 cmdline.extend(
-                    "{}={}".format(k, shquote(v)) for k, v in envdelta.items()
+                    f"{k}={shquote(v)}" for k, v in envdelta.items()
                 )
             if isinstance(args, (tuple, list)):
                 cmdline.extend(args)
@@ -275,17 +274,17 @@ class SshMachine(BaseRemoteMachine):
                 sock.connect(("localhost", 1234))
                 # sock is now tunneled to the MySQL socket on megazord
         """
-        formatted_lhost = "" if lhost is None else "[{}]:".format(lhost)
-        formatted_dhost = "" if dhost is None else "[{}]:".format(dhost)
+        formatted_lhost = "" if lhost is None else f"[{lhost}]:"
+        formatted_dhost = "" if dhost is None else f"[{dhost}]:"
         ssh_opts = (
             [
                 "-L",
-                "{}{}:{}{}".format(formatted_lhost, lport, formatted_dhost, dport),
+                f"{formatted_lhost}{lport}:{formatted_dhost}{dport}",
             ]
             if not reverse
             else [
                 "-R",
-                "{}{}:{}{}".format(formatted_dhost, dport, formatted_lhost, lport),
+                f"{formatted_dhost}{dport}:{formatted_lhost}{lport}",
             ]
         )
         proc = self.popen((), ssh_opts=ssh_opts, new_session=True)
@@ -305,28 +304,28 @@ class SshMachine(BaseRemoteMachine):
     @_setdoc(BaseRemoteMachine)
     def download(self, src, dst):
         if isinstance(src, LocalPath):
-            raise TypeError("src of download cannot be {!r}".format(src))
+            raise TypeError(f"src of download cannot be {src!r}")
         if isinstance(src, RemotePath) and src.remote != self:
-            raise TypeError("src {!r} points to a different remote machine".format(src))
+            raise TypeError(f"src {src!r} points to a different remote machine")
         if isinstance(dst, RemotePath):
-            raise TypeError("dst of download cannot be {!r}".format(dst))
+            raise TypeError(f"dst of download cannot be {dst!r}")
         if IS_WIN32:
             src = self._translate_drive_letter(src)
             dst = self._translate_drive_letter(dst)
-        self._scp_command("{}:{}".format(self._fqhost, shquote(src)), dst)
+        self._scp_command(f"{self._fqhost}:{shquote(src)}", dst)
 
     @_setdoc(BaseRemoteMachine)
     def upload(self, src, dst):
         if isinstance(src, RemotePath):
-            raise TypeError("src of upload cannot be {!r}".format(src))
+            raise TypeError(f"src of upload cannot be {src!r}")
         if isinstance(dst, LocalPath):
-            raise TypeError("dst of upload cannot be {!r}".format(dst))
+            raise TypeError(f"dst of upload cannot be {dst!r}")
         if isinstance(dst, RemotePath) and dst.remote != self:
-            raise TypeError("dst {!r} points to a different remote machine".format(dst))
+            raise TypeError(f"dst {dst!r} points to a different remote machine")
         if IS_WIN32:
             src = self._translate_drive_letter(src)
             dst = self._translate_drive_letter(dst)
-        self._scp_command(src, "{}:{}".format(self._fqhost, shquote(dst)))
+        self._scp_command(src, f"{self._fqhost}:{shquote(dst)}")
 
 
 class PuttyMachine(SshMachine):
@@ -379,7 +378,7 @@ class PuttyMachine(SshMachine):
         )
 
     def __str__(self):
-        return "putty-ssh://{}".format(self._fqhost)
+        return f"putty-ssh://{self._fqhost}"
 
     def _translate_drive_letter(self, path):
         # pscp takes care of windows paths automatically

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -148,9 +148,7 @@ class SshMachine(BaseRemoteMachine):
                 cmdline.extend(["cd", str(cwd), "&&"])
             if envdelta:
                 cmdline.append("env")
-                cmdline.extend(
-                    f"{k}={shquote(v)}" for k, v in envdelta.items()
-                )
+                cmdline.extend(f"{k}={shquote(v)}" for k, v in envdelta.items())
             if isinstance(args, (tuple, list)):
                 cmdline.extend(args)
             else:

--- a/plumbum/path/__init__.py
+++ b/plumbum/path/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from plumbum.path.base import FSUser, Path, RelativePath
 from plumbum.path.local import LocalPath, LocalWorkdir
 from plumbum.path.remote import RemotePath, RemoteWorkdir

--- a/plumbum/path/__init__.py
+++ b/plumbum/path/__init__.py
@@ -2,3 +2,16 @@ from plumbum.path.base import FSUser, Path, RelativePath
 from plumbum.path.local import LocalPath, LocalWorkdir
 from plumbum.path.remote import RemotePath, RemoteWorkdir
 from plumbum.path.utils import copy, delete, move
+
+__all__ = (
+    "FSUser",
+    "Path",
+    "RelativePath",
+    "LocalPath",
+    "LocalWorkdir",
+    "RemotePath",
+    "RemoteWorkdir",
+    "copy",
+    "delete",
+    "move",
+)

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import itertools
 import operator
 import os
@@ -32,7 +29,7 @@ class Path(str, six.ABC):
     CASE_SENSITIVE = True
 
     def __repr__(self):
-        return "<{} {}>".format(self.__class__.__name__, str(self))
+        return f"<{self.__class__.__name__} {str(self)}>"
 
     def __div__(self, other):
         """Joins two paths"""
@@ -125,8 +122,7 @@ class Path(str, six.ABC):
             if filter(p):
                 yield p
             if p.is_dir() and dir_filter(p):
-                for p2 in p.walk(filter, dir_filter):
-                    yield p2
+                yield from p.walk(filter, dir_filter)
 
     @abstractproperty
     def name(self):
@@ -437,7 +433,7 @@ class Path(str, six.ABC):
         return self.parents[0]
 
 
-class RelativePath(object):
+class RelativePath:
     """
     Relative paths are the "delta" required to get from one path to another.
     Note that relative path do not point at anything, and thus are not paths.
@@ -463,7 +459,7 @@ class RelativePath(object):
         return self.parts[index]
 
     def __repr__(self):
-        return "RelativePath({!r})".format(self.parts)
+        return f"RelativePath({self.parts!r})"
 
     def __eq__(self, other):
         return str(self) == str(other)

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -2,10 +2,8 @@ import itertools
 import operator
 import os
 import warnings
-from abc import abstractmethod, abstractproperty
+from abc import ABC, abstractmethod, abstractproperty
 from functools import reduce
-
-from plumbum.lib import six
 
 
 class FSUser(int):
@@ -20,7 +18,7 @@ class FSUser(int):
         return self
 
 
-class Path(str, six.ABC):
+class Path(str, ABC):
     """An abstraction over file system paths. This class is abstract, and the two implementations
     are :class:`LocalPath <plumbum.machines.local.LocalPath>` and
     :class:`RemotePath <plumbum.path.remote.RemotePath>`.

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -5,6 +5,8 @@ import warnings
 from abc import ABC, abstractmethod, abstractproperty
 from functools import reduce
 
+FLAGS = {"f": os.F_OK, "w": os.W_OK, "r": os.R_OK, "x": os.X_OK}
+
 
 class FSUser(int):
     """A special object that represents a file-system user. It derives from ``int``, so it behaves
@@ -324,9 +326,7 @@ class Path(str, ABC):
         """
 
     @staticmethod
-    def _access_mode_to_flags(
-        mode, flags={"f": os.F_OK, "w": os.W_OK, "r": os.R_OK, "x": os.X_OK}
-    ):
+    def _access_mode_to_flags(mode, flags=FLAGS):
         if isinstance(mode, str):
             mode = reduce(operator.or_, [flags[m] for m in mode.lower()], 0)
         return mode

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -371,7 +371,7 @@ class Path(str, ABC):
 
     @property
     def parts(self):
-        """Splits the directory into parts, including the base directroy, returns a tuple"""
+        """Splits the directory into parts, including the base directory, returns a tuple"""
         return tuple([self.drive + self.root] + self.split())
 
     def relative_to(self, source):

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import errno
 import glob
 import logging
@@ -58,8 +57,8 @@ class LocalPath(Path):
         if not parts:
             raise TypeError("At least one path part is required (none given)")
         if any(isinstance(path, RemotePath) for path in parts):
-            raise TypeError("LocalPath cannot be constructed from {!r}".format(parts))
-        self = super(LocalPath, cls).__new__(
+            raise TypeError(f"LocalPath cannot be constructed from {parts!r}")
+        self = super().__new__(
             cls, os.path.normpath(os.path.join(*(str(p) for p in parts)))
         )
         return self
@@ -193,14 +192,14 @@ class LocalPath(Path):
     @_setdoc(Path)
     def move(self, dst):
         if isinstance(dst, RemotePath):
-            raise TypeError("Cannot move local path {} to {!r}".format(self, dst))
+            raise TypeError(f"Cannot move local path {self} to {dst!r}")
         shutil.move(str(self), str(dst))
         return LocalPath(dst)
 
     @_setdoc(Path)
     def copy(self, dst, override=None):
         if isinstance(dst, RemotePath):
-            raise TypeError("Cannot copy local path {} to {!r}".format(self, dst))
+            raise TypeError(f"Cannot copy local path {self} to {dst!r}")
         dst = LocalPath(dst)
         if override is False and dst.exists():
             raise TypeError("File exists and override was not specified")
@@ -293,7 +292,7 @@ class LocalPath(Path):
     def link(self, dst):
         if isinstance(dst, RemotePath):
             raise TypeError(
-                "Cannot create a hardlink from local path {} to {!r}".format(self, dst)
+                f"Cannot create a hardlink from local path {self} to {dst!r}"
             )
         if hasattr(os, "link"):
             os.link(str(self), str(dst))
@@ -310,7 +309,7 @@ class LocalPath(Path):
     def symlink(self, dst):
         if isinstance(dst, RemotePath):
             raise TypeError(
-                "Cannot create a symlink from local path {} to {!r}".format(self, dst)
+                f"Cannot create a symlink from local path {self} to {dst!r}"
             )
         if hasattr(os, "symlink"):
             os.symlink(str(self), str(dst))
@@ -359,7 +358,7 @@ class LocalWorkdir(LocalPath):
         raise TypeError("unhashable type")
 
     def __new__(cls):
-        return super(LocalWorkdir, cls).__new__(cls, os.getcwd())
+        return super().__new__(cls, os.getcwd())
 
     def chdir(self, newdir):
         """Changes the current working directory to the given one
@@ -367,7 +366,7 @@ class LocalWorkdir(LocalPath):
         :param newdir: The destination director (a string or a ``LocalPath``)
         """
         if isinstance(newdir, RemotePath):
-            raise TypeError("newdir cannot be {!r}".format(newdir))
+            raise TypeError(f"newdir cannot be {newdir!r}")
         logger.debug("Chdir to %s", newdir)
         os.chdir(str(newdir))
         return self.__class__()

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 from contextlib import contextmanager
 
-from plumbum.lib import IS_WIN32, _setdoc, glob_escape
+from plumbum.lib import IS_WIN32, _setdoc
 from plumbum.path.base import FSUser, Path
 from plumbum.path.remote import RemotePath
 
@@ -165,7 +165,7 @@ class LocalPath(Path):
     @_setdoc(Path)
     def glob(self, pattern):
         fn = lambda pat: [
-            LocalPath(m) for m in glob.glob(os.path.join(glob_escape(str(self)), pat))
+            LocalPath(m) for m in glob.glob(os.path.join(glob.escape(str(self)), pat))
         ]
         return self._glob(pattern, fn)
 

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 from contextlib import contextmanager
 
-from plumbum.lib import IS_WIN32, _setdoc, glob_escape, six
+from plumbum.lib import IS_WIN32, _setdoc, glob_escape
 from plumbum.path.base import FSUser, Path
 from plumbum.path.remote import RemotePath
 
@@ -28,13 +28,8 @@ except ImportError:
         raise OSError("`getgrnam` not supported")
 
 
-try:  # Py3
-    import urllib.parse as urlparse
-    import urllib.request as urllib
-except ImportError:
-    import urllib  # type: ignore
-
-    import urlparse  # type: ignore
+import urllib.parse as urlparse
+import urllib.request as urllib
 
 logger = logging.getLogger("plumbum.local")
 
@@ -247,7 +242,7 @@ class LocalPath(Path):
         if encoding:
             data = data.encode(encoding)
         if mode is None:
-            if isinstance(data, six.unicode_type):
+            if isinstance(data, str):
                 mode = "w"
             else:
                 mode = "wb"

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -87,14 +87,14 @@ class RemotePath(Path):
     @property  # type: ignore
     @_setdoc(Path)
     def name(self):
-        if not "/" in str(self):
+        if "/" not in str(self):
             return str(self)
         return str(self).rsplit("/", 1)[1]
 
     @property  # type: ignore
     @_setdoc(Path)
     def dirname(self):
-        if not "/" in str(self):
+        if "/" not in str(self):
             return str(self)
         return self.__class__(self.remote, str(self).rsplit("/", 1)[0])
 
@@ -186,8 +186,8 @@ class RemotePath(Path):
             raise ValueError("Invalid suffix %r" % (suffix))
         name = self.name
         depth = len(self.suffixes) if depth is None else min(depth, len(self.suffixes))
-        for i in range(depth):
-            name, ext = name.rsplit(".", 1)
+        for _ in range(depth):
+            name, _ = name.rsplit(".", 1)
         return self.__class__(self.remote, self.dirname) / (name + suffix)
 
     @_setdoc(Path)

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -1,16 +1,12 @@
 import errno
 import os
 import sys
+import urllib.request as urllib
 from contextlib import contextmanager
 
 from plumbum.commands import ProcessExecutionError, shquote
-from plumbum.lib import _setdoc, six
+from plumbum.lib import _setdoc
 from plumbum.path.base import FSUser, Path
-
-try:  # Py3
-    import urllib.request as urllib
-except ImportError:
-    import urllib  # type: ignore
 
 
 class StatRes:
@@ -362,9 +358,7 @@ class RemoteWorkdir(RemotePath):
     """Remote working directory manipulator"""
 
     def __new__(cls, remote):
-        self = super().__new__(
-            cls, remote, remote._session.run("pwd")[1].strip()
-        )
+        self = super().__new__(cls, remote, remote._session.run("pwd")[1].strip())
         return self
 
     def __hash__(self):

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import errno
 import os
 import sys
@@ -14,7 +13,7 @@ except ImportError:
     import urllib  # type: ignore
 
 
-class StatRes(object):
+class StatRes:
     """POSIX-like stat result"""
 
     def __init__(self, tup):
@@ -73,10 +72,10 @@ class RemotePath(Path):
                 else:
                     normed.append(item)
         if windows:
-            self = super(RemotePath, cls).__new__(cls, "\\".join(normed))
+            self = super().__new__(cls, "\\".join(normed))
             self.CASE_SENSITIVE = False  # On this object only
         else:
-            self = super(RemotePath, cls).__new__(cls, "/" + "/".join(normed))
+            self = super().__new__(cls, "/" + "/".join(normed))
             self.CASE_SENSITIVE = True
 
         self.remote = remote
@@ -215,7 +214,7 @@ class RemotePath(Path):
         if isinstance(dst, RemotePath):
             if dst.remote is not self.remote:
                 raise TypeError("dst points to a different remote machine")
-        elif not isinstance(dst, six.string_types):
+        elif not isinstance(dst, str):
             raise TypeError(
                 "dst must be a string or a RemotePath (to the same remote machine), "
                 "got %r" % (dst,)
@@ -227,17 +226,17 @@ class RemotePath(Path):
         if isinstance(dst, RemotePath):
             if dst.remote is not self.remote:
                 raise TypeError("dst points to a different remote machine")
-        elif not isinstance(dst, six.string_types):
+        elif not isinstance(dst, str):
             raise TypeError(
                 "dst must be a string or a RemotePath (to the same remote machine), "
                 "got %r" % (dst,)
             )
         if override:
-            if isinstance(dst, six.string_types):
+            if isinstance(dst, str):
                 dst = RemotePath(self.remote, dst)
             dst.delete()
         else:
-            if isinstance(dst, six.string_types):
+            if isinstance(dst, str):
                 dst = RemotePath(self.remote, dst)
             if dst.exists():
                 raise TypeError("Override not specified and dst exists")
@@ -304,7 +303,7 @@ class RemotePath(Path):
         if isinstance(dst, RemotePath):
             if dst.remote is not self.remote:
                 raise TypeError("dst points to a different remote machine")
-        elif not isinstance(dst, six.string_types):
+        elif not isinstance(dst, str):
             raise TypeError(
                 "dst must be a string or a RemotePath (to the same remote machine), "
                 "got %r" % (dst,)
@@ -316,7 +315,7 @@ class RemotePath(Path):
         if isinstance(dst, RemotePath):
             if dst.remote is not self.remote:
                 raise TypeError("dst points to a different remote machine")
-        elif not isinstance(dst, six.string_types):
+        elif not isinstance(dst, str):
             raise TypeError(
                 "dst must be a string or a RemotePath (to the same remote machine), "
                 "got %r" % (dst,)
@@ -363,7 +362,7 @@ class RemoteWorkdir(RemotePath):
     """Remote working directory manipulator"""
 
     def __new__(cls, remote):
-        self = super(RemoteWorkdir, cls).__new__(
+        self = super().__new__(
             cls, remote, remote._session.run("pwd")[1].strip()
         )
         return self
@@ -373,7 +372,7 @@ class RemoteWorkdir(RemotePath):
 
     def chdir(self, newdir):
         """Changes the current working directory to the given one"""
-        self.remote._session.run("cd {}".format(shquote(newdir)))
+        self.remote._session.run(f"cd {shquote(newdir)}")
         if hasattr(self.remote, "_cwd"):
             del self.remote._cwd
         return self.__class__(self.remote)

--- a/plumbum/path/utils.py
+++ b/plumbum/path/utils.py
@@ -1,6 +1,5 @@
 import os
 
-from plumbum.lib import six
 from plumbum.machines.local import LocalPath, local
 from plumbum.path.base import Path
 

--- a/plumbum/path/utils.py
+++ b/plumbum/path/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from plumbum.lib import six
@@ -15,12 +14,12 @@ def delete(*paths):
     for p in paths:
         if isinstance(p, Path):
             p.delete()
-        elif isinstance(p, six.string_types):
+        elif isinstance(p, str):
             local.path(p).delete()
         elif hasattr(p, "__iter__"):
             delete(*p)
         else:
-            raise TypeError("Cannot delete {!r}".format(p))
+            raise TypeError(f"Cannot delete {p!r}")
 
 
 def _move(src, dst):
@@ -45,7 +44,7 @@ def move(src, dst):
             dst.mkdir()
         elif not dst.is_dir():
             raise ValueError(
-                "When using multiple sources, dst {!r} must be a directory".format(dst)
+                f"When using multiple sources, dst {dst!r} must be a directory"
             )
         for src2 in src:
             move(src2, dst)
@@ -83,7 +82,7 @@ def copy(src, dst):
             dst.mkdir()
         elif not dst.is_dir():
             raise ValueError(
-                "When using multiple sources, dst {!r} must be a directory".format(dst)
+                f"When using multiple sources, dst {dst!r} must be a directory"
             )
         for src2 in src:
             copy(src2, dst)

--- a/plumbum/typed_env.py
+++ b/plumbum/typed_env.py
@@ -162,7 +162,7 @@ class TypedEnv(MutableMapping):
         if self._defined_keys:
             # return only defined
             return sorted(self._defined_keys)
-        # return whatever is in the environemnt (for convenience)
+        # return whatever is in the environment (for convenience)
         members = set(self._env.keys())
         members.update(dir(self.__class__))
         return sorted(members)

--- a/plumbum/typed_env.py
+++ b/plumbum/typed_env.py
@@ -1,11 +1,6 @@
 import inspect
 import os
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
-
+from collections.abc import MutableMapping
 
 NO_DEFAULT = object()
 
@@ -152,9 +147,7 @@ class TypedEnv(MutableMapping):
         try:
             return self._raw_get(name)
         except EnvironmentVariableError:
-            raise AttributeError(
-                f"{self.__class__} has no attribute {name!r}"
-            )
+            raise AttributeError(f"{self.__class__} has no attribute {name!r}")
 
     def __getitem__(self, key):
         return getattr(self, key)  # delegate through the descriptors

--- a/plumbum/typed_env.py
+++ b/plumbum/typed_env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import inspect
 import os
 
@@ -47,7 +46,7 @@ class TypedEnv(MutableMapping):
 
     __slots__ = ["_env", "_defined_keys"]
 
-    class _BaseVar(object):
+    class _BaseVar:
         def __init__(self, name, default=NO_DEFAULT):
             self.names = tuple(name) if isinstance(name, (tuple, list)) else (name,)
             self.name = self.names[0]
@@ -81,7 +80,7 @@ class TypedEnv(MutableMapping):
         def convert(self, s):
             s = s.lower()
             if s not in ("yes", "no", "true", "false", "1", "0"):
-                raise ValueError("Unrecognized boolean value: {!r}".format(s))
+                raise ValueError(f"Unrecognized boolean value: {s!r}")
             return s in ("yes", "true", "1")
 
         def __set__(self, instance, value):
@@ -154,7 +153,7 @@ class TypedEnv(MutableMapping):
             return self._raw_get(name)
         except EnvironmentVariableError:
             raise AttributeError(
-                "{} has no attribute {!r}".format(self.__class__, name)
+                f"{self.__class__} has no attribute {name!r}"
             )
 
     def __getitem__(self, key):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ warn_unused_ignores = true
 
 
 [[tool.mypy.overrides]]
-module = ["IPython.*", "pywintypes.*", "win32con.*", "win32file.*", "PIL.*"]
+module = ["IPython.*", "pywintypes.*", "win32con.*", "win32file.*", "PIL.*", "plumbum.cmd.*", "ipywidgets.*", "traitlets.*", "plumbum.version"]
 ignore_missing_imports = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ write_to = "plumbum/version.py"
 
 [tool.mypy]
 files = ["plumbum"]
-python_version = "2.7"
+python_version = "3.6"
 warn_unused_configs = true
 warn_unused_ignores = true
 
@@ -20,3 +20,31 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = ["IPython.*", "pywintypes.*", "win32con.*", "win32file.*", "PIL.*"]
 ignore_missing_imports = true
+
+
+[tool.pytest.ini_options]
+min_version = "6.0"
+addopts = "-v -ra --cov-config=setup.cfg"
+norecursedirs = ["examples", "experiments"]
+required_plugins = ["pytest-timeout", "pytest-mock"]
+timeout = 300
+optional_tests = """
+  ssh: requires self ssh access to run
+  sudo: requires sudo access to run
+"""
+
+[tool.isort]
+profile = "black"
+
+[tool.check-manifest]
+ignore = [
+  ".*",
+  "docs/**",
+  "examples/*",
+  "experiments/*",
+  "conda.recipe/*",
+  "CONTRIBUTING.rst",
+]
+
+[tool.pycln]
+all = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,27 +51,18 @@ exclude =
 dev =
     paramiko
     psutil
-    pytest
+    pytest>=6.0
     pytest-cov
     pytest-mock
     pytest-timeout
 docs =
-    Sphinx>=3.0.0
-    sphinx-rtd-theme>=0.5.0
+    Sphinx>=4.0.0
+    sphinx-rtd-theme>=1.0.0
 ssh =
     paramiko
 
 [options.package_data]
 plumbum.cli = i18n/*/LC_MESSAGES/*.mo
-
-[tool:pytest]
-addopts = -v -ra --cov-config=setup.cfg
-norecursedirs = examples experiments
-required_plugins = pytest-timeout pytest-mock
-timeout = 300
-optional_tests =
-    ssh: requires self ssh access to run
-    sudo: requires sudo access to run
 
 [coverage:run]
 branch = True
@@ -93,17 +84,5 @@ exclude_lines =
 
 [flake8]
 max-complexity = 50
-ignore = E203, E231, E501, E722, W503, B950, B904, B003, B008, E731, B902
+extend-ignore = E203, E501, E722, B950
 select = C,E,F,W,B,B9
-
-[tool:isort]
-profile = black
-
-[check-manifest]
-ignore =
-    .*
-    docs/**
-    examples/*
-    experiments/*
-    conda.recipe/*
-    CONTRIBUTING.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,8 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -43,7 +41,7 @@ provides = plumbum
 packages = find:
 install_requires =
     pywin32;platform_system=='Windows' and platform_python_implementation!="PyPy"
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.6
 
 [options.packages.find]
 exclude =
@@ -65,9 +63,6 @@ ssh =
 
 [options.package_data]
 plumbum.cli = i18n/*/LC_MESSAGES/*.mo
-
-[bdist_wheel]
-universal = 1
 
 [tool:pytest]
 addopts = -v -ra --cov-config=setup.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,5 +84,5 @@ exclude_lines =
 
 [flake8]
 max-complexity = 50
-extend-ignore = E203, E501, E722, B950
+extend-ignore = E203, E501, E722, B950, E731
 select = C,E,F,W,B,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,3 +86,7 @@ exclude_lines =
 max-complexity = 50
 extend-ignore = E203, E501, E722, B950, E731
 select = C,E,F,W,B,B9
+
+[codespell]
+ignore-words-list = ans,switchs,hart,ot,twoo,fo
+skip = *.po

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from setuptools import setup
 

--- a/tests/_test_paramiko.py
+++ b/tests/_test_paramiko.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from plumbum import local
 from plumbum.paramiko_machine import ParamikoMachine as PM
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ import pytest
 
 _logger = logging.getLogger(__name__)
 
-marker_re = re.compile(r"^(?P<marker>\w+)(:\s*(?P<description>.*))?")
+marker_re = re.compile(r"^\s*(?P<marker>\w+)(:\s*(?P<description>.*))?")
 
 
 def pytest_addoption(parser):
@@ -74,7 +74,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     # register all optional tests declared in ini file as markers
     # https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers
-    ot_ini = config.inicfg.get("optional_tests").splitlines()
+    ot_ini = config.inicfg.get("optional_tests").strip().splitlines()
     for ot in ot_ini:
         # ot should be a line like "optmarker: this is an opt marker", as with markers section
         config.addinivalue_line("markers", ot)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import itertools
+import logging
 import os
+import re
 import tempfile
 
 import pytest
@@ -46,12 +49,6 @@ THE SOFTWARE.
 """
 
 
-import itertools
-import logging
-import re
-
-import pytest
-
 _logger = logging.getLogger(__name__)
 
 marker_re = re.compile(r"^\s*(?P<marker>\w+)(:\s*(?P<description>.*))?")
@@ -78,7 +75,7 @@ def pytest_configure(config):
     for ot in ot_ini:
         # ot should be a line like "optmarker: this is an opt marker", as with markers section
         config.addinivalue_line("markers", ot)
-    ot_markers = {marker_re.match(l).group(1) for l in ot_ini}
+    ot_markers = {marker_re.match(ln).group(1) for ln in ot_ini}
 
     # collect requested optional tests
     ot_run = config.getoption("run_optional_tests")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,7 @@
 import os
-import sys
 import tempfile
 
 import pytest
-
-if sys.version_info[0] < 3:
-    collect_ignore = ["test_3_cli.py"]
 
 SDIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,9 +72,9 @@ def pytest_configure(config):
     # register all optional tests declared in ini file as markers
     # https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers
     ot_ini = config.inicfg.get("optional_tests").strip().splitlines()
-    for ot in ot_ini:
+    for ot_ in ot_ini:
         # ot should be a line like "optmarker: this is an opt marker", as with markers section
-        config.addinivalue_line("markers", ot)
+        config.addinivalue_line("markers", ot_)
     ot_markers = {marker_re.match(ln).group(1) for ln in ot_ini}
 
     # collect requested optional tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 import tempfile

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import platform
 import sys

--- a/tests/env.py
+++ b/tests/env.py
@@ -9,9 +9,5 @@ WIN = sys.platform.startswith("win32") or sys.platform.startswith("cygwin")
 CPYTHON = platform.python_implementation() == "CPython"
 PYPY = platform.python_implementation() == "PyPy"
 
-PY2 = sys.version_info.major == 2
-
-PY = sys.version_info
-
 IS_A_TTY = sys.stdin.isatty()
 HAS_CHOWN = hasattr(os, "chown")

--- a/tests/test_3_cli.py
+++ b/tests/test_3_cli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from plumbum import cli
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,3 @@
-import sys
-
-import pytest
-
 from plumbum import cli, local
 from plumbum.cli.terminal import get_terminal_size
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 
 import pytest
@@ -57,7 +56,7 @@ class Geet(cli.Application):
 
     def cleanup(self, retcode):
         self.cleanups.append(1)
-        print("geet cleaning up with rc = {}".format(retcode))
+        print(f"geet cleaning up with rc = {retcode}")
 
 
 @Geet.subcommand("add")
@@ -78,7 +77,7 @@ class GeetCommit(cli.Application):
 
     def cleanup(self, retcode):
         self.parent.cleanups.append(2)
-        print("geet commit cleaning up with rc = {}".format(retcode))
+        print(f"geet commit cleaning up with rc = {retcode}")
 
 
 class Sample(cli.Application):

--- a/tests/test_clicolor.py
+++ b/tests/test_clicolor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from plumbum import cli, colors
 
 colors.use_color = 3

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,9 +1,12 @@
-import pytest
-
 # Just check to see if this file is importable
-from plumbum.cli.image import Image
+from plumbum.cli.image import Image  # noqa: F401
 from plumbum.colorlib.names import FindNearest, color_html
-from plumbum.colorlib.styles import ANSIStyle, AttributeNotFound, Color, ColorNotFound
+from plumbum.colorlib.styles import (  # noqa: F401
+    ANSIStyle,
+    AttributeNotFound,
+    Color,
+    ColorNotFound,
+)
 
 
 class TestNearestColor:
@@ -61,7 +64,7 @@ class TestANSIColor:
         assert str(ANSIStyle(fgcolor=Color.from_simple("red"))) == "\033[31m"
 
 
-class TestNearestColor:
+class TestNearestColorAgain:
     def test_allcolors(self):
         myrange = (
             0,

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -86,6 +86,4 @@ class TestNearestColor:
             for g in myrange:
                 for b in myrange:
                     near = FindNearest(r, g, b)
-                    assert (
-                        near.all_slow() == near.all_fast()
-                    ), f"Tested: {r}, {g}, {b}"
+                    assert near.all_slow() == near.all_fast(), f"Tested: {r}, {g}, {b}"

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 # Just check to see if this file is importable
@@ -89,4 +88,4 @@ class TestNearestColor:
                     near = FindNearest(r, g, b)
                     assert (
                         near.all_slow() == near.all_fast()
-                    ), "Tested: {}, {}, {}".format(r, g, b)
+                    ), f"Tested: {r}, {g}, {b}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import pytest
 
 from plumbum import local

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,7 +71,7 @@ two = hello""",
             mypath.unlink()
 
     def test_notouch(self):
-        conf = ConfigINI(fname)
+        ConfigINI(fname)
         assert not local.path(fname).exists()
 
     def test_only_string(self):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 import plumbum

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,3 @@
-import pytest
-
-import plumbum
 from plumbum import local
 from plumbum._testtools import skip_on_windows
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-
 import pytest
 
 from plumbum import colors
@@ -12,7 +10,6 @@ from plumbum.colorlib.styles import ColorNotFound
 
 class TestImportColors:
     def testDifferentImports(self):
-        import plumbum.colors
         from plumbum.colors import bold
         from plumbum.colors.fg import red
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 
 import sys
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -21,12 +21,7 @@ from plumbum import (
     ProcessTimedOut,
     local,
 )
-from plumbum._testtools import (
-    skip_on_windows,
-    skip_without_chown,
-    skip_without_tty,
-    xfail_on_pypy,
-)
+from plumbum._testtools import skip_on_windows, skip_without_chown, skip_without_tty
 from plumbum.fs.atomic import AtomicCounterFile, AtomicFile, PidFile
 from plumbum.lib import IS_WIN32
 from plumbum.machines.local import LocalCommand, PlumbumLocalPopen
@@ -93,7 +88,7 @@ class TestLocalPath:
 
     def test_split(self):
         p = local.path("/var/log/messages")
-        p.split() == ["var", "log", "messages"]
+        assert p.split() == ["var", "log", "messages"]
 
     def test_suffix(self):
         # This picks up the drive letter differently if not constructed here
@@ -330,7 +325,9 @@ class TestLocalMachine:
             local["non_exist1N9"]()
 
         with pytest.raises(ImportError):
-            from plumbum.cmd import non_exist1N9  # @UnresolvedImport @UnusedImport
+            from plumbum.cmd import non_exist1N9
+
+            assert non_exist1N9
 
     def test_get(self):
         assert str(local["ls"]) == str(local.get("ls"))
@@ -457,8 +454,6 @@ class TestLocalMachine:
             assert p == local.cwd / "not-in-path" / "dummy-executable"
 
     def test_local(self):
-        from plumbum.cmd import cat, head
-
         assert "plumbum" in str(local.cwd)
         assert "PATH" in local.env.getdict()
         assert local.path("foo") == os.path.join(os.getcwd(), "foo")
@@ -579,7 +574,7 @@ class TestLocalMachine:
         from plumbum.cmd import ls
 
         with pytest.raises(ProcessExecutionError) as err:
-            for i, lines in enumerate(ls["--bla"].popen()):
+            for i, _lines in enumerate(ls["--bla"].popen()):  # noqa: B007
                 pass
             assert i == 1
         assert (
@@ -720,8 +715,6 @@ class TestLocalMachine:
         assert execinfo.value.argv[-2:] == ["-a", ""]
 
     def test_tempdir(self):
-        from plumbum.cmd import cat
-
         with local.tempdir() as dir:
             assert dir.is_dir()
             data = b"hello world"
@@ -733,8 +726,6 @@ class TestLocalMachine:
         assert not dir.exists()
 
     def test_direct_open_tmpdir(self):
-        from plumbum.cmd import cat
-
         with local.tempdir() as dir:
             assert dir.is_dir()
             data = b"hello world"
@@ -939,7 +930,7 @@ for _ in range({}):
         c = ls["-l", ["-a", "*.py"]]
         assert c.formulate()[1:] == ["-l", "-a", "*.py"]
 
-    def test_contains(self):
+    def test_contains_ls(self):
         assert "ls" in local
 
     def test_issue_139(self):
@@ -998,7 +989,7 @@ for _ in range({}):
         from plumbum.cmd import ls
 
         f = ls["-l"].run_tf()
-        assert f == True
+        assert f is True
 
     def test_run_retcode(self):
         from plumbum.cmd import ls
@@ -1033,8 +1024,6 @@ class TestLocalEncoding:
 
     @pytest.mark.usefixtures("cleandir")
     def test_out_rich(self):
-        import io
-
         from plumbum.cmd import cat
 
         with open("temp.txt", "w", encoding="utf8") as f:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import pickle
 import signal
@@ -55,7 +54,7 @@ class TestLocalPath:
 
     def test_name(self):
         name = self.longpath.name
-        assert isinstance(name, six.string_types)
+        assert isinstance(name, str)
         assert "file.txt" == str(name)
 
     def test_dirname(self):
@@ -89,7 +88,7 @@ class TestLocalPath:
     def test_chown(self):
         with local.tempdir() as dir:
             p = dir / "foo.txt"
-            p.write(six.b("hello"))
+            p.write(b"hello")
             assert p.uid == os.getuid()
             assert p.gid == os.getgid()
             p.chown(p.uid.name)
@@ -154,7 +153,7 @@ class TestLocalPath:
     def test_read_write(self):
         with local.tempdir() as dir:
             f = dir / "test.txt"
-            text = six.b("hello world\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d").decode("utf8")
+            text = b"hello world\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d".decode("utf8")
             f.write(text, "utf8")
             text2 = f.read("utf8")
             assert text == text2
@@ -640,7 +639,7 @@ class TestLocalMachine:
     def test_tee_race(self, capfd):
         from plumbum.cmd import seq
 
-        EXPECT = "".join("{}\n".format(i) for i in range(1, 5001))
+        EXPECT = "".join(f"{i}\n" for i in range(1, 5001))
         for _ in range(5):
             result = seq["1", "5000"] & TEE
             assert result[1] == EXPECT
@@ -736,7 +735,7 @@ class TestLocalMachine:
 
         with local.tempdir() as dir:
             assert dir.is_dir()
-            data = six.b("hello world")
+            data = b"hello world"
             with open(str(dir / "test.txt"), "wb") as f:
                 f.write(data)
             with open(str(dir / "test.txt"), "rb") as f:
@@ -749,7 +748,7 @@ class TestLocalMachine:
 
         with local.tempdir() as dir:
             assert dir.is_dir()
-            data = six.b("hello world")
+            data = b"hello world"
             with open(dir / "test.txt", "wb") as f:
                 f.write(data)
             with open(dir / "test.txt", "rb") as f:
@@ -765,13 +764,13 @@ class TestLocalMachine:
 
     def test_read_write_unicode(self):
         with local.tempdir() as tmp:
-            data = six.u("hello world")
+            data = "hello world"
             (tmp / "foo.txt").write(data)
             assert (tmp / "foo.txt").read() == data
 
     def test_read_write_bin(self):
         with local.tempdir() as tmp:
-            data = six.b("hello world")
+            data = b"hello world"
             (tmp / "foo.txt").write(data)
             assert (tmp / "foo.txt").read(mode="rb") == data
 
@@ -840,10 +839,10 @@ class TestLocalMachine:
     def test_atomic_file(self):
         af1 = AtomicFile("tmp.txt")
         af2 = AtomicFile("tmp.txt")
-        af1.write_atomic(six.b("foo"))
-        af2.write_atomic(six.b("bar"))
-        assert af1.read_atomic() == six.b("bar")
-        assert af2.read_atomic() == six.b("bar")
+        af1.write_atomic(b"foo")
+        af2.write_atomic(b"bar")
+        assert af1.read_atomic() == b"bar"
+        assert af2.read_atomic() == b"bar"
         local.path("tmp.txt").delete()
 
     @skip_on_windows
@@ -1053,7 +1052,7 @@ class TestLocalEncoding:
 
         from plumbum.cmd import cat
 
-        with io.open("temp.txt", "w", encoding="utf8") as f:
+        with open("temp.txt", "w", encoding="utf8") as f:
             f.write(self.richstr)
         out = cat("temp.txt")
         assert self.richstr in out
@@ -1067,7 +1066,7 @@ class TestLocalEncoding:
 
         name = self.richstr + six.str("_program")
         with open(name, "w") as f:
-            f.write("#!{}\nprint('yes')".format(sys.executable))
+            f.write(f"#!{sys.executable}\nprint('yes')")
 
         st = os.stat(name)
         os.chmod(name, st.st_mode | stat.S_IEXEC)

--- a/tests/test_nohup.py
+++ b/tests/test_nohup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import time
 

--- a/tests/test_putty.py
+++ b/tests/test_putty.py
@@ -1,6 +1,5 @@
 """Test that PuttyMachine initializes its SshMachine correctly"""
 
-import env
 import pytest
 
 from plumbum import PuttyMachine, SshMachine
@@ -12,7 +11,6 @@ def ssh_port(request):
 
 
 class TestPuttyMachine:
-    @pytest.mark.skipif(env.PYPY & env.PY2, reason="PyPy2 doesn't support mocker.spy")
     def test_putty_command(self, mocker, ssh_port):
         local = mocker.patch("plumbum.machines.ssh_machine.local")
         init = mocker.spy(SshMachine, "__init__")

--- a/tests/test_putty.py
+++ b/tests/test_putty.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test that PuttyMachine initializes its SshMachine correctly"""
 
 import env
@@ -67,4 +66,4 @@ class TestPuttyMachine:
         user = local.env.user
 
         machine = PuttyMachine(host)
-        assert str(machine) == "putty-ssh://{}@{}".format(user, host)
+        assert str(machine) == f"putty-ssh://{user}@{host}"

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import os
 import socket
@@ -93,7 +92,7 @@ class TestRemotePath:
 
     def test_name(self):
         name = RemotePath(self._connect(), "/some/long/path/to/file.txt").name
-        assert isinstance(name, six.string_types)
+        assert isinstance(name, str)
         assert "file.txt" == str(name)
 
     def test_dirname(self):
@@ -154,7 +153,7 @@ class TestRemotePath:
         with self._connect() as rem:
             with rem.tempdir() as dir:
                 p = dir / "foo.txt"
-                p.write(six.b("hello"))
+                p.write(b"hello")
                 # because we're connected to localhost, we expect UID and GID to be the same
                 assert p.uid == os.getuid()
                 assert p.gid == os.getgid()
@@ -271,7 +270,7 @@ class TestRemotePath:
             assert not tmp.exists()
 
 
-class BaseRemoteMachineTest(object):
+class BaseRemoteMachineTest:
     TUNNEL_PROG_AF_INET = r"""import sys, socket
 s = socket.socket()
 s.bind(("", 0))
@@ -408,7 +407,7 @@ s.close()
         with self._connect() as rem:
             with rem.tempdir() as dir:
                 assert dir.is_dir()
-                data = six.b("hello world")
+                data = b"hello world"
                 (dir / "foo.txt").write(data)
                 assert (dir / "foo.txt").read() == data
 
@@ -484,7 +483,7 @@ class TestRemoteMachine(BaseRemoteMachineTest):
                 with rem.tunnel(12222, port_or_socket, dhost=dhost) as tun:
                     s = socket.socket()
                     s.connect(("localhost", 12222))
-                    s.send(six.b("world"))
+                    s.send(b"world")
                     data = s.recv(100)
                     s.close()
 
@@ -633,7 +632,7 @@ class TestParamikoMachine(BaseRemoteMachineTest):
                 with local.tempdir() as tmpdir:
                     assert remote_tmpdir.is_dir()
                     assert tmpdir.is_dir()
-                    data = six.b("hello world")
+                    data = b"hello world"
                     with (remote_tmpdir / "bar.txt").open("wb") as f:
                         f.write(data)
                     rem.download((remote_tmpdir / "bar.txt"), (tmpdir / "bar.txt"))
@@ -649,7 +648,7 @@ class TestParamikoMachine(BaseRemoteMachineTest):
                 with local.tempdir() as tmpdir:
                     assert remote_tmpdir.is_dir()
                     assert tmpdir.is_dir()
-                    data = six.b("hello world")
+                    data = b"hello world"
                     with (tmpdir / "bar.txt").open("wb") as f:
                         f.write(data)
                     rem.upload((tmpdir / "bar.txt"), (remote_tmpdir / "bar.txt"))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -3,7 +3,6 @@ import os
 import socket
 import sys
 import time
-from copy import deepcopy
 from multiprocessing import Queue
 from threading import Thread
 
@@ -416,7 +415,7 @@ s.close()
     def test_iter_lines_timeout(self):
         with self._connect() as rem:
             try:
-                for i, (out, err) in enumerate(
+                for i, (out, err) in enumerate(  # noqa: B007
                     rem["ping"]["-i", 0.5, "127.0.0.1"].popen().iter_lines(timeout=4)
                 ):
                     print("out:", out)
@@ -434,7 +433,7 @@ s.close()
     def test_iter_lines_error(self):
         with self._connect() as rem:
             with pytest.raises(ProcessExecutionError) as ex:
-                for i, lines in enumerate(rem["ls"]["--bla"].popen()):
+                for i, _lines in enumerate(rem["ls"]["--bla"].popen()):  # noqa: B007
                     pass
                 assert i == 1
             assert "/bin/ls: " in ex.value.stderr
@@ -476,7 +475,7 @@ class TestRemoteMachine(BaseRemoteMachineTest):
                 except ValueError:
                     dhost = None
 
-                with rem.tunnel(12222, port_or_socket, dhost=dhost) as tun:
+                with rem.tunnel(12222, port_or_socket, dhost=dhost):
                     s = socket.socket()
                     s.connect(("localhost", 12222))
                     s.send(b"world")
@@ -603,7 +602,7 @@ class TestParamikoMachine(BaseRemoteMachineTest):
     def test_piping(self):
         with self._connect() as rem:
             try:
-                cmd = rem["ls"] | rem["cat"]
+                rem["ls"] | rem["cat"]
             except NotImplementedError:
                 pass
             else:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -21,7 +21,6 @@ from plumbum import (
     local,
 )
 from plumbum._testtools import skip_on_windows, skip_without_chown
-from plumbum.lib import six
 from plumbum.machines.session import HostPublicKeyUnknown, IncorrectLogin
 
 try:
@@ -58,9 +57,6 @@ def test_connection():
     SshMachine(TEST_HOST)
 
 
-@pytest.mark.skip(
-    env.LINUX and env.PY[:2] == (3, 5), reason="Doesn't work on 3.5 on Linux on GHA"
-)
 def test_incorrect_login(sshpass):
     with pytest.raises(IncorrectLogin):
         SshMachine(

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -621,33 +621,28 @@ class TestParamikoMachine(BaseRemoteMachineTest):
 
     def test_path_open_remote_write_local_read(self):
         with self._connect() as rem:
-            # TODO: once Python 2.6 support is dropped, the nested
-            # with-statements below can be combined using "with x as a, y as b"
-            with rem.tempdir() as remote_tmpdir:
-                with local.tempdir() as tmpdir:
-                    assert remote_tmpdir.is_dir()
-                    assert tmpdir.is_dir()
-                    data = b"hello world"
-                    with (remote_tmpdir / "bar.txt").open("wb") as f:
-                        f.write(data)
-                    rem.download((remote_tmpdir / "bar.txt"), (tmpdir / "bar.txt"))
-                    assert (tmpdir / "bar.txt").open("rb").read() == data
+            with rem.tempdir() as remote_tmpdir, local.tempdir() as tmpdir:
+                assert remote_tmpdir.is_dir()
+                assert tmpdir.is_dir()
+                data = b"hello world"
+                with (remote_tmpdir / "bar.txt").open("wb") as f:
+                    f.write(data)
+                rem.download((remote_tmpdir / "bar.txt"), (tmpdir / "bar.txt"))
+                assert (tmpdir / "bar.txt").open("rb").read() == data
 
             assert not remote_tmpdir.exists()
             assert not tmpdir.exists()
 
     def test_path_open_local_write_remote_read(self):
         with self._connect() as rem:
-            # TODO: cf. note on Python 2.6 support above
-            with rem.tempdir() as remote_tmpdir:
-                with local.tempdir() as tmpdir:
-                    assert remote_tmpdir.is_dir()
-                    assert tmpdir.is_dir()
-                    data = b"hello world"
-                    with (tmpdir / "bar.txt").open("wb") as f:
-                        f.write(data)
-                    rem.upload((tmpdir / "bar.txt"), (remote_tmpdir / "bar.txt"))
-                    assert (remote_tmpdir / "bar.txt").open("rb").read() == data
+            with rem.tempdir() as remote_tmpdir, local.tempdir() as tmpdir:
+                assert remote_tmpdir.is_dir()
+                assert tmpdir.is_dir()
+                data = b"hello world"
+                with (tmpdir / "bar.txt").open("wb") as f:
+                    f.write(data)
+                rem.upload((tmpdir / "bar.txt"), (remote_tmpdir / "bar.txt"))
+                assert (remote_tmpdir / "bar.txt").open("rb").read() == data
 
             assert not remote_tmpdir.exists()
             assert not tmpdir.exists()

--- a/tests/test_sudo.py
+++ b/tests/test_sudo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from plumbum import local

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,22 +1,12 @@
 import sys
 import time
+from collections import OrderedDict
 from contextlib import contextmanager
+from io import StringIO
 
 import pytest
 
 from plumbum.cli.terminal import Progress, ask, choose, hexdump, prompt
-from plumbum.lib import StringIO
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    try:
-        from ordereddict import OrderedDict
-    except ImportError:
-        OrderedDict = None
-needs_od = pytest.mark.skipif(
-    OrderedDict is None, reason="Ordered dict not available (Py 2.6)"
-)
 
 
 @contextmanager
@@ -118,7 +108,6 @@ class TestTerminal:
             value = choose("Pick", dict(one="a", two="b"))
             assert value in ("a", "b")
 
-    @needs_od
     def test_ordered_dict(self):
         dic = OrderedDict()
         dic["one"] = "a"
@@ -130,7 +119,6 @@ class TestTerminal:
             value = choose("Pick", dic)
             assert value == "b"
 
-    @needs_od
     def test_choose_dict_default(self, capsys):
         dic = OrderedDict()
         dic["one"] = "a"

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,10 +1,7 @@
 import sys
-import time
 from collections import OrderedDict
 from contextlib import contextmanager
 from io import StringIO
-
-import pytest
 
 from plumbum.cli.terminal import Progress, ask, choose, hexdump, prompt
 
@@ -141,9 +138,9 @@ class TestTerminal:
         assert "\n".join(hexdump(StringIO(data))) == output
 
     def test_progress(self, capsys):
-        for i in Progress.range(4, has_output=True, timer=False):
+        for _ in Progress.range(4, has_output=True, timer=False):
             print("hi")
-        stdout, stderr = capsys.readouterr()
+        stdout, _stderr = capsys.readouterr()
         output = """\
 0% complete
 0% complete
@@ -160,8 +157,8 @@ hi
         assert stdout == output
 
     def test_progress_empty(self, capsys):
-        for i in Progress.range(0, has_output=True, timer=False):
+        for _ in Progress.range(0, has_output=True, timer=False):
             print("hi")
-        stdout, stderr = capsys.readouterr()
+        stdout = capsys.readouterr().out
         output = "0/0 complete"
         assert output in stdout

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import time
 from contextlib import contextmanager

--- a/tests/test_typed_env.py
+++ b/tests/test_typed_env.py
@@ -8,7 +8,7 @@ class TestTypedEnv:
         class E(TypedEnv):
             terminal = TypedEnv.Str("TERM")
             B = TypedEnv.Bool("BOOL", default=True)
-            I = TypedEnv.Int("INT INTEGER".split())
+            I = TypedEnv.Int("INT INTEGER".split())  # noqa: E741  # noqa: E741
             INTS = TypedEnv.CSV("CS_INTS", type=int)
 
         raw_env = dict(TERM="xterm", CS_INTS="1,2,3,4")
@@ -44,12 +44,12 @@ class TestTypedEnv:
             e.I
 
         raw_env["INTEGER"] = "4"
-        assert e.I == 4
+        assert e.I == 4  # noqa: E741
         assert e["I"] == 4
 
-        e.I = "5"
+        e.I = "5"  # noqa: E741
         assert raw_env["INT"] == "5"
-        assert e.I == 5
+        assert e.I == 5  # noqa: E741
         assert e["I"] == 5
 
         assert "{I} {B} {terminal}".format(**e) == "5 False foo"

--- a/tests/test_typed_env.py
+++ b/tests/test_typed_env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from plumbum.typed_env import TypedEnv

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from plumbum import SshMachine, local

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function
-
 from plumbum import cli
 
 
 class TestValidator:
     def test_named(self):
-        class Try(object):
+        class Try:
             @cli.positional(x=abs, y=str)
             def main(selfy, x, y):
                 pass
@@ -15,7 +12,7 @@ class TestValidator:
         assert Try.main.positional_varargs is None
 
     def test_position(self):
-        class Try(object):
+        class Try:
             @cli.positional(abs, str)
             def main(selfy, x, y):
                 pass
@@ -24,7 +21,7 @@ class TestValidator:
         assert Try.main.positional_varargs is None
 
     def test_mix(self):
-        class Try(object):
+        class Try:
             @cli.positional(abs, str, d=bool)
             def main(selfy, x, y, z, d):
                 pass
@@ -33,7 +30,7 @@ class TestValidator:
         assert Try.main.positional_varargs is None
 
     def test_var(self):
-        class Try(object):
+        class Try:
             @cli.positional(abs, str, int)
             def main(selfy, x, y, *g):
                 pass
@@ -42,7 +39,7 @@ class TestValidator:
         assert Try.main.positional_varargs is int
 
     def test_defaults(self):
-        class Try(object):
+        class Try:
             @cli.positional(abs, str)
             def main(selfy, x, y="hello"):
                 pass

--- a/tests/test_visual_color.py
+++ b/tests/test_visual_color.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function
 
 import os
 import unittest

--- a/translations.py
+++ b/translations.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # If you are on macOS and using brew, you might need the following first:
 # export PATH="/usr/local/opt/gettext/bin:$PATH"


### PR DESCRIPTION
Good bye, Python 2.7 and 3.5! (Today 3.6 hit EOL, we are behind).