### PR TITLE
Fixed Improper Method Call: Replaced `NotImplementedError`

### DIFF
--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -190,22 +190,22 @@ class ParamikoMachine(BaseRemoteMachine):
 
     class RemoteCommand(BaseRemoteMachine.RemoteCommand):  # type: ignore[valid-type, misc]
         def __or__(self, *_):
-            raise NotImplementedError("Not supported with ParamikoMachine")
+            return NotImplemented
 
         def __gt__(self, *_):
-            raise NotImplementedError("Not supported with ParamikoMachine")
+            return NotImplemented
 
         def __rshift__(self, *_):
-            raise NotImplementedError("Not supported with ParamikoMachine")
+            return NotImplemented
 
         def __ge__(self, *_):
-            raise NotImplementedError("Not supported with ParamikoMachine")
+            return NotImplemented
 
         def __lt__(self, *_):
-            raise NotImplementedError("Not supported with ParamikoMachine")
+            return NotImplemented
 
         def __lshift__(self, *_):
-            raise NotImplementedError("Not supported with ParamikoMachine")
+            return NotImplemented
 
     def __init__(
         self,

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -628,7 +628,7 @@ class TestParamikoMachine(BaseRemoteMachineTest):
         with self._connect() as rem:
             try:
                 rem["ls"] | rem["cat"]
-            except NotImplementedError:
+            except (NotImplementedError, TypeError):
                 pass
             else:
                 pytest.fail("Should not pipe")


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [paramiko_machine.py](https://github.com/tomerfiliba/plumbum/blob/master/plumbum/machines/paramiko_machine.py#L190), class: `RemoteCommand`, there is a special method `__or__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__or__ `should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is [here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).

### Related Documentation
- [docs.python.org - NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented)
- [docs.python.org - NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError)


## Changes
- Replaced `NotImplementedError` with `NotImplemented`


## Previously Found & Fixed
- https://www.github.com/SciTools/iris/pull/5544
- https://www.github.com/cupy/cupy/pull/7900
- https://www.github.com/ethereum/web3.py/pull/3080


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
