### PR TITLE
chore: switch to ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,16 +19,12 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: "23.10.1"
-  hooks:
-  - id: black
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.1.3"
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
+    - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: "v1.6.1"

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -82,6 +82,7 @@ class Image:
 
 class ShowImageApp(cli.Application):
     "Display an image on the terminal"
+
     double = cli.Flag(
         ["-d", "--double"], help="Double resolution (looks good only with some fonts)"
     )

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -230,7 +230,8 @@ class SwitchAttr:
         argname=VALUE,
         **kwargs,
     ):
-        self.__doc__ = "Sets an attribute"  # to prevent the help message from showing SwitchAttr's docstring
+        # Setting to prevent the help message from showing SwitchAttr's docstring
+        self.__doc__ = "Sets an attribute"
         if default and argtype is not None:
             defaultmsg = _("; the default is {0}").format(default)
             if "help" in kwargs:

--- a/plumbum/typed_env.py
+++ b/plumbum/typed_env.py
@@ -93,9 +93,7 @@ class TypedEnv(MutableMapping):
         a list of objects of type ``type`` (``str`` by default).
         """
 
-        def __init__(
-            self, name, default=NO_DEFAULT, type=str, separator=","
-        ):  # pylint:disable=redefined-builtin
+        def __init__(self, name, default=NO_DEFAULT, type=str, separator=","):  # pylint:disable=redefined-builtin
             super().__init__(name, default=default)
             self.type = type
             self.separator = separator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ ignore = [
   "PT004",
   "PT011",  # TODO: add match parameter
   "RUF012",  # ClassVar required if mutable
+  "ISC001",  # conflicts with formatter
 ]
 flake8-unused-arguments.ignore-variadic-names = true
 


### PR DESCRIPTION
Switching to Ruff's built-in black-like formatter. See https://github.com/scientific-python/cookie/pull/299.
