### PR TITLE
fix: use importlib resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - id: mypy
     files: plumbum
     args: []
-    additional_dependencies: [typed-ast, types-paramiko, types-setuptools, pytest]
+    additional_dependencies: [typed-ast, types-paramiko, types-setuptools, pytest, importlib-resources]
 
 - repo: https://github.com/abravalheri/validate-pyproject
   rev: "v0.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "pywin32; platform_system=='Windows' and platform_python_implementation!='PyPy'",
+    "importlib_resources; python_version<'3.9'",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
See about fixing one of the two issues in #678 by getting off pkg_resources. I think this won't work as I wrote it on Python < 3.12, as that is when directories were added, but let's see.


TODO: add a test, it shouldn't have worked, directories weren't supported until 3.12.