### PR TITLE
Support SSH tunnels with dynamic free port allocation

### DIFF
--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -217,6 +217,7 @@ class ShellSession:
         self.isatty = isatty
         self._lock = threading.RLock()
         self._current = None
+        self._startup_result = None
         if connect_timeout:
 
             def closer():
@@ -228,7 +229,7 @@ class ShellSession:
             timer = threading.Timer(connect_timeout, closer)
             timer.start()
         try:
-            self.run("")
+            self._startup_result = self.run("")
         finally:
             if connect_timeout:
                 timer.cancel()

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 from plumbum.commands import ProcessExecutionError, shquote
@@ -13,10 +14,21 @@ class SshTunnel:
     """An object representing an SSH tunnel (created by
     :func:`SshMachine.tunnel <plumbum.machines.remote.SshMachine.tunnel>`)"""
 
-    __slots__ = ["_session", "__weakref__"]
+    __slots__ = ["_session", "_lport", "_dport", "_reverse", "__weakref__"]
 
-    def __init__(self, session):
+    def __init__(self, session, lport, dport, reverse):
         self._session = session
+        self._lport = lport
+        self._dport = dport
+        self._reverse = reverse
+        if reverse and str(dport) == "0" and session._startup_result is not None:
+            # Try to detect assigned remote port.
+            regex = re.compile(
+                r"^Allocated port (\d+) for remote forward to .+$", re.MULTILINE
+            )
+            match = regex.search(session._startup_result[2])
+            if match:
+                self._dport = match.group(1)
 
     def __repr__(self):
         tunnel = self._session.proc if self._session.alive() else "(defunct)"
@@ -31,6 +43,21 @@ class SshTunnel:
     def close(self):
         """Closes(terminates) the tunnel"""
         self._session.close()
+
+    @property
+    def lport(self):
+        """Tunneled port or socket on the local machine."""
+        return self._lport
+
+    @property
+    def dport(self):
+        """Tunneled port or socket on the remote machine."""
+        return self._dport
+
+    @property
+    def reverse(self):
+        """Represents if the tunnel is a reverse tunnel."""
+        return self._reverse
 
 
 class SshMachine(BaseRemoteMachine):
@@ -287,7 +314,10 @@ class SshMachine(BaseRemoteMachine):
         return SshTunnel(
             ShellSession(
                 proc, self.custom_encoding, connect_timeout=self.connect_timeout
-            )
+            ),
+            lport,
+            dport,
+            reverse,
         )
 
     def _translate_drive_letter(self, path):  # pylint: disable=no-self-use

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -1,5 +1,7 @@
 import re
+import socket
 import warnings
+from contextlib import closing
 
 from plumbum.commands import ProcessExecutionError, shquote
 from plumbum.lib import IS_WIN32
@@ -8,6 +10,14 @@ from plumbum.machines.remote import BaseRemoteMachine
 from plumbum.machines.session import ShellSession
 from plumbum.path.local import LocalPath
 from plumbum.path.remote import RemotePath
+
+
+def _get_free_port():
+    """Attempts to find a free port."""
+    s = socket.socket()
+    with closing(s):
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
 
 
 class SshTunnel:
@@ -299,6 +309,8 @@ class SshMachine(BaseRemoteMachine):
         """
         formatted_lhost = "" if lhost is None else f"[{lhost}]:"
         formatted_dhost = "" if dhost is None else f"[{dhost}]:"
+        if str(lport) == "0":
+            lport = _get_free_port()
         ssh_opts = (
             [
                 "-L",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -36,6 +36,10 @@ def strassert(one, two):
     assert str(one) == str(two)
 
 
+def assert_is_port(port):
+    assert 0 < int(port) < 2**16
+
+
 # TEST_HOST = "192.168.1.143"
 TEST_HOST = "127.0.0.1"
 if TEST_HOST not in ("::1", "127.0.0.1", "localhost"):
@@ -444,9 +448,9 @@ s.close()
             rfile.delete()
 
 
-def serve_reverse_tunnel(queue):
+def serve_reverse_tunnel(queue, port):
     s = socket.socket()
-    s.bind(("", 12223))
+    s.bind(("", port))
     s.listen(1)
     s2, _ = s.accept()
     data = s2.recv(100).decode("ascii").strip()
@@ -472,7 +476,11 @@ class TestRemoteMachine(BaseRemoteMachineTest):
                 except ValueError:
                     dhost = None
 
-                with rem.tunnel(12222, port_or_socket, dhost=dhost):
+                with rem.tunnel(12222, port_or_socket, dhost=dhost) as tun:
+                    assert tun.lport == 12222
+                    assert tun.dport == port_or_socket
+                    assert not tun.reverse
+
                     s = socket.socket()
                     s.connect(("localhost", 12222))
                     s.send(b"world")
@@ -482,10 +490,19 @@ class TestRemoteMachine(BaseRemoteMachineTest):
                 print(p.communicate())
                 assert data == b"hello world"
 
-    def test_reverse_tunnel(self):
+    @pytest.mark.parametrize("dynamic_dport", [False, True])
+    def test_reverse_tunnel(self, dynamic_dport):
 
+        lport = 12223 + dynamic_dport
         with self._connect() as rem:
-            get_unbound_socket_remote = """import sys, socket
+            queue = Queue()
+            tunnel_server = Thread(target=serve_reverse_tunnel, args=(queue, lport))
+            tunnel_server.start()
+            message = str(time.time())
+
+            if not dynamic_dport:
+
+                get_unbound_socket_remote = """import sys, socket
 s = socket.socket()
 s.bind(("", 0))
 s.listen(1)
@@ -493,20 +510,28 @@ sys.stdout.write(str(s.getsockname()[1]))
 sys.stdout.flush()
 s.close()
 """
-            p = (rem.python["-u"] << get_unbound_socket_remote).popen()
-            remote_socket = p.stdout.readline().decode("ascii").strip()
-            queue = Queue()
-            tunnel_server = Thread(target=serve_reverse_tunnel, args=(queue,))
-            tunnel_server.start()
-            message = str(time.time())
-            with rem.tunnel(12223, remote_socket, dhost="localhost", reverse=True):
+                p = (rem.python["-u"] << get_unbound_socket_remote).popen()
+                remote_socket = p.stdout.readline().decode("ascii").strip()
+            else:
+                remote_socket = 0
+
+            with rem.tunnel(
+                lport, remote_socket, dhost="localhost", reverse=True
+            ) as tun:
+                assert tun.lport == lport
+                if not dynamic_dport:
+                    assert tun.dport == remote_socket
+                else:
+                    assert_is_port(tun.dport)
+                assert tun.reverse
+
                 remote_send_af_inet = """import socket
 s = socket.socket()
 s.connect(("localhost", {}))
 s.send("{}".encode("ascii"))
 s.close()
 """.format(
-                    remote_socket, message
+                    tun.dport, message
                 )
                 (rem.python["-u"] << remote_send_af_inet).popen()
                 tunnel_server.join(timeout=1)


### PR DESCRIPTION
Hi! This adds two new features:

*   Reverse (Open)SSH tunnels with dynamically allocated remote ports. E.g.

    ```python
    > tun = SshMachine(...).tunnel(1234, 0, reverse=True)
    > tun.dport
    '43385'
    ```

    Dynamic remote port allocation is done by OpenSSH (`ssh -R`).

*   Non-reverse and reverse (Open)SSH tunnels with dynamically allocated local ports. E.g.

    ```python
    > tun = SshMachine(...).tunnel(0, 1234)
    > tun.lport
    37689
    ```

    Dynamic local port allocation is done by `rpyc.utils.factory._get_free_port`, which I've duplicated into Plumbum. (Minor point: license-wise, `rpyc.utils.factory._get_free_port` is released by @tomerfiliba under the MIT license already. In theory Plumbum should add attribution to satisfy RPyC's license here, but I suspect that Tomer probably would not mind as they authored both projects.)

This also adds a `reverse` property to `SshTunnel`. `lhost` and `dhost` properties could also be added if deemed useful—I imagine the use primary cases there would be to check what address the tunnel was bound to or if the tunnel is for ports or sockets.

This PR probably should also update `SshMachine().tunnel`'s docs. Note that #562 did not update docs for `reverse`.