### PR TITLE
refactor: use pylint and fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3
+    - name: pylint
+      run: pipx run nox -s pylint
 
   tests:
     name: Tests on 🐍 ${{ matrix.python-version }} ${{ matrix.os }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,16 @@ def lint(session):
     session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
+@nox.session
+def pylint(session):
+    """
+    Run pylint.
+    """
+
+    session.install(".", "paramiko", "ipython", "pylint")
+    session.run("pylint", "plumbum", *session.posargs)
+
+
 @nox.session(python=ALL_PYTHONS, reuse_venv=True)
 def tests(session):
     """

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -35,6 +35,10 @@ of command-line interface (CLI) programs.
 See https://plumbum.readthedocs.io for full details
 """
 
+import sys
+from types import ModuleType
+from typing import List
+
 # Avoids a circular import error later
 import plumbum.path  # noqa: F401
 from plumbum.commands import (
@@ -83,10 +87,8 @@ __all__ = (
 
 # ===================================================================================================
 # Module hack: ``from plumbum.cmd import ls``
+# Can be replaced by a real module with __getattr__ after Python 3.6 is dropped
 # ===================================================================================================
-import sys
-from types import ModuleType
-from typing import List
 
 
 class LocalModule(ModuleType):
@@ -99,7 +101,7 @@ class LocalModule(ModuleType):
         try:
             return local[name]
         except CommandNotFound:
-            raise AttributeError(name)
+            raise AttributeError(name) from None
 
     __path__ = []  # type: List[str]
     __file__ = __file__
@@ -107,10 +109,6 @@ class LocalModule(ModuleType):
 
 cmd = LocalModule(__name__ + ".cmd", LocalModule.__doc__)
 sys.modules[cmd.__name__] = cmd
-
-del sys
-del ModuleType
-del LocalModule
 
 
 def __dir__():

--- a/plumbum/cli/config.py
+++ b/plumbum/cli/config.py
@@ -39,7 +39,6 @@ class ConfigBase(ABC):
     @abstractmethod
     def read(self):
         """Read in the linked file"""
-        pass
 
     @abstractmethod
     def write(self):
@@ -49,12 +48,10 @@ class ConfigBase(ABC):
     @abstractmethod
     def _get(self, option):
         """Internal get function for subclasses"""
-        pass
 
     @abstractmethod
     def _set(self, option, value):
         """Internal set function for subclasses. Must return the value that was set."""
-        pass
 
     def get(self, option, default=None):
         "Get an item from the store, returns default if fails"
@@ -89,7 +86,7 @@ class ConfigINI(ConfigBase):
         super().read()
 
     def write(self):
-        with open(self.filename, "w") as f:
+        with open(self.filename, "w", encoding="utf-8") as f:
             self.parser.write(f)
         super().write()
 
@@ -107,7 +104,7 @@ class ConfigINI(ConfigBase):
         try:
             return self.parser.get(sec, option)
         except (NoSectionError, NoOptionError):
-            raise KeyError(f"{sec}:{option}")
+            raise KeyError(f"{sec}:{option}") from None
 
     def _set(self, option, value):
         sec, option = self._sec_opt(option)

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -5,16 +5,18 @@ loc = locale.getlocale()[0]
 if loc is None or loc.startswith("en"):
 
     class NullTranslation:
-        def gettext(self, str):
-            return str
+        def gettext(self, str1):  # pylint: disable=no-self-use
+            return str1
 
-        def ngettext(self, str1, strN, n):
+        def ngettext(self, str1, strN, n):  # pylint: disable=no-self-use
             if n == 1:
                 return str1.replace("{0}", str(n))
-            else:
-                return strN.replace("{0}", str(n))
 
-    def get_translation_for(package_name: str) -> NullTranslation:
+            return strN.replace("{0}", str(n))
+
+    def get_translation_for(
+        package_name: str,  # pylint: disable=unused-argument
+    ) -> NullTranslation:
         return NullTranslation()
 
 else:

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -34,18 +34,19 @@ class Image:
 
         import PIL.Image
 
-        if double:
-            return self.show_pil_double(PIL.Image.open(filename))
-        else:
-            return self.show_pil(PIL.Image.open(filename))
+        return (
+            self.show_pil_double(PIL.Image.open(filename))
+            if double
+            else self.show_pil(PIL.Image.open(filename))
+        )
 
     def _init_size(self, im):
         """Return the expected image size"""
         if self.size is None:
             term_size = get_terminal_size()
             return self.best_aspect(im.size, term_size)
-        else:
-            return self.size
+
+        return self.size
 
     def show_pil(self, im):
         "Standard show routine"
@@ -87,7 +88,7 @@ class ShowImageApp(cli.Application):
     )
 
     @cli.switch(["-c", "--colors"], cli.Range(1, 4), help="Level of color, 1-4")
-    def colors_set(self, n):
+    def colors_set(self, n):  # pylint: disable=no-self-use
         colors.use_color = n
 
     size = cli.SwitchAttr(["-s", "--size"], help="Size, should be in the form 100x150")

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -83,7 +83,6 @@ class ProgressBase(ABC):
     @abstractmethod
     def display(self):
         """Called to update the progress bar"""
-        pass
 
     def increment(self):
         """Sets next value and displays the bar"""
@@ -107,16 +106,15 @@ class ProgressBase(ABC):
         """Returns a string version of time remaining"""
         if self.value < 1:
             return "Starting...                         "
-        else:
-            elapsed_time, time_remaining = list(map(str, self.time_remaining()))
-            return "{} completed, {} remaining".format(
-                elapsed_time.split(".")[0], time_remaining.split(".")[0]
-            )
+
+        elapsed_time, time_remaining = list(map(str, self.time_remaining()))
+        completed = elapsed_time.split(".")[0]
+        remaining = time_remaining.split(".")[0]
+        return f"{completed} completed, {remaining} remaining"
 
     @abstractmethod
     def done(self):
         """Is called when the iterator is done."""
-        pass
 
     @classmethod
     def range(cls, *value, **kargs):
@@ -156,15 +154,15 @@ class Progress(ProgressBase):
         )
         if width - len(ending) < 10 or self.has_output:
             self.width = 0
+
             if self.timer:
                 return f"{percent:.0%} complete: {self.str_time_remaining()}"
-            else:
-                return f"{percent:.0%} complete"
 
-        else:
-            self.width = width - len(ending) - 2 - 1
-            nstars = int(percent * self.width)
-            pbar = "[" + "*" * nstars + " " * (self.width - nstars) + "]" + ending
+            return f"{percent:.0%} complete"
+
+        self.width = width - len(ending) - 2 - 1
+        nstars = int(percent * self.width)
+        pbar = "[" + "*" * nstars + " " * (self.width - nstars) + "]" + ending
 
         str_percent = f" {percent:.0%} "
 
@@ -243,7 +241,7 @@ class ProgressAuto(ProgressBase):
     def __new__(cls, *args, **kargs):
         """Uses the generator trick that if a cls instance is returned, the __init__ method is not called."""
         try:  # pragma: no cover
-            __IPYTHON__
+            __IPYTHON__  # pylint: disable=pointless-statement
             try:
                 from traitlets import TraitError
             except ImportError:  # Support for IPython < 4.0
@@ -252,7 +250,7 @@ class ProgressAuto(ProgressBase):
             try:
                 return ProgressIPy(*args, **kargs)
             except TraitError:
-                raise NameError()
+                raise NameError() from None
         except (NameError, ImportError):
             return Progress(*args, **kargs)
 

--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -57,14 +57,13 @@ def ask(question, default=None):
             answer = readline(question).strip().lower()
         except EOFError:
             answer = None
-        if answer in ("y", "yes"):
+        if answer in {"y", "yes"}:
             return True
-        elif answer in ("n", "no"):
+        if answer in {"n", "no"}:
             return False
-        elif not answer and default is not None:
+        if not answer and default is not None:
             return default
-        else:
-            sys.stdout.write("Invalid response, please try again\n")
+        sys.stdout.write("Invalid response, please try again\n")
 
 
 def choose(question, options, default=None):
@@ -93,7 +92,7 @@ def choose(question, options, default=None):
     choices = {}
     defindex = None
     for i, item in enumerate(options):
-        i = i + 1  # python2.5
+        i += 1
         if isinstance(item, (tuple, list)) and len(item) == 2:
             text = item[0]
             val = item[1]
@@ -103,12 +102,12 @@ def choose(question, options, default=None):
         choices[i] = val
         if default is not None and default == val:
             defindex = i
-        sys.stdout.write("(%d) %s\n" % (i, text))
+        sys.stdout.write(f"({i}) {text}\n")
     if default is not None:
         if defindex is None:
             msg = f"Choice [{default}]: "
         else:
-            msg = "Choice [%d]: " % (defindex,)
+            msg = f"Choice [{defindex}]: "
     else:
         msg = "Choice: "
     while True:
@@ -128,7 +127,12 @@ def choose(question, options, default=None):
         return choices[choice]
 
 
-def prompt(question, type=str, default=NotImplemented, validator=lambda val: True):
+def prompt(
+    question,
+    type=str,  # pylint: disable=redefined-builtin
+    default=NotImplemented,
+    validator=lambda val: True,
+):
     """
     Presents the user with a validated question, keeps asking if validation does not pass.
 
@@ -148,22 +152,24 @@ def prompt(question, type=str, default=NotImplemented, validator=lambda val: Tru
             ans = readline(question).strip()
         except EOFError:
             ans = ""
+
         if not ans:
             if default is not NotImplemented:
                 # sys.stdout.write("\b%s\n" % (default,))
                 return default
-            else:
-                continue
+            continue
         try:
             ans = type(ans)
         except (TypeError, ValueError) as ex:
             sys.stdout.write(f"Invalid value ({ex}), please try again\n")
             continue
+
         try:
             valid = validator(ans)
         except ValueError as ex:
             sys.stdout.write(f"{ex}, please try again\n")
             continue
+
         if not valid:
             sys.stdout.write("Value not in specified range, please try again\n")
             continue
@@ -200,11 +206,8 @@ def hexdump(data_or_stream, bytes_per_line=16, aggregate=True):
         prev = chunk
         if skipped:
             yield "*"
-        yield "{:06x} | {}| {}".format(
-            i * bytes_per_line,
-            hexd.ljust(bytes_per_line * 3, " "),
-            text,
-        )
+        hexd_ljust = hexd.ljust(bytes_per_line * 3, " ")
+        yield f"{i*bytes_per_line:06x} | {hexd_ljust}| {text}"
         skipped = False
 
 

--- a/plumbum/colorlib/__init__.py
+++ b/plumbum/colorlib/__init__.py
@@ -4,6 +4,7 @@ and attributes like bold and
 underlined text. It also provides ``reset`` to recover the normal font.
 """
 
+import sys
 
 from .factories import StyleFactory
 from .styles import ANSIStyle, ColorNotFound, HTMLStyle, Style
@@ -26,7 +27,7 @@ htmlcolors = StyleFactory(HTMLStyle)
 
 def load_ipython_extension(ipython):  # pragma: no cover
     try:
-        from ._ipython_ext import OutputMagics
+        from ._ipython_ext import OutputMagics  # pylint:disable=import-outside-toplevel
     except ImportError:
         print("IPython required for the IPython extension to be loaded.")
         raise
@@ -38,8 +39,6 @@ def load_ipython_extension(ipython):  # pragma: no cover
 def main():  # pragma: no cover
     """Color changing script entry. Call using
     python -m plumbum.colors, will reset if no arguments given."""
-    import sys
-
     color = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else ""
     ansicolors.use_color = True
     ansicolors.get_colors_from_string(color).now()

--- a/plumbum/colorlib/_ipython_ext.py
+++ b/plumbum/colorlib/_ipython_ext.py
@@ -18,12 +18,12 @@ class OutputMagics(Magics):  # pragma: no cover
         )
         display_fn = getattr(IPython.display, "display_" + choice)
 
-        "Captures stdout and renders it in the notebook with some ."
+        # Captures stdout and renders it in the notebook
         with StringIO() as out:
             old_out = sys.stdout
             try:
                 sys.stdout = out
-                exec(cell, self.shell.user_ns, local_ns)
+                exec(cell, self.shell.user_ns, local_ns)  # pylint: disable=exec-used
                 out.seek(0)
                 display_fn(out.getvalue(), raw=True)
             finally:

--- a/plumbum/colorlib/factories.py
+++ b/plumbum/colorlib/factories.py
@@ -33,7 +33,7 @@ class ColorFactory:
         try:
             return self._style.from_color(self._style.color_class(item, fg=self._fg))
         except ColorNotFound:
-            raise AttributeError(item)
+            raise AttributeError(item) from None
 
     def full(self, name):
         """Gets the style for a color, using standard name procedure: either full
@@ -52,8 +52,8 @@ class ColorFactory:
         """Return the extended color scheme color for a value."""
         if g is None and b is None:
             return self.hex(r)
-        else:
-            return self._style.from_color(self._style.color_class(r, g, b, fg=self._fg))
+
+        return self._style.from_color(self._style.color_class(r, g, b, fg=self._fg))
 
     def hex(self, hexcode):
         """Return the extended color scheme color for a value."""
@@ -73,9 +73,10 @@ class ColorFactory:
             (start, stop, stride) = val.indices(256)
             if stop <= 16:
                 return [self.simple(v) for v in range(start, stop, stride)]
-            else:
-                return [self.full(v) for v in range(start, stop, stride)]
-        elif isinstance(val, tuple):
+
+            return [self.full(v) for v in range(start, stop, stride)]
+
+        if isinstance(val, tuple):
             return self.rgb(*val)
 
         try:
@@ -107,13 +108,12 @@ class ColorFactory:
         """This will reset the color on leaving the with statement."""
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, _type, _value, _traceback) -> None:
         """This resets a FG/BG color or all styles,
         due to different definition of RESET for the
         factories."""
 
         self.reset.now()
-        return False
 
     def __repr__(self):
         """Simple representation of the class by name."""
@@ -200,6 +200,8 @@ class StyleFactory(ColorFactory):
         """Gets colors from an ansi string, returns those colors"""
         return self._style.from_ansi(colored_string, True)
 
-    def load_stylesheet(self, stylesheet=default_styles):
+    def load_stylesheet(self, stylesheet=None):
+        if stylesheet is None:
+            stylesheet = default_styles
         for item in stylesheet:
             setattr(self, item, self.get_colors_from_string(stylesheet[item]))

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -41,7 +41,7 @@ def get_color_repr():
     """Gets best colors for current system."""
     if "NO_COLOR" in os.environ:
         return 0
-    if os.environ.get("FORCE_COLOR", "0") in {"0", "1", "2", "3", "4"}:
+    if os.environ.get("FORCE_COLOR", "") in {"0", "1", "2", "3", "4"}:
         return int(os.environ["FORCE_COLOR"])
     if not sys.stdout.isatty():
         return 0

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -101,10 +101,11 @@ class BaseCommand:
         """Creates a bound-command with the given arguments"""
         if not args:
             return self
+
         if isinstance(self, BoundCommand):
             return BoundCommand(self.cmd, self.args + list(args))
-        else:
-            return BoundCommand(self, args)
+
+        return BoundCommand(self, args)
 
     def __call__(self, *args, **kwargs):
         """A shortcut for `run(args)`, returning only the process' stdout"""
@@ -207,7 +208,7 @@ class BaseCommand:
 
         def runner():
             if was_run[0]:
-                return  # already done
+                return None  # already done
             was_run[0] = True
             try:
                 return run_proc(p, retcode, timeout)
@@ -333,7 +334,7 @@ class BoundCommand(BaseCommand):
 
 
 class BoundEnvCommand(BaseCommand):
-    __slots__ = ("cmd", "env", "cwd")
+    __slots__ = ("cmd",)
 
     def __init__(self, cmd, env=None, cwd=None):
         self.cmd = cmd
@@ -441,7 +442,7 @@ class BaseRedirection(BaseCommand):
     __slots__ = ("cmd", "file")
     SYM = None  # type: str
     KWARG = None  # type: str
-    MODE = None  # type: str
+    MODE = "r"  # type: str
 
     def __init__(self, cmd, file):
         self.cmd = cmd
@@ -471,8 +472,8 @@ class BaseRedirection(BaseCommand):
             raise RedirectionError(f"{self.KWARG} is already redirected")
         if isinstance(self.file, RemotePath):
             raise TypeError("Cannot redirect to/from remote paths")
-        if isinstance(self.file, (str,) + (LocalPath,)):
-            f = kwargs[self.KWARG] = open(str(self.file), self.MODE)
+        if isinstance(self.file, (str, LocalPath)):
+            f = kwargs[self.KWARG] = open(str(self.file), self.MODE, encoding="utf-8")
         else:
             kwargs[self.KWARG] = self.file
             f = None

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -12,13 +12,16 @@ from plumbum.commands.processes import ProcessExecutionError
 class _fake_lock:
     """Needed to allow normal os.exit() to work without error"""
 
-    def acquire(self, val):
+    @staticmethod
+    def acquire(_):
         return True
 
-    def release(self):
+    @staticmethod
+    def release():
         pass
 
 
+# pylint: disable-next: inconsistent-return-statements
 def posix_daemonize(command, cwd, stdout=None, stderr=None, append=True):
     if stdout is None:
         stdout = os.devnull
@@ -36,9 +39,9 @@ def posix_daemonize(command, cwd, stdout=None, stderr=None, append=True):
         try:
             os.setsid()
             os.umask(0)
-            stdin = open(os.devnull)
-            stdout = open(stdout, "a" if append else "w")
-            stderr = open(stderr, "a" if append else "w")
+            stdin = open(os.devnull, encoding="utf-8")
+            stdout = open(stdout, "a" if append else "w", encoding="utf-8")
+            stderr = open(stderr, "a" if append else "w", encoding="utf-8")
             signal.signal(signal.SIGHUP, signal.SIG_IGN)
             proc = command.popen(
                 cwd=cwd,
@@ -113,9 +116,9 @@ def win32_daemonize(command, cwd, stdout=None, stderr=None, append=True):
     if stderr is None:
         stderr = stdout
     DETACHED_PROCESS = 0x00000008
-    stdin = open(os.devnull)
-    stdout = open(stdout, "a" if append else "w")
-    stderr = open(stderr, "a" if append else "w")
+    stdin = open(os.devnull, encoding="utf-8")
+    stdout = open(stdout, "a" if append else "w", encoding="utf-8")
+    stderr = open(stderr, "a" if append else "w", encoding="utf-8")
     return command.popen(
         cwd=cwd,
         stdin=stdin.fileno(),

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -49,7 +49,7 @@ def _iter_lines_posix(proc, decode, linesize, line_timeout=None):
 def _iter_lines_win32(proc, decode, linesize, line_timeout=None):
     class Piper(Thread):
         def __init__(self, fd, pipe):
-            super().__init__(name="PlumbumPiper%sThread" % fd)
+            super().__init__(name=f"PlumbumPiper{fd}Thread")
             self.pipe = pipe
             self.fd = fd
             self.empty = False
@@ -115,7 +115,7 @@ class ProcessExecutionError(EnvironmentError):
     """
 
     def __init__(self, argv, retcode, stdout, stderr, message=None):
-        Exception.__init__(self, argv, retcode, stdout, stderr)
+        super().__init__(self, argv, retcode, stdout, stderr)
         self.message = message
         self.argv = argv
         self.retcode = retcode
@@ -172,7 +172,7 @@ class CommandNotFound(AttributeError):
     command was not found in the system's ``PATH``"""
 
     def __init__(self, program, path):
-        Exception.__init__(self, program, path)
+        super().__init__(self, program, path)
         self.program = program
         self.path = path
 
@@ -250,7 +250,7 @@ def _register_proc_timeout(proc, timeout):
 
 
 def _shutdown_bg_threads():
-    global _shutting_down
+    global _shutting_down  # pylint: disable=global-statement
     _shutting_down = True
     # Make sure this still exists (don't throw error in atexit!)
     if _timeout_queue:

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -20,9 +20,8 @@ except ImportError:
         from win32con import LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY
         from win32file import OVERLAPPED, LockFileEx, UnlockFile
     except ImportError:
-        raise ImportError(
-            "On Windows, we require Python for Windows Extensions (pywin32)"
-        )
+        print("On Windows, Plumbum requires Python for Windows Extensions (pywin32)")
+        raise
 
     @contextmanager
     def locked_file(fileno, blocking=True):
@@ -38,7 +37,7 @@ except ImportError:
             )
         except WinError:
             _, ex, _ = sys.exc_info()
-            raise OSError(*ex.args)
+            raise OSError(*ex.args) from None
         try:
             yield
         finally:
@@ -277,7 +276,7 @@ class PidFile:
     def __del__(self):
         try:
             self.release()
-        except Exception:
+        except Exception:  # pylint:disable=broad-except
             pass
 
     def close(self):
@@ -303,7 +302,7 @@ class PidFile:
             raise PidFileTaken(
                 f"PID file {self.atomicfile.path!r} taken by process {pid}",
                 pid,
-            )
+            ) from None
         else:
             self.atomicfile.write_atomic(str(os.getpid()).encode("utf8"))
             atexit.register(self.release)

--- a/plumbum/fs/mounts.py
+++ b/plumbum/fs/mounts.py
@@ -13,12 +13,8 @@ class MountEntry:
         self.options = options.split(",")
 
     def __str__(self):
-        return "{} on {} type {} ({})".format(
-            self.dev,
-            self.point,
-            self.fstype,
-            ",".join(self.options),
-        )
+        options = ",".join(self.options)
+        return f"{self.dev} on {self.point} type {self.fstype} ({options})"
 
 
 MOUNT_PATTERN = re.compile(r"(.+?)\s+on\s+(.+?)\s+type\s+(\S+)(?:\s+\((.+?)\))?")
@@ -42,4 +38,4 @@ def mounted(fs):
     """
     Indicates if a the given filesystem (device file or mount point) is currently mounted
     """
-    return any(fs == entry.dev or fs == entry.point for entry in mount_table())
+    return any(fs in {entry.dev, entry.point} for entry in mount_table())

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -15,9 +15,7 @@ class ProcInfo:
         self.args = args
 
     def __repr__(self):
-        return "ProcInfo({!r}, {!r}, {!r}, {!r})".format(
-            self.pid, self.uid, self.stat, self.args
-        )
+        return f"ProcInfo({self.pid!r}, {self.uid!r}, {self.stat!r}, {self.args!r})"
 
 
 @contextmanager
@@ -48,13 +46,13 @@ class StaticProperty:
         return self._function()
 
 
-def getdoc(object):
+def getdoc(obj):
     """
     This gets a docstring if available, and cleans it, but does not look up docs in
-    inheritance tree (Pre 3.5 behavior of ``inspect.getdoc``).
+    inheritance tree (Pre Python 3.5 behavior of ``inspect.getdoc``).
     """
     try:
-        doc = object.__doc__
+        doc = obj.__doc__
     except AttributeError:
         return None
     if not isinstance(doc, str):
@@ -70,12 +68,12 @@ def read_fd_decode_safely(fd, size=4096):
     Returns the data and the decoded text.
     """
     data = os.read(fd.fileno(), size)
-    for i in range(4):
+    for _ in range(3):
         try:
             return data, data.decode("utf-8")
         except UnicodeDecodeError as e:
             if e.reason != "unexpected end of data":
                 raise
-            if i == 3:
-                raise
             data += os.read(fd.fileno(), 1)
+
+    return data, data.decode("utf-8")

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -49,13 +49,11 @@ class BaseMachine:
             command = self[cmd]
             if not command.executable.exists():
                 raise CommandNotFound(cmd, command.executable)
-            else:
-                return command
+            return command
         except CommandNotFound:
             if othercommands:
                 return self.get(othercommands[0], *othercommands[1:])
-            else:
-                raise
+            raise
 
     def __contains__(self, cmd):
         """Tests for the existence of the command, e.g., ``"ls" in plumbum.local``.
@@ -88,7 +86,7 @@ class BaseMachine:
             try:
                 return self._machine[name]
             except CommandNotFound:
-                raise AttributeError(name)
+                raise AttributeError(name) from None
 
     @property
     def cmd(self):

--- a/plumbum/machines/env.py
+++ b/plumbum/machines/env.py
@@ -6,6 +6,7 @@ class EnvPathList(list):
     __slots__ = ["_path_factory", "_pathsep", "__weakref__"]
 
     def __init__(self, path_factory, pathsep):
+        super().__init__()
         self._path_factory = path_factory
         self._pathsep = pathsep
 
@@ -41,6 +42,7 @@ class BaseEnv:
     CASE_SENSITIVE = True
 
     def __init__(self, path_factory, pathsep):
+        self._curr = {}
         self._path_factory = path_factory
         self._path = EnvPathList(path_factory, pathsep)
         self._update_path()
@@ -150,9 +152,9 @@ class BaseEnv:
     def _get_home(self):
         if "HOME" in self:
             return self._path_factory(self["HOME"])
-        elif "USERPROFILE" in self:  # pragma: no cover
+        if "USERPROFILE" in self:  # pragma: no cover
             return self._path_factory(self["USERPROFILE"])
-        elif "HOMEPATH" in self:  # pragma: no cover
+        if "HOMEPATH" in self:  # pragma: no cover
             return self._path_factory(self.get("HOMEDRIVE", ""), self["HOMEPATH"])
         return None
 

--- a/plumbum/machines/env.py
+++ b/plumbum/machines/env.py
@@ -41,8 +41,8 @@ class BaseEnv:
     __slots__ = ["_curr", "_path", "_path_factory", "__weakref__"]
     CASE_SENSITIVE = True
 
-    def __init__(self, path_factory, pathsep):
-        self._curr = {}
+    def __init__(self, path_factory, pathsep, *, _curr):
+        self._curr = _curr
         self._path_factory = path_factory
         self._path = EnvPathList(path_factory, pathsep)
         self._update_path()

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -56,8 +56,7 @@ class LocalEnv(BaseEnv):
 
     def __init__(self):
         # os.environ already takes care of upper'ing on windows
-        self._curr = os.environ.copy()
-        BaseEnv.__init__(self, LocalPath, os.path.pathsep)
+        super().__init__(LocalPath, os.path.pathsep, _curr=os.environ.copy())
         if IS_WIN32 and "HOME" not in self and self.home is not None:
             self["HOME"] = self.home
 

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -24,7 +24,7 @@ class PlumbumLocalPopen(PopenAddons):
     iter_lines = iter_lines
 
     def __init__(self, *args, **kwargs):
-        self._proc = Popen(*args, **kwargs)
+        self._proc = Popen(*args, **kwargs)  # pylint: disable=consider-using-with
 
     def __iter__(self):
         return self.iter_lines()
@@ -223,15 +223,15 @@ class LocalMachine(BaseMachine):
 
         if isinstance(cmd, LocalPath):
             return LocalCommand(cmd)
-        elif not isinstance(cmd, RemotePath):
+
+        if not isinstance(cmd, RemotePath):
             if "/" in cmd or "\\" in cmd:
                 # assume path
                 return LocalCommand(local.path(cmd))
-            else:
-                # search for command
-                return LocalCommand(self.which(cmd))
-        else:
-            raise TypeError(f"cmd must not be a RemotePath: {cmd!r}")
+            # search for command
+            return LocalCommand(self.which(cmd))
+
+        raise TypeError(f"cmd must not be a RemotePath: {cmd!r}")
 
     def _popen(
         self,
@@ -317,12 +317,12 @@ class LocalMachine(BaseMachine):
         """
         if IS_WIN32:
             return win32_daemonize(command, cwd, stdout, stderr, append)
-        else:
-            return posix_daemonize(command, cwd, stdout, stderr, append)
+
+        return posix_daemonize(command, cwd, stdout, stderr, append)
 
     if IS_WIN32:
 
-        def list_processes(self):
+        def list_processes(self):  # pylint: disable=no-self-use
             """
             Returns information about all running processes (on Windows: using ``tasklist``)
 
@@ -379,11 +379,11 @@ class LocalMachine(BaseMachine):
     def tempdir(self):
         """A context manager that creates a temporary directory, which is removed when the context
         exits"""
-        dir = self.path(mkdtemp())  # @ReservedAssignment
+        new_dir = self.path(mkdtemp())
         try:
-            yield dir
+            yield new_dir
         finally:
-            dir.delete()
+            new_dir.delete()
 
     @contextmanager
     def as_user(self, username=None):

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -70,7 +70,8 @@ class ParamikoPopen(PopenAddons):
         self.channel.shutdown_write()
         self.channel.close()
 
-    def kill(self):
+    @staticmethod
+    def kill():
         # possible way to obtain pid:
         # "(cmd ; echo $?) & echo ?!"
         # and then client.exec_command("kill -9 %s" % (pid,))
@@ -106,7 +107,7 @@ class ParamikoPopen(PopenAddons):
                     self.stdin.flush()
 
             i = (i + 1) % len(sources)
-            name, coll, pipe, outfile = sources[i]
+            _name, coll, pipe, outfile = sources[i]
             line = pipe.readline()
             # logger.debug("%s> %r", name, line)
             if not line:
@@ -255,7 +256,7 @@ class ParamikoMachine(BaseRemoteMachine):
             kwargs["gss_host"] = gss_host
         if load_system_ssh_config:
             ssh_config = paramiko.SSHConfig()
-            with open(os.path.expanduser("~/.ssh/config")) as f:
+            with open(os.path.expanduser("~/.ssh/config"), encoding="utf-8") as f:
                 ssh_config.parse(f)
             try:
                 hostConfig = ssh_config.lookup(host)
@@ -308,7 +309,7 @@ class ParamikoMachine(BaseRemoteMachine):
         stdin=None,
         stdout=None,
         stderr=None,
-        new_session=False,
+        new_session=False,  # pylint: disable=unused-argument
         env=None,
         cwd=None,
     ):
@@ -474,7 +475,12 @@ class SocketCompatibleChannel:
 ###################################################################################################
 # Custom iter_lines for paramiko.Channel
 ###################################################################################################
-def _iter_lines(proc, decode, linesize, line_timeout=None):
+def _iter_lines(
+    proc,
+    decode,  # pylint: disable=unused-argument
+    linesize,
+    line_timeout=None,
+):
 
     from selectors import EVENT_READ, DefaultSelector
 

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -19,10 +19,8 @@ class SshTunnel:
         self._session = session
 
     def __repr__(self):
-        if self._session.alive():
-            return f"<SshTunnel {self._session.proc}>"
-        else:
-            return "<SshTunnel (defunct)>"
+        tunnel = self._session.proc if self._session.alive() else "(defunct)"
+        return f"<SshTunnel {tunnel}>"
 
     def __enter__(self):
         return self
@@ -218,7 +216,7 @@ class SshMachine(BaseRemoteMachine):
         dport,
         lhost="localhost",
         dhost="localhost",
-        connect_timeout=5,
+        connect_timeout=5,  # pylint: disable=unused-argument
         reverse=False,
     ):
         r"""Creates an SSH tunnel from the TCP port (``lport``) of the local machine
@@ -290,7 +288,7 @@ class SshMachine(BaseRemoteMachine):
             )
         )
 
-    def _translate_drive_letter(self, path):
+    def _translate_drive_letter(self, path):  # pylint: disable=no-self-use
         # replace c:\some\path with /c/some/path
         path = str(path)
         if ":" in path:

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -289,7 +289,7 @@ class Path(str, ABC):
         """
 
     @abstractmethod
-    def open(self, mode="r"):
+    def open(self, mode="r", *, encoding=None):
         """opens this path as a file"""
 
     @abstractmethod

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -2,7 +2,7 @@ import itertools
 import operator
 import os
 import warnings
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from functools import reduce
 
 FLAGS = {"f": os.F_OK, "w": os.W_OK, "r": os.R_OK, "x": os.X_OK}
@@ -51,16 +51,16 @@ class Path(str, ABC):
     def __eq__(self, other):
         if isinstance(other, Path):
             return self._get_info() == other._get_info()
-        elif isinstance(other, str):
+        if isinstance(other, str):
             if self.CASE_SENSITIVE:
                 return str(self) == other
-            else:
-                return str(self).lower() == other.lower()
-        else:
-            return NotImplemented
+
+            return str(self).lower() == other.lower()
+
+        return NotImplemented
 
     def __ne__(self, other):
-        return not (self == other)
+        return not self == other
 
     def __gt__(self, other):
         return str(self) > str(other)
@@ -75,10 +75,7 @@ class Path(str, ABC):
         return str(self) <= str(other)
 
     def __hash__(self):
-        if self.CASE_SENSITIVE:
-            return hash(str(self))
-        else:
-            return hash(str(self).lower())
+        return hash(str(self)) if self.CASE_SENSITIVE else hash(str(self).lower())
 
     def __bool__(self):
         return bool(str(self))
@@ -103,8 +100,10 @@ class Path(str, ABC):
         return self.join("../" * count)
 
     def walk(
-        self, filter=lambda p: True, dir_filter=lambda p: True
-    ):  # @ReservedAssignment
+        self,
+        filter=lambda p: True,  # pylint: disable=redefined-builtin
+        dir_filter=lambda p: True,
+    ):
         """traverse all (recursive) sub-elements under this directory, that match the given filter.
         By default, the filter accepts everything; you can provide a custom filter function that
         takes a path as an argument and returns a boolean
@@ -120,7 +119,8 @@ class Path(str, ABC):
             if p.is_dir() and dir_filter(p):
                 yield from p.walk(filter, dir_filter)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def name(self):
         """The basename component of this path"""
 
@@ -130,37 +130,45 @@ class Path(str, ABC):
         warnings.warn("Use .name instead", FutureWarning)
         return self.name
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def stem(self):
         """The name without an extension, or the last component of the path"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def dirname(self):
         """The dirname component of this path"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def root(self):
         """The root of the file tree (`/` on Unix)"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def drive(self):
         """The drive letter (on Windows)"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def suffix(self):
         """The suffix of this file"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def suffixes(self):
         """This is a list of all suffixes"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def uid(self):
         """The user that owns this path. The returned value is a :class:`FSUser <plumbum.path.FSUser>`
         object which behaves like an ``int`` (as expected from ``uid``), but it also has a ``.name``
         attribute that holds the string-name of the user"""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def gid(self):
         """The group that owns this path. The returned value is a :class:`FSUser <plumbum.path.FSUser>`
         object which behaves like an ``int`` (as expected from ``gid``), but it also has a ``.name``
@@ -220,7 +228,6 @@ class Path(str, ABC):
     @abstractmethod
     def stat(self):
         """Returns the os.stats for a file"""
-        pass
 
     @abstractmethod
     def with_name(self, name):
@@ -236,10 +243,7 @@ class Path(str, ABC):
     def preferred_suffix(self, suffix):
         """Adds a suffix if one does not currently exist (otherwise, no change). Useful
         for loading files with a default suffix"""
-        if len(self.suffixes) > 0:
-            return self
-        else:
-            return self.with_suffix(suffix)
+        return self if len(self.suffixes) > 0 else self.with_suffix(suffix)
 
     @abstractmethod
     def glob(self, pattern):
@@ -322,9 +326,13 @@ class Path(str, ABC):
         """
 
     @staticmethod
-    def _access_mode_to_flags(mode, flags=FLAGS):
+    def _access_mode_to_flags(mode, flags=None):
+        if flags is None:
+            flags = FLAGS
+
         if isinstance(mode, str):
             mode = reduce(operator.or_, [flags[m] for m in mode.lower()], 0)
+
         return mode
 
     @abstractmethod
@@ -354,7 +362,7 @@ class Path(str, ABC):
     def unlink(self):
         """Deletes a symbolic link"""
 
-    def split(self, *dummy_args, **dummy_kargs):
+    def split(self, *_args, **_kargs):
         """Splits the path on directory separators, yielding a list of directories, e.g,
         ``"/var/log/messages"`` will yield ``['var', 'log', 'messages']``.
         """
@@ -394,17 +402,18 @@ class Path(str, ABC):
         """Same as ``self.relative_to(other)``"""
         return self.relative_to(other)
 
-    def _glob(self, pattern, fn):
+    @staticmethod
+    def _glob(pattern, fn):
         """Applies a glob string or list/tuple/iterable to the current path, using ``fn``"""
         if isinstance(pattern, str):
             return fn(pattern)
-        else:
-            results = []
-            for single_pattern in pattern:
-                results.extend(fn(single_pattern))
-            return sorted(list(set(results)))
 
-    def resolve(self, strict=False):
+        results = []
+        for single_pattern in pattern:
+            results.extend(fn(single_pattern))
+        return sorted(list(set(results)))
+
+    def resolve(self, strict=False):  # pylint:disable=unused-argument
         """Added to allow pathlib like syntax. Does nothing since
         Plumbum paths are always absolute. Does not (currently) resolve
         symlinks."""
@@ -459,7 +468,7 @@ class RelativePath:
         return str(self) == str(other)
 
     def __ne__(self, other):
-        return not (self == other)
+        return not self == other
 
     def __gt__(self, other):
         return str(self) > str(other)

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -4,6 +4,8 @@ import logging
 import os
 import shutil
 import sys
+import urllib.parse as urlparse
+import urllib.request as urllib
 from contextlib import contextmanager
 
 from plumbum.lib import IS_WIN32
@@ -15,21 +17,18 @@ try:
     from pwd import getpwnam, getpwuid
 except ImportError:
 
-    def getpwuid(x):  # type: ignore
+    def getpwuid(_x):  # type: ignore
         return (None,)
 
-    def getgrgid(x):  # type: ignore
+    def getgrgid(_x):  # type: ignore
         return (None,)
 
-    def getpwnam(x):  # type: ignore
+    def getpwnam(_x):  # type: ignore
         raise OSError("`getpwnam` not supported")
 
-    def getgrnam(x):  # type: ignore
+    def getgrnam(_x):  # type: ignore
         raise OSError("`getgrnam` not supported")
 
-
-import urllib.parse as urlparse
-import urllib.request as urllib
 
 logger = logging.getLogger("plumbum.local")
 
@@ -139,7 +138,7 @@ class LocalPath(Path):
 
     def with_suffix(self, suffix, depth=1):
         if suffix and not suffix.startswith(os.path.extsep) or suffix == os.path.extsep:
-            raise ValueError("Invalid suffix %r" % (suffix))
+            raise ValueError(f"Invalid suffix {suffix!r}")
         name = self.name
         depth = len(self.suffixes) if depth is None else min(depth, len(self.suffixes))
         for _ in range(depth):
@@ -203,7 +202,7 @@ class LocalPath(Path):
                     raise
 
     def open(self, mode="r"):
-        return open(str(self), mode)
+        return open(str(self), mode, encoding="utf-8")
 
     def read(self, encoding=None, mode="r"):
         if encoding and "b" not in mode:
@@ -226,7 +225,7 @@ class LocalPath(Path):
             f.write(data)
 
     def touch(self):
-        with open(str(self), "a"):
+        with open(str(self), "a", encoding="utf-8"):
             os.utime(str(self), None)
 
     def chown(self, owner=None, group=None, recursive=None):

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -32,6 +32,8 @@ except ImportError:
 
 logger = logging.getLogger("plumbum.local")
 
+_EMPTY = object()
+
 
 # ===================================================================================================
 # Local Paths
@@ -201,8 +203,12 @@ class LocalPath(Path):
                 if ex.errno != errno.EEXIST or not exist_ok:
                     raise
 
-    def open(self, mode="r"):
-        return open(str(self), mode, encoding="utf-8")
+    def open(self, mode="r", encoding=None):
+        return open(
+            str(self),
+            mode,
+            encoding=encoding,
+        )
 
     def read(self, encoding=None, mode="r"):
         if encoding and "b" not in mode:

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -284,12 +284,17 @@ class RemotePath(Path):
             )
         self.remote._path_link(self, dst, True)
 
-    def open(self, mode="r", bufsize=-1):
+    def open(self, mode="r", bufsize=-1, *, encoding=None):
         """
         Opens this path as a file.
 
         Only works for ParamikoMachine-associated paths for now.
         """
+        if encoding is not None:
+            raise NotImplementedError(
+                "encoding not supported for ParamikoMachine paths"
+            )
+
         if hasattr(self.remote, "sftp") and hasattr(self.remote.sftp, "open"):
             return self.remote.sftp.open(self, mode, bufsize)
 

--- a/plumbum/path/utils.py
+++ b/plumbum/path/utils.py
@@ -48,20 +48,17 @@ def move(src, dst):
         for src2 in src:
             move(src2, dst)
         return dst
-    elif not isinstance(src, Path):
+    if not isinstance(src, Path):
         src = local.path(src)
 
     if isinstance(src, LocalPath):
-        if isinstance(dst, LocalPath):
-            return src.move(dst)
-        else:
-            return _move(src, dst)
-    elif isinstance(dst, LocalPath):
+        return src.move(dst) if isinstance(dst, LocalPath) else _move(src, dst)
+    if isinstance(dst, LocalPath):
         return _move(src, dst)
-    elif src.remote == dst.remote:
+    if src.remote == dst.remote:
         return src.move(dst)
-    else:
-        return _move(src, dst)
+
+    return _move(src, dst)
 
 
 def copy(src, dst):
@@ -86,25 +83,27 @@ def copy(src, dst):
         for src2 in src:
             copy(src2, dst)
         return dst
-    elif not isinstance(src, Path):
+
+    if not isinstance(src, Path):
         src = local.path(src)
 
     if isinstance(src, LocalPath):
         if isinstance(dst, LocalPath):
             return src.copy(dst)
-        else:
-            dst.remote.upload(src, dst)
-            return dst
-    elif isinstance(dst, LocalPath):
+        dst.remote.upload(src, dst)
+        return dst
+
+    if isinstance(dst, LocalPath):
         src.remote.download(src, dst)
         return dst
-    elif src.remote == dst.remote:
+
+    if src.remote == dst.remote:
         return src.copy(dst)
-    else:
-        with local.tempdir() as tmp:
-            copy(src, tmp)
-            copy(tmp / src.name, dst)
-        return dst
+
+    with local.tempdir() as tmp:
+        copy(src, tmp)
+        copy(tmp / src.name, dst)
+    return dst
 
 
 def gui_open(filename):

--- a/plumbum/typed_env.py
+++ b/plumbum/typed_env.py
@@ -47,7 +47,7 @@ class TypedEnv(MutableMapping):
             self.name = self.names[0]
             self.default = default
 
-        def convert(self, value):
+        def convert(self, value):  # pylint:disable=no-self-use
             return value
 
         def __get__(self, instance, owner):
@@ -72,11 +72,11 @@ class TypedEnv(MutableMapping):
         Case-insensitive. Throws a ``ValueError`` for any other value.
         """
 
-        def convert(self, s):
-            s = s.lower()
-            if s not in ("yes", "no", "true", "false", "1", "0"):
-                raise ValueError(f"Unrecognized boolean value: {s!r}")
-            return s in ("yes", "true", "1")
+        def convert(self, value):
+            value = value.lower()
+            if value not in {"yes", "no", "true", "false", "1", "0"}:
+                raise ValueError(f"Unrecognized boolean value: {value!r}")
+            return value in {"yes", "true", "1"}
 
         def __set__(self, instance, value):
             instance[self.name] = "yes" if value else "no"
@@ -93,7 +93,9 @@ class TypedEnv(MutableMapping):
         a list of objects of type ``type`` (``str`` by default).
         """
 
-        def __init__(self, name, default=NO_DEFAULT, type=str, separator=","):
+        def __init__(
+            self, name, default=NO_DEFAULT, type=str, separator=","
+        ):  # pylint:disable=redefined-builtin
             super(TypedEnv.CSV, self).__init__(name, default=default)
             self.type = type
             self.separator = separator
@@ -106,7 +108,9 @@ class TypedEnv(MutableMapping):
 
     # =========
 
-    def __init__(self, env=os.environ):
+    def __init__(self, env=None):
+        if env is None:
+            env = os.environ
         self._env = env
         self._defined_keys = {
             k
@@ -131,8 +135,7 @@ class TypedEnv(MutableMapping):
             value = self._env.get(key, NO_DEFAULT)
             if value is not NO_DEFAULT:
                 return value
-        else:
-            raise EnvironmentVariableError(key_names[0])
+        raise EnvironmentVariableError(key_names[0])
 
     def __contains__(self, key):
         try:
@@ -147,7 +150,9 @@ class TypedEnv(MutableMapping):
         try:
             return self._raw_get(name)
         except EnvironmentVariableError:
-            raise AttributeError(f"{self.__class__} has no attribute {name!r}")
+            raise AttributeError(
+                f"{self.__class__} has no attribute {name!r}"
+            ) from None
 
     def __getitem__(self, key):
         return getattr(self, key)  # delegate through the descriptors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,44 @@ ignore = [
 
 [tool.pycln]
 all = true
+
+
+[tool.pylint]
+master.py-version = "3.6"
+master.jobs = "0"
+master.fail-under = "9.97"
+reports.output-format = "colorized"
+similarities.ignore-imports = "yes"
+messages_control.enable = [
+  "useless-suppression",
+]
+messages_control.disable = [
+  "arguments-differ", # TODO: investigate
+  "attribute-defined-outside-init", # TODO: investigate
+  "broad-except", # TODO: investigate
+  "cyclic-import",
+  "duplicate-code",  # TODO: check
+  "fixme",
+  "import-error",
+  "import-outside-toplevel",  # TODO: see if this can be limited to certain imports
+  "invalid-name",
+  "line-too-long",
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+  "no-member",
+  "protected-access",
+  "too-few-public-methods",
+  "too-many-arguments",
+  "too-many-branches",
+  "too-many-function-args",
+  "too-many-instance-attributes",
+  "too-many-lines",
+  "too-many-locals",
+  "too-many-nested-blocks",
+  "too-many-public-methods",
+  "too-many-return-statements",
+  "too-many-statements",
+  "non-parent-init-called", # TODO: should be looked at
+  "unidiomatic-typecheck", # TODO: might be able to remove
+]


### PR DESCRIPTION
Fixing lots of things. Better error messages, cleaner, etc. A few remaining warnings to fix, not at 10/10 yet.

* Using guard style everywhere
* Reducing local imports
* Reducing local class usage (yuck!)
* Shorter tracebacks (like Python 2) in quite a few cases
* More/better super usage
* Added `encoding=` setting for open (local, remote isn't supported by Paramiko)
* Use UTF-8 encoding in more places (better future compat)
* Use f-strings everywhere
* Less overlapping names / definitions
* Removed a Python 2.5 workaround :)
* Use staticmethod a few places
* Use sets a few more places
* Remove deprecated abstractproperty usage
