### PR TITLE
fix: pylint 2.14 support, pin pylint

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def pylint(session):
     Run pylint.
     """
 
-    session.install(".", "paramiko", "ipython", "pylint")
+    session.install(".", "paramiko", "ipython", "pylint~=2.14.3")
     session.run("pylint", "plumbum", *session.posargs)
 
 

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -69,7 +69,7 @@ class ProgressBase(ABC):
         return rval
 
     def next(self):
-        return self.__next__()
+        return next(self)
 
     @property
     def value(self):

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -290,7 +290,7 @@ class PidFile:
             return
         self._ctx = self.atomicfile.locked(blocking=False)
         try:
-            self._ctx.__enter__()
+            self._ctx.__enter__()  # pylint: disable=unnecessary-dunder-call
         except OSError:
             self._ctx = None
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ ignore = [
 [tool.pylint]
 master.py-version = "3.6"
 master.jobs = "0"
+master.load-plugins = ["pylint.extensions.no_self_use"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 messages_control.enable = [
@@ -103,4 +104,5 @@ messages_control.disable = [
   "too-many-return-statements",
   "too-many-statements",
   "unidiomatic-typecheck", # TODO: might be able to remove
+  "unnecessary-lambda-assignment", # TODO: 4 instances
 ]


### PR DESCRIPTION
CI can break when a new minor version is released. Ideally this could be auto-bumped, but for now, let's just pin in the nox file.
