### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,6 @@ description = Plumbum: shell combinators library
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 url = https://plumbum.readthedocs.io
-project_urls =
-    Bug Tracker = https://github.com/tomerfiliba/plumbum/issues
-    Changelog = https://plumbum.readthedocs.io/en/latest/changelog.html
-    Source = https://github.com/tomerfiliba/plumbum
 author = Tomer Filiba
 author_email = tomerfiliba@gmail.com
 license = MIT
@@ -39,6 +35,10 @@ keywords =
     execution,
     color,
     cli
+project_urls =
+    Bug Tracker = https://github.com/tomerfiliba/plumbum/issues
+    Changelog = https://plumbum.readthedocs.io/en/latest/changelog.html
+    Source = https://github.com/tomerfiliba/plumbum
 provides = plumbum
 
 [options]


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)