### PR TITLE
Fix stalling in Pipeline command

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -398,8 +398,6 @@ class Pipeline(BaseCommand):
         dstproc = self.dstcmd.popen(**kwargs)
         # allow p1 to receive a SIGPIPE if p2 exits
         srcproc.stdout.close()
-        if srcproc.stderr is not None:
-            dstproc.stderr = srcproc.stderr
         if srcproc.stdin and src_kwargs.get("stdin") != PIPE:
             srcproc.stdin.close()
         dstproc.srcproc = srcproc

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -18,14 +18,42 @@ def _check_process(proc, retcode, timeout, stdout, stderr):
     return proc.returncode, stdout, stderr
 
 
+def _get_piped_streams(proc):
+    """Get a list of all valid standard streams for proc that were opened with PIPE option.
+
+    If proc was started from a Pipeline command, this function assumes it will have a
+    "srcproc" member pointing to the previous command in the pipeline. That link will
+    be used to traverse all started processes started from the pipeline, the list will
+    include stdout/stderr streams opened as PIPE for all commands in the pipeline.
+    If that was not the case, some processes could write to pipes no one reads from
+    which would result in process stalling after the pipe's buffer is filled.
+
+    Streams that were closed (because they were redirected to the input of a subsequent command)
+    are not included in the result
+    """
+    streams = []
+
+    def add_stream(type_, stream):
+        if stream is None or stream.closed:
+            return
+        streams.append((type_, stream))
+
+    while proc:
+        add_stream(1, proc.stderr)
+        add_stream(0, proc.stdout)
+        proc = getattr(proc, "srcproc", None)
+
+    return streams
+
+
 def _iter_lines_posix(proc, decode, linesize, line_timeout=None):
     from selectors import EVENT_READ, DefaultSelector
-
+    streams = _get_piped_streams(proc)
     # Python 3.4+ implementation
     def selector():
         sel = DefaultSelector()
-        sel.register(proc.stdout, EVENT_READ, 0)
-        sel.register(proc.stderr, EVENT_READ, 1)
+        for stream_type, stream in streams:
+            sel.register(stream, EVENT_READ, stream_type)
         while True:
             ready = sel.select(line_timeout)
             if not ready and line_timeout:
@@ -41,10 +69,9 @@ def _iter_lines_posix(proc, decode, linesize, line_timeout=None):
         yield ret
         if proc.poll() is not None:
             break
-    for line in proc.stdout:
-        yield 0, decode(line)
-    for line in proc.stderr:
-        yield 1, decode(line)
+    for stream_type, stream in streams:
+        for line in stream:
+            yield stream_type, decode(line)
 
 
 def _iter_lines_win32(proc, decode, linesize, line_timeout=None):

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -48,7 +48,9 @@ def _get_piped_streams(proc):
 
 def _iter_lines_posix(proc, decode, linesize, line_timeout=None):
     from selectors import EVENT_READ, DefaultSelector
+
     streams = _get_piped_streams(proc)
+
     # Python 3.4+ implementation
     def selector():
         sel = DefaultSelector()

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -40,25 +40,29 @@ def test_draining_stderr_with_stdout_redirect(tmp_path, generate_cmd, process_cm
 @pytest.fixture()
 def generate_cmd(tmp_path):
     generate = tmp_path / "generate.py"
-    generate.write_text("""\
+    generate.write_text(
+        """\
 import sys
 for i in range(5000):
     print("generated", i, file=sys.stderr)
     print(i)
-""")
+"""
+    )
     return plumbum.local["python"][generate]
 
 
 @pytest.fixture()
 def process_cmd(tmp_path):
     process = tmp_path / "process.py"
-    process.write_text("""\
+    process.write_text(
+        """\
 import sys
 for line in sys.stdin:
     i = line.strip()
     print("consumed", i, file=sys.stderr)
     print(i)
-""")
+"""
+    )
     return plumbum.local["python"][process]
 
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,12 +1,14 @@
 from typing import List, Tuple
 
+import env
 import pytest
 
 import plumbum
 from plumbum.commands import BaseCommand
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.xfail(env.WIN, reason="TODO: only fixed on posix systems")
+@pytest.mark.timeout(3)
 def test_draining_stderr(generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(
         generate_cmd | process_cmd | process_cmd
@@ -15,7 +17,8 @@ def test_draining_stderr(generate_cmd, process_cmd):
     assert len(stdout) == 5000
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.xfail(env.WIN, reason="TODO: only fixed on posix systems")
+@pytest.mark.timeout(3)
 def test_draining_stderr_with_stderr_redirect(tmp_path, generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(
         generate_cmd | (process_cmd >= str(tmp_path / "output.txt")) | process_cmd
@@ -24,7 +27,8 @@ def test_draining_stderr_with_stderr_redirect(tmp_path, generate_cmd, process_cm
     assert len(stdout) == 5000
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.xfail(env.WIN, reason="TODO: only fixed on posix systems")
+@pytest.mark.timeout(3)
 def test_draining_stderr_with_stdout_redirect(tmp_path, generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(
         generate_cmd | process_cmd | process_cmd > str(tmp_path / "output.txt")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -79,9 +79,9 @@ def get_output_with_iter_lines(cmd: BaseCommand) -> Tuple[List[str], List[str]]:
     stderr, stdout = [], []
     proc = cmd.popen()
     for stdout_line, stderr_line in proc.iter_lines(retcode=[0, None]):
-        if stderr_line is not None:
+        if stderr_line:
             stderr.append(stderr_line)
-        if stdout_line is not None:
+        if stdout_line:
             stdout.append(stdout_line)
     proc.wait()
     return stdout, stderr

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,6 +1,5 @@
 from typing import List, Tuple
 
-import env
 import pytest
 
 import plumbum

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -13,6 +13,9 @@ def test_draining_stderr(generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(
         generate_cmd | process_cmd | process_cmd
     )
+    expected_output = {f"generated {i}" for i in range(5000)}
+    expected_output.update(f"consumed {i}" for i in range(5000))
+    assert set(stderr) - expected_output == set()
     assert len(stderr) == 15000
     assert len(stdout) == 5000
 
@@ -23,6 +26,9 @@ def test_draining_stderr_with_stderr_redirect(tmp_path, generate_cmd, process_cm
     stdout, stderr = get_output_with_iter_lines(
         generate_cmd | (process_cmd >= str(tmp_path / "output.txt")) | process_cmd
     )
+    expected_output = {f"generated {i}" for i in range(5000)}
+    expected_output.update(f"consumed {i}" for i in range(5000))
+    assert set(stderr) - expected_output == set()
     assert len(stderr) == 10000
     assert len(stdout) == 5000
 
@@ -33,6 +39,9 @@ def test_draining_stderr_with_stdout_redirect(tmp_path, generate_cmd, process_cm
     stdout, stderr = get_output_with_iter_lines(
         generate_cmd | process_cmd | process_cmd > str(tmp_path / "output.txt")
     )
+    expected_output = {f"generated {i}" for i in range(5000)}
+    expected_output.update(f"consumed {i}" for i in range(5000))
+    assert set(stderr) - expected_output == set()
     assert len(stderr) == 15000
     assert len(stdout) == 0
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -4,10 +4,11 @@ import env
 import pytest
 
 import plumbum
+from plumbum._testtools import skip_on_windows
 from plumbum.commands import BaseCommand
 
 
-@pytest.mark.xfail(env.WIN, reason="TODO: only fixed on posix systems")
+@skip_on_windows
 @pytest.mark.timeout(3)
 def test_draining_stderr(generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(
@@ -20,7 +21,7 @@ def test_draining_stderr(generate_cmd, process_cmd):
     assert len(stdout) == 5000
 
 
-@pytest.mark.xfail(env.WIN, reason="TODO: only fixed on posix systems")
+@skip_on_windows
 @pytest.mark.timeout(3)
 def test_draining_stderr_with_stderr_redirect(tmp_path, generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(
@@ -33,7 +34,7 @@ def test_draining_stderr_with_stderr_redirect(tmp_path, generate_cmd, process_cm
     assert len(stdout) == 5000
 
 
-@pytest.mark.xfail(env.WIN, reason="TODO: only fixed on posix systems")
+@skip_on_windows
 @pytest.mark.timeout(3)
 def test_draining_stderr_with_stdout_redirect(tmp_path, generate_cmd, process_cmd):
     stdout, stderr = get_output_with_iter_lines(

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,0 +1,70 @@
+from typing import List, Tuple
+
+import pytest
+
+import plumbum
+from plumbum.commands import BaseCommand
+
+
+@pytest.mark.timeout(1)
+def test_draining_stderr(generate_cmd, process_cmd):
+    stdout, stderr = get_output_with_iter_lines(
+        generate_cmd | process_cmd | process_cmd
+    )
+    assert len(stderr) == 15000
+    assert len(stdout) == 5000
+
+
+@pytest.mark.timeout(1)
+def test_draining_stderr_with_stderr_redirect(tmp_path, generate_cmd, process_cmd):
+    stdout, stderr = get_output_with_iter_lines(
+        generate_cmd | (process_cmd >= str(tmp_path / "output.txt")) | process_cmd
+    )
+    assert len(stderr) == 10000
+    assert len(stdout) == 5000
+
+
+@pytest.mark.timeout(1)
+def test_draining_stderr_with_stdout_redirect(tmp_path, generate_cmd, process_cmd):
+    stdout, stderr = get_output_with_iter_lines(
+        generate_cmd | process_cmd | process_cmd > str(tmp_path / "output.txt")
+    )
+    assert len(stderr) == 15000
+    assert len(stdout) == 0
+
+
+@pytest.fixture()
+def generate_cmd(tmp_path):
+    generate = tmp_path / "generate.py"
+    generate.write_text("""\
+import sys
+for i in range(5000):
+    print("generated", i, file=sys.stderr)
+    print(i)
+""")
+    return plumbum.local["python"][generate]
+
+
+@pytest.fixture()
+def process_cmd(tmp_path):
+    process = tmp_path / "process.py"
+    process.write_text("""\
+import sys
+for line in sys.stdin:
+    i = line.strip()
+    print("consumed", i, file=sys.stderr)
+    print(i)
+""")
+    return plumbum.local["python"][process]
+
+
+def get_output_with_iter_lines(cmd: BaseCommand) -> Tuple[List[str], List[str]]:
+    stderr, stdout = [], []
+    proc = cmd.popen()
+    for stdout_line, stderr_line in proc.iter_lines(retcode=[0, None]):
+        if stderr_line is not None:
+            stderr.append(stderr_line)
+        if stdout_line is not None:
+            stdout.append(stdout_line)
+    proc.wait()
+    return stdout, stderr


### PR DESCRIPTION
When a command (other than the first) in a pipeline wrote more than 64k to the stderr, and the output was consumed with the iter_lines function, the whole pipeline stalled. Fixed by reading the output of all commands where either stdout or stderr was set to PIPE.

This is the same issue as described in
https://github.com/tomerfiliba/plumbum/issues/548

Same problem still exists if command is executed with run(), but that code calls proc.communicate to read stderr/stdout and I do not know how to fix that.
