### PR TITLE
chore: py2 removed from docs, code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Redirection
 
     >>> from plumbum.cmd import cat, head
     >>> ((cat < "setup.py") | head["-n", 4])()
-    '#!/usr/bin/env python\nimport os\n\ntry:\n'
+    '#!/usr/bin/env python3\nimport os\n\ntry:\n'
     >>> (ls["-a"] > "file.list")()
     ''
     >>> (cat["file.list"] | wc["-l"])()
@@ -174,7 +174,7 @@ Sample output
 
 ::
 
-    $ python simple_cli.py -v -I foo/bar -Ispam/eggs x.cpp y.cpp z.cpp
+    $ python3 simple_cli.py -v -I foo/bar -Ispam/eggs x.cpp y.cpp z.cpp
     Verbose: True
     Include dirs: ['foo/bar', 'spam/eggs']
     Compiling: ('x.cpp', 'y.cpp', 'z.cpp')

--- a/docs/_cheatsheet.rst
+++ b/docs/_cheatsheet.rst
@@ -9,10 +9,10 @@ Basics
     >>> ls
     LocalCommand(<LocalPath /bin/ls>)
     >>> ls()
-    u'build.py\ndist\ndocs\nLICENSE\nplumbum\nREADME.rst\nsetup.py\ntests\ntodo.txt\n'
+    'build.py\ndist\ndocs\nLICENSE\nplumbum\nREADME.rst\nsetup.py\ntests\ntodo.txt\n'
     >>> notepad = local["c:\\windows\\notepad.exe"]
     >>> notepad()                                   # Notepad window pops up
-    u''                                             # Notepad window is closed by user, command returns
+    ''                                              # Notepad window is closed by user, command returns
 
 Instead of writing ``xxx = local["xxx"]`` for every program you wish to use, you can
 also :ref:`import commands <import-hack>`:
@@ -28,7 +28,7 @@ Or, use the ``local.cmd`` syntactic-sugar:
     >>> local.cmd.ls
     LocalCommand(<LocalPath /bin/ls>)
     >>> local.cmd.ls()
-    u'build.py\ndist\ndocs\nLICENSE\nplumbum\nREADME.rst\nsetup.py\ntests\ntodo.txt\n'
+    'build.py\ndist\ndocs\nLICENSE\nplumbum\nREADME.rst\nsetup.py\ntests\ntodo.txt\n'
 
 See :ref:`guide-local-commands`.
 
@@ -38,10 +38,10 @@ Piping
 .. code-block:: python
 
     >>> chain = ls["-a"] | grep["-v", "\\.py"] | wc["-l"]
-    >>> print chain
+    >>> print(chain)
     /bin/ls -a | /bin/grep -v '\.py' | /usr/bin/wc -l
     >>> chain()
-    u'13\n'
+    '13\n'
 
 See :ref:`guide-local-commands-pipelining`.
 
@@ -51,11 +51,11 @@ Redirection
 .. code-block:: python
 
     >>> ((cat < "setup.py") | head["-n", 4])()
-    u'#!/usr/bin/env python\nimport os\n\ntry:\n'
+    '#!/usr/bin/env python3\nimport os\n\ntry:\n'
     >>> (ls["-a"] > "file.list")()
-    u''
+    ''
     >>> (cat["file.list"] | wc["-l"])()
-    u'17\n'
+    '17\n'
 
 See :ref:`guide-local-commands-redir`.
 
@@ -69,7 +69,7 @@ Working-directory manipulation
     >>> with local.cwd(local.cwd / "docs"):
     ...     chain()
     ...
-    u'15\n'
+    '15\n'
 
 A more explicit, and thread-safe way of running a command in a differet directory is using the ``.with_cwd()`` method:
 
@@ -103,7 +103,7 @@ Command nesting
 .. code-block:: python
 
     >>> from plumbum.cmd import sudo
-    >>> print sudo[ifconfig["-a"]]
+    >>> print(sudo[ifconfig["-a"]])
     /usr/bin/sudo /sbin/ifconfig -a
     >>> (sudo[ifconfig["-a"]] | grep["-i", "loop"]) & FG
     lo        Link encap:Local Loopback
@@ -127,7 +127,7 @@ and `Paramiko <https://github.com/paramiko/paramiko/>`_ (a pure-Python implement
     >>> with remote.cwd("/lib"):
     ...     (r_ls | grep["0.so.0"])()
     ...
-    u'libusb-1.0.so.0\nlibusb-1.0.so.0.0.0\n'
+    'libusb-1.0.so.0\nlibusb-1.0.so.0.0.0\n'
 
 See :ref:`guide-remote`.
 
@@ -150,9 +150,9 @@ CLI applications
             logging.root.setLevel(level)
 
         def main(self, *srcfiles):
-            print "Verbose:", self.verbose
-            print "Include dirs:", self.include_dirs
-            print "Compiling:", srcfiles
+            print("Verbose:", self.verbose)
+            print("Include dirs:", self.include_dirs)
+            print("Compiling:", srcfiles)
 
     if __name__ == "__main__":
         MyCompiler.run()
@@ -162,7 +162,7 @@ Sample output
 
 ::
 
-    $ python simple_cli.py -v -I foo/bar -Ispam/eggs x.cpp y.cpp z.cpp
+    $ python3 simple_cli.py -v -I foo/bar -Ispam/eggs x.cpp y.cpp z.cpp
     Verbose: True
     Include dirs: ['foo/bar', 'spam/eggs']
     Compiling: ('x.cpp', 'y.cpp', 'z.cpp')

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -32,10 +32,10 @@ might look like this::
 
 And you can run it::
 
-    $ python example.py foo
+    $ python3 example.py foo
     I will now read foo
 
-    $ python example.py --help
+    $ python3 example.py --help
     example.py v1.0
 
     Usage: example.py [SWITCHES] filename
@@ -443,12 +443,12 @@ can be enabled by defining the class-level attribute ``ALLOW_ABBREV`` to True. F
 
 With the above definition, running the following will raise an error due to ambiguity::
 
-    $ python example.py --ch   # error! matches --cheese and --chives
+    $ python3 example.py --ch   # error! matches --cheese and --chives
 
 However, the following two lines are equivalent::
 
-    $ python example.py --che
-    $ python example.py --cheese
+    $ python3 example.py --che
+    $ python3 example.py --cheese
 
 
 .. _guide-subcommands:
@@ -525,7 +525,7 @@ attached to the root application using the ``subcommand`` decorator ::
 
 Here's an example of running this application::
 
-    $ python geet.py --help
+    $ python3 geet.py --help
     geet v1.7.2
     The l33t version control
 
@@ -540,7 +540,7 @@ Here's an example of running this application::
         push                       pushes the current local branch to the remote
                                    one; see 'geet push --help' for more info
 
-    $ python geet.py commit --help
+    $ python3 geet.py commit --help
     geet commit v1.7.2
     creates a new commit in the current branch
 
@@ -553,7 +553,7 @@ Here's an example of running this application::
         -a                         automatically add changed files
         -m VALUE:str               sets the commit message; required
 
-    $ python geet.py commit -m "foo"
+    $ python3 geet.py commit -m "foo"
     committing...
 
 
@@ -605,7 +605,7 @@ is ignored and the image will no longer be constrained to scale proportionately.
 To directly plot an image, the ``show`` method takes a filename and a double
 parameter, which doubles the vertical resolution on some fonts. The ``show_pil``
 and ``show_pil_double`` methods directly take a PIL-like object. To plot an image
-from the command line, the module can be run directly: ``python -m
+from the command line, the module can be run directly: ``python3 -m
 plumbum.cli.image myimage.png``.
 
 For the full list of helpers or more information, see the :ref:`api docs <api-cli>`.

--- a/docs/colorlib.rst
+++ b/docs/colorlib.rst
@@ -87,17 +87,17 @@ following, typed into the command line, will restore it:
 
 .. code:: bash
 
-    $ python -m plumbum.colors
+    $ python3 -m plumbum.colors
 
 This also supports command line access to unsafe color manipulations, such as
 
 .. code:: bash
 
-    $ python -m plumbum.colors blue
-    $ python -m plumbum.colors bg red
-    $ python -m plumbum.colors fg 123
-    $ python -m plumbum.colors bg reset
-    $ python -m plumbum.colors underline
+    $ python3 -m plumbum.colors blue
+    $ python3 -m plumbum.colors bg red
+    $ python3 -m plumbum.colors fg 123
+    $ python3 -m plumbum.colors bg reset
+    $ python3 -m plumbum.colors underline
 
 You can use any path or number available as a style.
 

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -164,17 +164,17 @@ when Python exits.
 
     .. code:: bash
 
-        $ python -m plumbum.colors
+        $ python3 -m plumbum.colors
 
     This also supports command line access to unsafe color manipulations, such as
 
     .. code:: bash
 
-        $ python -m plumbum.colors blue
-        $ python -m plumbum.colors bg red
-        $ python -m plumbum.colors fg 123
-        $ python -m plumbum.colors bg reset
-        $ python -m plumbum.colors underline
+        $ python3 -m plumbum.colors blue
+        $ python3 -m plumbum.colors bg red
+        $ python3 -m plumbum.colors fg 123
+        $ python3 -m plumbum.colors bg reset
+        $ python3 -m plumbum.colors underline
 
 You can use any path or number available as a style.
 

--- a/docs/local_commands.rst
+++ b/docs/local_commands.rst
@@ -93,7 +93,7 @@ Now that we can bind arguments to commands, forming pipelines is easy and straig
 using ``|`` (bitwise-or)::
 
     >>> chain = ls["-l"] | grep[".py"]
-    >>> print chain
+    >>> print(chain)
     C:\Program Files\Git\bin\ls.exe -l | C:\Program Files\Git\bin\grep.exe .py
     >>>
     >>> chain()
@@ -167,7 +167,7 @@ one you passed::
    but not both), you can use the ``run`` method, which will provide all of them
 
    >>>  cat["non/existing.file"].run(retcode=None)
-   (1, u'', u'/bin/cat: non/existing.file: No such file or directory\n')
+   (1, '', '/bin/cat: non/existing.file: No such file or directory\n')
 
 
 
@@ -277,11 +277,11 @@ as we've seen above, but they can also be other **commands**! This allows nestin
 one another, forming complex command objects. The classic example is ``sudo``::
 
     >>> from plumbum.cmd import sudo
-    >>> print sudo[ls["-l", "-a"]]
+    >>> print(sudo[ls["-l", "-a"]])
     /usr/bin/sudo /bin/ls -l -a
 
     >>> sudo[ls["-l", "-a"]]()
-    u'total 22\ndrwxr-xr-x    8 sebulba  Administ     4096 May  9 20:46 .\n[...]'
+    'total 22\ndrwxr-xr-x    8 sebulba  Administ     4096 May  9 20:46 .\n[...]'
 
 In fact, you can nest even command-chains (i.e., pipes and redirections), e.g.,
 ``sudo[ls | grep["\\.py"]]``; however, that would require that the top-level program be able
@@ -302,7 +302,7 @@ We'll learn more about remote command execution :ref:`later <guide-remote-comman
 meanwhile, we should learn that command nesting works by *shell-quoting* (or *shell-escaping*)
 the nested command. Quoting normally takes place from the second level of nesting::
 
-    >>> print ssh["somehost", ssh["anotherhost", ls | grep["\\.py"]]]
+    >>> print(ssh["somehost", ssh["anotherhost", ls | grep["\\.py"]]])
     /bin/ssh somehost /bin/ssh anotherhost /bin/ls '|' /bin/grep "'\\.py'"
 
 In this example, we first ssh to ``somehost``, from it we ssh to ``anotherhost``, and on that host

--- a/docs/local_machine.rst
+++ b/docs/local_machine.rst
@@ -19,9 +19,9 @@ Another member is ``python``, which is a command object that points to the curre
 (``sys.executable``)::
 
     >>> local.python
-    <LocalCommand c:\python27\python.exe>
-    >>> local.python("-c", "import sys;print sys.version")
-    '2.7.2 (default, Jun 12 2011, 15:08:59) [MSC v.1500 32 bit (Intel)]\r\n'
+    <LocalCommand c:\python310\python.exe>
+    >>> local.python("-c", "import sys;print(sys.version)")
+    '3.10.0 (default, Feb 2 2022, 02:22:22) [MSC v.1931 64 bit (Intel)]\r\n'
 
 Working Directory
 -----------------
@@ -35,14 +35,15 @@ The ``local.cwd`` attribute represents the current working directory. You can ch
 
 You can also use it as a *context manager*, so it behaves like ``pushd``/``popd``::
 
+    >>> ls_l = ls | wc["-l"]
     >>> with local.cwd("c:\\windows"):
-    ...     print "%s:%s" % (local.cwd, (ls | wc["-l"])())
+    ...     print(f"{local.cwd}:{ls_l()}")
     ...     with local.cwd("c:\\windows\\system32"):
-    ...         print "%s:%s" % (local.cwd, (ls | wc["-l"])())
+    ...         print(f"{local.cwd}:{ls_l()}")
     ...
     c:\windows: 105
     c:\windows\system32: 3013
-    >>> print "%s:%s" % (local.cwd, (ls | wc["-l"])())
+    >>> print(f"{local.cwd}:{ls_l()}")
     d:\workspace\plumbum: 9
 
 Finally, A more explicit and thread-safe way of running a command in a different directory is using the ``.with_cwd()`` method:
@@ -65,10 +66,10 @@ And similarity to ``cwd`` is the context-manager nature of ``env``; each level w
 it's own private copy of the environment::
 
     >>> with local.env(FOO="BAR"):
-    ...     local.python("-c", "import os;print os.environ['FOO']")
+    ...     local.python("-c", "import os; print(os.environ['FOO'])")
     ...     with local.env(FOO="SPAM"):
-    ...         local.python("-c", "import os;print os.environ['FOO']")
-    ...     local.python("-c", "import os;print os.environ['FOO']")
+    ...         local.python("-c", "import os; print(os.environ['FOO'])")
+    ...     local.python("-c", "import os; print(os.environ['FOO'])")
     ...
     'BAR\r\n'
     'SPAM\r\n'
@@ -77,10 +78,10 @@ it's own private copy of the environment::
     Traceback (most recent call last):
        [...]
     ProcessExecutionError: Unexpected exit code: 1
-    Command line: | /usr/bin/python -c "import os;print(os.environ['FOO'])"
+    Command line: | /usr/bin/python3 -c "import os; print(os.environ['FOO'])"
     Stderr:       | Traceback (most recent call last):
                   |   File "<string>", line 1, in <module>
-                  |   File "/usr/lib/python3.5/os.py", line 725, in __getitem__
+                  |   File "/usr/lib/python3.10/os.py", line 725, in __getitem__
                   |     raise KeyError(key) from None
                   | KeyError: 'FOO'
 
@@ -93,13 +94,13 @@ properties for getting the username (``.user``), the home path (``.home``), and 
     >>> local.env.home
     <Path c:\Users\sebulba>
     >>> local.env.path
-    [<Path c:\python27\lib\site-packages\gtk-2.0\runtime\bin>, <Path c:\Users\sebulba\bin>, ...]
+    [<Path c:\python39\lib\site-packages\gtk-2.0\runtime\bin>, <Path c:\Users\sebulba\bin>, ...]
     >>>
     >>> local.which("python")
-    <Path c:\python27\python.exe>
-    >>> local.env.path.insert(0, "c:\\python32")
+    <Path c:\python39\python.exe>
+    >>> local.env.path.insert(0, "c:\\python310")
     >>> local.which("python")
-    <Path c:\python32\python.exe>
+    <Path c:\python310\python.exe>
 
 
 For further information, see the :ref:`api docs <api-local-machine>`.

--- a/docs/paths.rst
+++ b/docs/paths.rst
@@ -60,7 +60,7 @@ Paths can be composed using ``/`` or ``[]``::
 You can also iterate over directories to get the contents::
 
     >>> for p2 in p:
-    ...     print p2
+    ...     print(p2)
     ...
     c:\windows\addins
     c:\windows\appcompat

--- a/docs/remote.rst
+++ b/docs/remote.rst
@@ -55,7 +55,7 @@ counterparts, they can be used as context managers, so their effects can be cont
     >>> rem.cwd
     <Workdir /home/john>
     >>> with rem.cwd(rem.cwd / "Desktop"):
-    ...     print rem.cwd
+    ...     print(rem.cwd)
     /home/john/Desktop
     >>> rem.env["PATH"]
     /bin:/sbin:/usr/bin:/usr/local/bin
@@ -102,7 +102,7 @@ object. You can either pass the command's name, in which case it will be resolve
     >>> r_ls = rem["ls"]
     >>> r_grep = rem["grep"]
     >>> r_ls()
-    u'foo\nbar\spam\n'
+    'foo\nbar\spam\n'
 
 Nesting Commands
 ^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ behind the scenes - it nests each command inside ``ssh``. Here are some examples
 
     >>> r_sudo = rem["sudo"]
     >>> r_ifconfig = rem["ifconfig"]
-    >>> print r_sudo[r_ifconfig["-a"]]()
+    >>> print(r_sudo[r_ifconfig["-a"]]())
     eth0      Link encap:Ethernet HWaddr ...
     [...]
 
@@ -119,11 +119,11 @@ You can nest multiple commands, one within another. For instance, you can connec
 over SSH and use that machine's SSH client to connect to yet another machine. Here's a sketch::
 
     >>> from plumbum.cmd import ssh
-    >>> print ssh["localhost", ssh["localhost", "ls"]]
+    >>> print(ssh["localhost", ssh["localhost", "ls"]])
     /usr/bin/ssh localhost /usr/bin/ssh localhost ls
     >>>
     >>> ssh["localhost", ssh["localhost", "ls"]]()
-    u'bin\nDesktop\nDocuments\n...'
+    'bin\nDesktop\nDocuments\n...'
 
 
 Piping
@@ -134,7 +134,7 @@ place on the local machine! Consider this code for instance ::
     >>> r_grep = rem["grep"]
     >>> r_ls = rem["ls"]
     >>> (r_ls | r_grep["b"])()
-    u'bin\nPublic\n'
+    'bin\nPublic\n'
 
 Although ``r_ls`` and ``r_grep`` are remote commands, the data is sent from ``r_ls`` to the local
 machine, which then sends it to the remote one for running ``grep``. This will be fixed in a future
@@ -145,7 +145,7 @@ For example, the previous code can be written as ::
 
     >>> from plumbum.cmd import grep
     >>> (r_ls | grep["b"])()
-    u'bin\nPublic\n'
+    'bin\nPublic\n'
 
 Which is even more efficient (no need to send data back and forth over SSH).
 
@@ -178,9 +178,9 @@ and it works along the lines of the ``SshMachine``::
     RemoteCommand(<ParamikoMachine paramiko://192.168.1.143>, <RemotePath /bin/ls>)
     >>> r_ls = rem["ls"]
     >>> r_ls()
-    u'bin\nDesktop\nDocuments\nDownloads\nexamples.desktop\nMusic\nPictures\n...'
+    'bin\nDesktop\nDocuments\nDownloads\nexamples.desktop\nMusic\nPictures\n...'
     >>> r_ls("-a")
-    u'.\n..\n.adobe\n.bash_history\n.bash_logout\n.bashrc\nbin...'
+    '.\n..\n.adobe\n.bash_history\n.bash_logout\n.bashrc\nbin...'
 
 .. note::
     Using ``ParamikoMachine`` requires paramiko to be installed on your system. Also, you have
@@ -209,7 +209,7 @@ object
 
         >>> s = mach.session()
         >>> s.run("ls | grep b")
-        (0, u'bin\nPublic\n', u'')
+        (0, 'bin\nPublic\n', '')
 
 
 Tunneling Example

--- a/examples/alignment.py
+++ b/examples/alignment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from plumbum import cli
 
 

--- a/examples/color.py
+++ b/examples/color.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from plumbum import colors
 

--- a/examples/filecopy.py
+++ b/examples/filecopy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 
 from plumbum import cli, local

--- a/examples/fullcolor.py
+++ b/examples/fullcolor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from plumbum import colors
 

--- a/examples/geet.py
+++ b/examples/geet.py
@@ -1,14 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Examples::
 
-    $ python geet.py
+    $ python3 geet.py
     no command given
 
-    $ python geet.py leet
+    $ python3 geet.py leet
     unknown command 'leet'
 
-    $ python geet.py --help
+    $ python3 geet.py --help
     geet v1.7.2
     The l33t version control
 
@@ -23,7 +23,7 @@ Examples::
         push                       pushes the current local branch to the remote
                                    one; see 'geet push --help' for more info
 
-    $ python geet.py commit --help
+    $ python3 geet.py commit --help
     geet commit v1.7.2
     creates a new commit in the current branch
 
@@ -36,7 +36,7 @@ Examples::
         -a                         automatically add changed files
         -m VALUE:str               sets the commit message; required
 
-    $ python geet.py commit -m "foo"
+    $ python3 geet.py commit -m "foo"
     committing...
 """
 

--- a/examples/make_figures.py
+++ b/examples/make_figures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from plumbum import FG, cli, local
 from plumbum.cmd import convert, pdflatex

--- a/examples/simple_cli.py
+++ b/examples/simple_cli.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
-$ python simple_cli.py --help
+$ python3 simple_cli.py --help
 simple_cli.py v1.0
 
 Usage: simple_cli.py [SWITCHES] srcfiles...
@@ -14,22 +14,22 @@ Switches:
     --loglevel LEVEL:int       Sets the log-level of the logger
     -v, --verbose              Enable verbose mode
 
-$ python simple_cli.py x.cpp y.cpp z.cpp
+$ python3 simple_cli.py x.cpp y.cpp z.cpp
 Verbose: False
 Include dirs: []
 Compiling: ('x.cpp', 'y.cpp', 'z.cpp')
 
-$ python simple_cli.py -v
+$ python3 simple_cli.py -v
 Verbose: True
 Include dirs: []
 Compiling: ()
 
-$ python simple_cli.py -v -Ifoo/bar -Ispam/eggs
+$ python3 simple_cli.py -v -Ifoo/bar -Ispam/eggs
 Verbose: True
 Include dirs: ['foo/bar', 'spam/eggs']
 Compiling: ()
 
-$ python simple_cli.py -v -I foo/bar -Ispam/eggs x.cpp y.cpp z.cpp
+$ python3 simple_cli.py -v -I foo/bar -Ispam/eggs x.cpp y.cpp z.cpp
 Verbose: True
 Include dirs: ['foo/bar', 'spam/eggs']
 Compiling: ('x.cpp', 'y.cpp', 'z.cpp')

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -6,16 +6,16 @@ as a ``Popen`` replacement, and much more::
 
     >>> from plumbum.cmd import ls, grep, wc, cat
     >>> ls()
-    u'build.py\ndist\ndocs\nLICENSE\nplumbum\nREADME.rst\nsetup.py\ntests\ntodo.txt\n'
+    'build.py\ndist\ndocs\nLICENSE\nplumbum\nREADME.rst\nsetup.py\ntests\ntodo.txt\n'
     >>> chain = ls["-a"] | grep["-v", "py"] | wc["-l"]
-    >>> print chain
+    >>> print(chain)
     /bin/ls -a | /bin/grep -v py | /usr/bin/wc -l
     >>> chain()
-    u'12\n'
+    '12\n'
     >>> ((ls["-a"] | grep["-v", "py"]) > "/tmp/foo.txt")()
-    u''
+    ''
     >>> ((cat < "/tmp/foo.txt") | wc["-l"])()
-    u'12\n'
+    '12\n'
     >>> from plumbum import local, FG, BG
     >>> with local.cwd("/tmp"):
     ...     (ls | wc["-l"]) & FG
@@ -23,9 +23,9 @@ as a ``Popen`` replacement, and much more::
     13              # printed directly to the interpreter's stdout
     >>> (ls | wc["-l"]) & BG
     <Future ['/usr/bin/wc', '-l'] (running)>
-    >>> f=_
+    >>> f = _
     >>> f.stdout    # will wait for the process to terminate
-    u'9\n'
+    '9\n'
 
 Plumbum includes local/remote path abstraction, working directory and environment
 manipulation, process execution, remote process execution over SSH, tunneling,

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -445,8 +445,7 @@ class Application:
         if argtype:
             try:
                 return argtype(val)
-            except (TypeError, ValueError):
-                ex = sys.exc_info()[1]  # compat
+            except (TypeError, ValueError) as ex:
                 raise WrongArgumentType(
                     T_(
                         "Argument of {name} expected to be {argtype}, not {val!r}:\n    {ex!r}"
@@ -608,8 +607,7 @@ class Application:
             inst.helpall()
         except ShowVersion:
             inst.version()
-        except SwitchError:
-            ex = sys.exc_info()[1]  # compatibility with python 2.5
+        except SwitchError as ex:
             print(T_("Error: {0}").format(ex))
             print(T_("------"))
             inst.help()

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -56,7 +56,7 @@ class Image:
         for y in range(size[1]):
             for x in range(size[0] - 1):
                 pix = new_im.getpixel((x, y))
-                print(colors.bg.rgb(*pix), " ", sep="", end="")  # u'\u2588'
+                print(colors.bg.rgb(*pix), " ", sep="", end="")  # '\u2588'
             print(colors.reset, " ", sep="")
         print(colors.reset)
 

--- a/plumbum/colorlib/__init__.py
+++ b/plumbum/colorlib/__init__.py
@@ -38,7 +38,7 @@ def load_ipython_extension(ipython):  # pragma: no cover
 
 def main():  # pragma: no cover
     """Color changing script entry. Call using
-    python -m plumbum.colors, will reset if no arguments given."""
+    python3 -m plumbum.colors, will reset if no arguments given."""
     color = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else ""
     ansicolors.use_color = True
     ansicolors.get_colors_from_string(color).now()

--- a/plumbum/colorlib/__main__.py
+++ b/plumbum/colorlib/__main__.py
@@ -1,6 +1,6 @@
 """
 This is provided as a quick way to recover your terminal. Simply run
-``python -m plumbum.colorlib``
+``python3 -m plumbum.colorlib``
 to recover terminal color.
 """
 

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -510,7 +510,7 @@ class Style:
             file.flush()
 
     print_ = print
-    """Shortcut just in case user not using __future__"""
+    """DEPRECATED: Shortcut from classic Python 2"""
 
     def __getitem__(self, wrapped):
         """The [] syntax is supported for wrapping"""

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -90,8 +90,7 @@ def posix_daemonize(command, cwd, stdout=None, stderr=None, append=True):
             if self.returncode is None:
                 try:
                     os.kill(self.pid, 0)
-                except OSError:
-                    ex = sys.exc_info()[1]
+                except OSError as ex:
                     if ex.errno == errno.ESRCH:
                         # process does not exist
                         self.returncode = 0

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -4,7 +4,6 @@ Atomic file operations
 
 import atexit
 import os
-import sys
 import threading
 from contextlib import contextmanager
 
@@ -35,8 +34,7 @@ except ImportError:
                 0xFFFFFFFF,
                 OVERLAPPED(),
             )
-        except WinError:
-            _, ex, _ = sys.exc_info()
+        except WinError as ex:
             raise OSError(*ex.args) from None
         try:
             yield
@@ -185,9 +183,9 @@ class AtomicCounterFile:
     Example::
 
         acf = AtomicCounterFile.open("/some/file")
-        print acf.next()   # e.g., 7
-        print acf.next()   # 8
-        print acf.next()   # 9
+        print(acf.next())  # e.g., 7
+        print(acf.next())  # 8
+        print(acf.next())  # 9
 
     .. versionadded:: 1.3
     """

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -180,7 +180,7 @@ class BaseRemoteMachine(BaseMachine):
             return out.strip()
 
         rc, out, _ = self._session.run(
-            "python -c 'import platform;print(platform.uname()[0])'", retcode=None
+            "python3 -c 'import platform;print(platform.uname()[0])'", retcode=None
         )
         if rc == 0:
             return out.strip()
@@ -264,7 +264,7 @@ class BaseRemoteMachine(BaseMachine):
     def python(self):
         """A command that represents the default remote python interpreter"""
         if not self._python:
-            self._python = self["python"]
+            self._python = self["python3"]
         return self._python
 
     def session(self, isatty=False, new_session=False):

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -3,7 +3,6 @@ import glob
 import logging
 import os
 import shutil
-import sys
 import urllib.parse as urlparse
 import urllib.request as urllib
 from contextlib import contextmanager
@@ -161,9 +160,8 @@ class LocalPath(Path):
         else:
             try:
                 os.remove(str(self))
-            except OSError:  # pragma: no cover
+            except OSError as ex:  # pragma: no cover
                 # file might already been removed (a race with other threads/processes)
-                _, ex, _ = sys.exc_info()
                 if ex.errno != errno.ENOENT:
                     raise
 
@@ -197,9 +195,8 @@ class LocalPath(Path):
                     os.makedirs(str(self), mode)
                 else:
                     os.mkdir(str(self), mode)
-            except OSError:  # pragma: no cover
+            except OSError as ex:  # pragma: no cover
                 # directory might already exist (a race with other threads/processes)
-                _, ex, _ = sys.exc_info()
                 if ex.errno != errno.EEXIST or not exist_ok:
                     raise
 
@@ -299,9 +296,8 @@ class LocalPath(Path):
             else:
                 # windows: use rmdir for directories and directory symlinks
                 os.rmdir(str(self))
-        except OSError:  # pragma: no cover
+        except OSError as ex:  # pragma: no cover
             # file might already been removed (a race with other threads/processes)
-            _, ex, _ = sys.exc_info()
             if ex.errno != errno.ENOENT:
                 raise
 

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -1,6 +1,5 @@
 import errno
 import os
-import sys
 import urllib.request as urllib
 from contextlib import contextmanager
 
@@ -224,8 +223,7 @@ class RemotePath(Path):
                 self.remote._path_mkdir(self.parent, mode=mode, minus_p=True)
             try:
                 self.remote._path_mkdir(self, mode=mode, minus_p=False)
-            except ProcessExecutionError:
-                _, ex, _ = sys.exc_info()
+            except ProcessExecutionError as ex:
                 if "File exists" not in ex.stderr:
                     raise
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pytest
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -428,22 +428,22 @@ class TestLocalMachine:
             local.python("-c", "import os;os.environ['FOOBAR72']")
         local.env["FOOBAR72"] = "spAm"
         assert local.python(
-            "-c", "import os;print (os.environ['FOOBAR72'])"
+            "-c", "import os; print(os.environ['FOOBAR72'])"
         ).splitlines() == ["spAm"]
 
         with local.env(FOOBAR73=1889):
             assert local.python(
-                "-c", "import os;print (os.environ['FOOBAR73'])"
+                "-c", "import os; print(os.environ['FOOBAR73'])"
             ).splitlines() == ["1889"]
             with local.env(FOOBAR73=1778):
                 assert local.python(
-                    "-c", "import os;print (os.environ['FOOBAR73'])"
+                    "-c", "import os; print(os.environ['FOOBAR73'])"
                 ).splitlines() == ["1778"]
             assert local.python(
-                "-c", "import os;print (os.environ['FOOBAR73'])"
+                "-c", "import os; print(os.environ['FOOBAR73'])"
             ).splitlines() == ["1889"]
         with pytest.raises(ProcessExecutionError):
-            local.python("-c", "import os;os.environ['FOOBAR73']")
+            local.python("-c", "import os; os.environ['FOOBAR73']")
 
         # path manipulation
         with pytest.raises(CommandNotFound):
@@ -459,7 +459,7 @@ class TestLocalMachine:
         assert local.path("foo") == os.path.join(os.getcwd(), "foo")
         local.which("ls")
         local["ls"]
-        assert local.python("-c", "print ('hi there')").splitlines() == ["hi there"]
+        assert local.python("-c", "print('hi there')").splitlines() == ["hi there"]
 
     @skip_on_windows
     def test_piping(self):
@@ -846,7 +846,7 @@ class TestLocalMachine:
     def test_atomic_file2(self):
         af = AtomicFile("tmp.txt")
 
-        code = """from __future__ import with_statement
+        code = """\
 from plumbum.fs.atomic import AtomicFile
 af = AtomicFile("tmp.txt")
 try:
@@ -863,7 +863,7 @@ except (OSError, IOError):
 
     @skip_on_windows
     def test_pid_file(self):
-        code = """from __future__ import with_statement
+        code = """\
 from plumbum.fs.atomic import PidFile, PidFileTaken
 try:
     with PidFile("mypid"):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import socket
-import sys
 import time
 from multiprocessing import Queue
 from threading import Thread
@@ -421,11 +420,8 @@ s.close()
                 ):
                     print("out:", out)
                     print("err:", err)
-            except NotImplementedError:
-                try:
-                    pytest.skip(str(sys.exc_info()[1]))
-                except AttributeError:
-                    return
+            except NotImplementedError as err:
+                pytest.skip(str(err))
             except ProcessTimedOut:
                 assert i > 3
             else:

--- a/tests/test_visual_color.py
+++ b/tests/test_visual_color.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import unittest

--- a/translations.py
+++ b/translations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # If you are on macOS and using brew, you might need the following first:
 # export PATH="/usr/local/opt/gettext/bin:$PATH"


### PR DESCRIPTION
* Includes removals for Python 2.5(!) workarounds.
* Always use `python3` over `python` in code and docs.
* Using Python 3 print statements in docs.
* Avoid showing `u'` in docs.


Closes #587.
