### PR TITLE
exceptions: ensure ProcessExecutionError can be pickled

### DIFF
--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -115,7 +115,7 @@ class ProcessExecutionError(OSError):
 
     def __init__(self, argv, retcode, stdout, stderr, message=None):
 
-        # we can't use 'super' here since EnvironmentError only keeps the first 2 args,
+        # we can't use 'super' here since OSError only keeps the first 2 args,
         # which leads to failuring in loading this object from a pickle.dumps.
         Exception.__init__(self, argv, retcode, stdout, stderr)
 

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -106,7 +106,7 @@ else:
 # ===================================================================================================
 # Exceptions
 # ===================================================================================================
-class ProcessExecutionError(EnvironmentError):
+class ProcessExecutionError(OSError):
     """Represents the failure of a process. When the exit code of a terminated process does not
     match the expected result, this exception is raised by :func:`run_proc
     <plumbum.commands.run_proc>`. It contains the process' return code, stdout, and stderr, as

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -114,7 +114,11 @@ class ProcessExecutionError(EnvironmentError):
     """
 
     def __init__(self, argv, retcode, stdout, stderr, message=None):
-        super().__init__(self, argv, retcode, stdout, stderr)
+
+        # we can't use 'super' here since EnvironmentError only keeps the first 2 args,
+        # which leads to failuring in loading this object from a pickle.dumps.
+        Exception.__init__(self, argv, retcode, stdout, stderr)
+
         self.message = message
         self.argv = argv
         self.retcode = retcode

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -724,6 +724,13 @@ class TestLocalMachine:
             ls("-a", "")  # check that empty strings are rendered correctly
         assert execinfo.value.argv[-2:] == ["-a", ""]
 
+    def test_exception_pickling(self):
+        import pickle
+
+        with pytest.raises(ProcessExecutionError) as exc_info:
+            local.cmd.ls("no-file")
+        assert pickle.loads(pickle.dumps(exc_info.value)).argv == exc_info.value.argv
+
     def test_tempdir(self):
         with local.tempdir() as dir:
             assert dir.is_dir()


### PR DESCRIPTION
Something in recent refactors broke this capability, which we are using in our infrastructure, so I've fixed and cemented it with a UT.