### PR TITLE
chore: use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling",
+    "hatchling>=1.27.0",
     "hatch-vcs",
 ]
 build-backend = "hatchling.build"
@@ -11,7 +11,8 @@ name = "plumbum"
 description = "Plumbum: shell combinators library"
 readme = "README.rst"
 authors = [{ name="Tomer Filiba", email="tomerfiliba@gmail.com" }]
-license = { file="LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
@@ -20,7 +21,6 @@ dependencies = [
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Hatchling `v1.27.0` added support for [PEP 639](https://peps.python.org/pep-0639/) license expressions.

Metadata diff
```diff
 ...
-License: Copyright (c) 2013 Tomer Filiba (tomerfiliba@gmail.com)
-        
-        Permission is hereby granted, free of charge, to any person obtaining a copy
-        of this software and associated documentation files (the "Software"), to deal
-        in the Software without restriction, including without limitation the rights
-        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-        copies of the Software, and to permit persons to whom the Software is
-        furnished to do so, subject to the following conditions:
-        
-        The above copyright notice and this permission notice shall be included in
-        all copies or substantial portions of the Software.
-        
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-        THE SOFTWARE.
+License-Expression: MIT
 License-File: LICENSE
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
```

The license file itself is still included in the sdist / wheel. Just not as text in the metadata itself anymore.