### PR TITLE
local: accept path-like (`pathlib.Path`) objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
           os: ubuntu-latest
         - python-version: 'pypy-3.9'
           os: ubuntu-latest
+        - python-version: '3.6'
+          os: ubuntu-20.04
+        exclude:
+        - python-version: '3.6'
+          os: ubuntu-latest
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ cython_debug/
 
 /tests/nohup.out
 /plumbum/version.py
+
+# jetbrains
+.idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,3 @@ cython_debug/
 
 # jetbrains
 .idea
-

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -233,6 +233,8 @@ class LocalMachine(BaseMachine):
             return LocalCommand(cmd)
 
         if not isinstance(cmd, RemotePath):
+            # handle "path-like" (pathlib.Path) objects
+            cmd = os.fspath(cmd)
             if "/" in cmd or "\\" in cmd:
                 # assume path
                 return LocalCommand(local.path(cmd))

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,8 @@ exclude_lines =
 
 [flake8]
 max-complexity = 50
-extend-ignore = E203, E501, B950, T202
-extend-select = B9
+extend-ignore = E203, E501, T202
+extend-select = B902, B903, B904
 per-file-ignores =
     tests/*: T
     examples/*: T

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -3,6 +3,7 @@ import pickle
 import signal
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -328,6 +329,10 @@ class TestLocalMachine:
             from plumbum.cmd import non_exist1N9
 
             assert non_exist1N9
+
+    def test_pathlib(self):
+        ls_path = Path(local.which('ls'))
+        assert "test_local.py" in local[ls_path]().splitlines()
 
     def test_get(self):
         assert str(local["ls"]) == str(local.get("ls"))

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -331,7 +331,7 @@ class TestLocalMachine:
             assert non_exist1N9
 
     def test_pathlib(self):
-        ls_path = Path(local.which('ls'))
+        ls_path = Path(local.which("ls"))
         assert "test_local.py" in local[ls_path]().splitlines()
 
     def test_get(self):


### PR DESCRIPTION
This will allow users to use the API as follows:

```python
from plumbum import local
from pathlib import Path

local[Path('/path/to/binary')]()
```