### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,8 @@ repos:
   hooks:
   - id: black
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: "v0.0.270"
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: "v0.0.275"
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ extend-ignore = [
   "PLR",
   "PT004",
   "PT011",  # TODO: add match parameter
-  "PLC1901", # Simplify == "", might be risky
+  "RUF012",  # ClassVar required if mutable
 ]
 target-version = "py37"
 exclude = ["docs/conf.py"]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.