### PR TITLE
tests: support pytest 9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     additional_dependencies:
       - types-paramiko
       - types-colorama
-      - pytest
+      - pytest<9  # pytest 9 requires Python 3.10+
       - ipython
       - pillow
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     # register all optional tests declared in ini file as markers
     # https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers
-    ot_ini = config.inicfg.get("optional_tests").strip().splitlines()
+
+    ot_ini = config.getini("optional_tests")
     for ot_ in ot_ini:
         # ot should be a line like "optmarker: this is an opt marker", as with markers section
         config.addinivalue_line("markers", ot_)


### PR DESCRIPTION
Support for pytest 9. We weren't accessing values correctly.
