### PR TITLE
Fix StdinDataRedirection's formulate() method

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -536,9 +536,8 @@ class StdinDataRedirection(BaseCommand):
     def formulate(self, level=0, args=()):
         return [
             f"echo {shquote(self.data)}",
-            "|",
-            self.cmd.formulate(level + 1, args),
-        ]
+            "|"
+        ] + self.cmd.formulate(level + 1, args),
 
     @property
     def machine(self):


### PR DESCRIPTION
### return flat list from derived object's formulate()

The StdinDataRedirection command object was returning a list inside a list, which caused trouble when getting the "str()" of the command.

Simple example to demonstrate the problem:

    Python 3.10.8 (tags/v3.10.8:aaaf517, Oct 11 2022, 16:50:30) [MSC v.1933 64 bit (AMD64)] on win32
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from plumbum.cmd import head
    >>> cmd = head['-2'] << "one\ntwo\nthree\nfour"
    >>> print(f"{cmd}")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "C:\Python310\lib\site-packages\plumbum\commands\base.py", line 66, in __str__
        return " ".join(self.formulate())
    TypeError: sequence item 2: expected str instance, list found
    >>>

This addresses open issue #398 