### PR TITLE
chore: simpler dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "actions/*"


### PR DESCRIPTION
Ignores no longer needed after April 2022. Dependabot keeps the same style pinning now.