### PR TITLE
fix: reduce unclosed IO warnings

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -398,6 +398,8 @@ class Pipeline(BaseCommand):
         dstproc = self.dstcmd.popen(**kwargs)
         # allow p1 to receive a SIGPIPE if p2 exits
         srcproc.stdout.close()
+        if srcproc.stderr:
+            srcproc.stderr.close()
         if srcproc.stdin and src_kwargs.get("stdin") != PIPE:
             srcproc.stdin.close()
         dstproc.srcproc = srcproc


### PR DESCRIPTION
Reduces a few of the warnings in https://github.com/tomerfiliba/plumbum/issues/655
