### PR TITLE
made StdinDataRedirection compatible with modifiers writing to stdout

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -547,7 +547,7 @@ class StdinDataRedirection(BaseCommand):
         return self.cmd.machine
 
     def popen(self, args=(), **kwargs):
-        if "stdin" in kwargs and kwargs["stdin"] != PIPE:
+        if kwargs.get('stdin') not in (PIPE, None):
             raise RedirectionError("stdin is already redirected")
         data = self.data
         if isinstance(data, str) and self._get_encoding() is not None:
@@ -558,8 +558,9 @@ class StdinDataRedirection(BaseCommand):
             f.write(chunk)
             data = data[self.CHUNK_SIZE :]
         f.seek(0)
+        kwargs['stdin'] = f
         # try:
-        return self.cmd.popen(args, stdin=f, **kwargs)
+        return self.cmd.popen(args, **kwargs)
         # finally:
         #    f.close()
 

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -547,7 +547,7 @@ class StdinDataRedirection(BaseCommand):
         return self.cmd.machine
 
     def popen(self, args=(), **kwargs):
-        if kwargs.get('stdin') not in (PIPE, None):
+        if kwargs.get("stdin") not in (PIPE, None):
             raise RedirectionError("stdin is already redirected")
         data = self.data
         if isinstance(data, str) and self._get_encoding() is not None:
@@ -558,7 +558,7 @@ class StdinDataRedirection(BaseCommand):
             f.write(chunk)
             data = data[self.CHUNK_SIZE :]
         f.seek(0)
-        kwargs['stdin'] = f
+        kwargs["stdin"] = f
         # try:
         return self.cmd.popen(args, **kwargs)
         # finally:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -640,6 +640,20 @@ class TestLocalMachine:
             assert EXPECT == capfd.readouterr()[0]
 
     @skip_on_windows
+    @pytest.mark.parametrize('modifier, expected', [(FG, None),
+                                                    (TF(FG=True), True),
+                                                    (RETCODE(FG=True), 0),
+                                                    (TEE, (0, 'meow', ''))])
+    def test_redirection_stdin_modifiers_fg(self, modifier, expected, capfd):
+        "StdinDataRedirection compatible with modifiers which write to stdout"
+        from plumbum.cmd import cat
+
+        cmd = cat << "meow"
+
+        assert cmd & modifier == expected
+        assert capfd.readouterr() == ("meow", "")
+
+    @skip_on_windows
     def test_logger_pipe(self):
         from plumbum.cmd import bash
         from plumbum.commands.modifiers import PipeToLoggerMixin

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -640,10 +640,15 @@ class TestLocalMachine:
             assert EXPECT == capfd.readouterr()[0]
 
     @skip_on_windows
-    @pytest.mark.parametrize('modifier, expected', [(FG, None),
-                                                    (TF(FG=True), True),
-                                                    (RETCODE(FG=True), 0),
-                                                    (TEE, (0, 'meow', ''))])
+    @pytest.mark.parametrize(
+        "modifier, expected",
+        [
+            (FG, None),
+            (TF(FG=True), True),
+            (RETCODE(FG=True), 0),
+            (TEE, (0, "meow", "")),
+        ],
+    )
     def test_redirection_stdin_modifiers_fg(self, modifier, expected, capfd):
         "StdinDataRedirection compatible with modifiers which write to stdout"
         from plumbum.cmd import cat


### PR DESCRIPTION
_I.e._ fixed:

    (cat << "meow") & FG

Modifiers writing to stdout – _e.g._: `FG`, `TEE`, `RETCODE(FG=True)` and
`TF(FG=True)` – invoke commands with the specification `stdin=None`.
This is handled correctly by `BaseCommand`; however, `StdinDataRedirection`
misinterprets this as a further attempt to specify stdin (_i.e._ to
specify _something_ rather than _nothing_).

This change brings `StdinDataRedirection` in line with its base class,
ignoring `None` as well as `PIPE`.

(Though a technical detail, the class would also have failed any
invocation setting `stdin=PIPE`, along the lines of: "TypeError: got
multiple values for keyword argument 'stdin'". The kwargs passed to the
wrapped command's `popen` are corrected as well.)

resolves #604