### PR TITLE
BaseRemoteMachine.tempdir(): add -t to mktemp to work in R/O $HOMEs

### DIFF
--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -328,7 +328,9 @@ class BaseRemoteMachine(BaseMachine):
         """A context manager that creates a remote temporary directory, which is removed when
         the context exits"""
         _, out, _ = self._session.run(
-            "mktemp -d 2>/dev/null || mktemp -d tmp.XXXXXXXXXX"
+            # -t -> acknowledge $TMPDIR, default to /tmp, so we work
+            # -also in places where $HOME is read only
+            "mktemp -d 2>/dev/null || mktemp -t -d tmp.XXXXXXXXXX"
         )
         local_dir = self.path(out.strip())
         try:


### PR DESCRIPTION
The call to mktemp with a relative template name creates the temp directory wherever the thing logs in to, $HOME.

If $HOME is read-only, then this fails.

With this change, the temp directory is made in whatever the system considers the temporary directory to be, acknowledging TMPDIR if set (per mktemp man page) and defaulting to /tmp.