### PR TITLE
refactor: use Python 3.7 simpler impl for cmd

### DIFF
--- a/plumbum/cmd.py
+++ b/plumbum/cmd.py
@@ -1,0 +1,9 @@
+import plumbum
+
+
+def __getattr__(name: str) -> plumbum.machines.LocalCommand:
+    """The module-hack that allows us to use ``from plumbum.cmd import some_program``"""
+    try:
+        return plumbum.local[name]
+    except plumbum.CommandNotFound:
+        raise AttributeError(name) from None


### PR DESCRIPTION
Only fall back to the old implementation on Python 3.6.