### PR TITLE
Fix: SSH bug in windows

### DIFF
--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -129,7 +129,7 @@ class SshMachine(BaseRemoteMachine):
                         Ctrl+C (SIGINT)
     """
 
-    __slots__ = ("_fqhost", "_scp_command", "_ssh_command", "host")
+    __slots__ = ("_fqhost", "_scp_command", "_scp_translate", "_ssh_command", "host")
 
     def __init__(
         self,
@@ -175,6 +175,7 @@ class SshMachine(BaseRemoteMachine):
         scp_args.extend(scp_opts)
         self._ssh_command = ssh_command[tuple(ssh_args)]
         self._scp_command = scp_command[tuple(scp_args)]
+        self._scp_translate = IS_WIN32 and self._scp_uses_posix_paths(self._scp_command)
         BaseRemoteMachine.__init__(
             self,
             encoding=encoding,
@@ -380,6 +381,25 @@ class SshMachine(BaseRemoteMachine):
             return "/" + path.replace(":", "").replace("\\", "/")
         return path
 
+    @staticmethod
+    def _scp_uses_posix_paths(scp_command: BaseCommand) -> bool:
+        """Whether ``scp_command`` expects POSIX-style ``/c/...`` local paths.
+
+        Cygwin- and MSYS2-based builds of ``scp`` (such as the one bundled with
+        Git for Windows) cannot make sense of native ``c:\\...`` paths and need
+        drive letters rewritten as ``/c/...``. They are recognisable by the
+        ``cygwin1.dll`` / ``msys-2.0.dll`` runtime that sits next to the
+        executable. The native Windows OpenSSH ``scp`` accepts drive-letter
+        paths directly, so for it (and on POSIX hosts) no translation is needed.
+        """
+        cmd: Any = scp_command
+        while not hasattr(cmd, "executable"):
+            cmd = getattr(cmd, "cmd", None)
+            if cmd is None:
+                return False
+        folder = local.path(cmd.executable).dirname
+        return any((folder / dll).exists() for dll in ("cygwin1.dll", "msys-2.0.dll"))
+
     def download(self, src: str | RemotePath, dst: str | LocalPath) -> None:
         if isinstance(src, LocalPath):
             raise TypeError(f"src of download cannot be {src!r}")
@@ -387,7 +407,7 @@ class SshMachine(BaseRemoteMachine):
             raise TypeError(f"src {src!r} points to a different remote machine")
         if isinstance(dst, RemotePath):
             raise TypeError(f"dst of download cannot be {dst!r}")
-        if not IS_WIN32:
+        if self._scp_translate:
             src = self._translate_drive_letter(src)
             dst = self._translate_drive_letter(dst)
         self._scp_command(f"{self._fqhost}:{shquote(src)}", dst)
@@ -399,7 +419,7 @@ class SshMachine(BaseRemoteMachine):
             raise TypeError(f"dst of upload cannot be {dst!r}")
         if isinstance(dst, RemotePath) and dst.remote != self:
             raise TypeError(f"dst {dst!r} points to a different remote machine")
-        if not IS_WIN32:
+        if self._scp_translate:
             src = self._translate_drive_letter(src)
             dst = self._translate_drive_letter(dst)
         self._scp_command(src, f"{self._fqhost}:{shquote(dst)}")

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -413,7 +413,7 @@ class SshMachine(BaseRemoteMachine):
         if isinstance(dst, RemotePath):
             raise TypeError(f"dst of download cannot be {dst!r}")
         if self._scp_translate:
-            src = self._translate_drive_letter(src)
+            # only the local path (dst) is parsed by the local scp binary
             dst = self._translate_drive_letter(dst)
         self._scp_command(f"{self._fqhost}:{shquote(src)}", dst)
 
@@ -425,8 +425,8 @@ class SshMachine(BaseRemoteMachine):
         if isinstance(dst, RemotePath) and dst.remote != self:
             raise TypeError(f"dst {dst!r} points to a different remote machine")
         if self._scp_translate:
+            # only the local path (src) is parsed by the local scp binary
             src = self._translate_drive_letter(src)
-            dst = self._translate_drive_letter(dst)
         self._scp_command(src, f"{self._fqhost}:{shquote(dst)}")
 
 

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -392,13 +392,18 @@ class SshMachine(BaseRemoteMachine):
         executable. The native Windows OpenSSH ``scp`` accepts drive-letter
         paths directly, so for it (and on POSIX hosts) no translation is needed.
         """
-        cmd: Any = scp_command
-        while not hasattr(cmd, "executable"):
-            cmd = getattr(cmd, "cmd", None)
-            if cmd is None:
-                return False
-        folder = local.path(cmd.executable).dirname
-        return any((folder / dll).exists() for dll in ("cygwin1.dll", "msys-2.0.dll"))
+        try:
+            cmd: Any = scp_command
+            while not hasattr(cmd, "executable"):
+                cmd = getattr(cmd, "cmd", None)
+                if cmd is None:
+                    return False
+            folder = local.path(cmd.executable).dirname
+            return any(
+                (folder / dll).exists() for dll in ("cygwin1.dll", "msys-2.0.dll")
+            )
+        except (AttributeError, OSError):
+            return False
 
     def download(self, src: str | RemotePath, dst: str | LocalPath) -> None:
         if isinstance(src, LocalPath):

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -387,7 +387,7 @@ class SshMachine(BaseRemoteMachine):
             raise TypeError(f"src {src!r} points to a different remote machine")
         if isinstance(dst, RemotePath):
             raise TypeError(f"dst of download cannot be {dst!r}")
-        if IS_WIN32:
+        if not IS_WIN32:
             src = self._translate_drive_letter(src)
             dst = self._translate_drive_letter(dst)
         self._scp_command(f"{self._fqhost}:{shquote(src)}", dst)
@@ -399,7 +399,7 @@ class SshMachine(BaseRemoteMachine):
             raise TypeError(f"dst of upload cannot be {dst!r}")
         if isinstance(dst, RemotePath) and dst.remote != self:
             raise TypeError(f"dst {dst!r} points to a different remote machine")
-        if IS_WIN32:
+        if not IS_WIN32:
             src = self._translate_drive_letter(src)
             dst = self._translate_drive_letter(dst)
         self._scp_command(src, f"{self._fqhost}:{shquote(dst)}")

--- a/tests/test_ssh_paths.py
+++ b/tests/test_ssh_paths.py
@@ -49,3 +49,42 @@ class TestScpTranslateGating:
     def test_no_translation_on_windows_with_native_scp(self, mocker, tmp_path):
         mocker.patch("plumbum.machines.ssh_machine.IS_WIN32", True)
         assert self._make(mocker, tmp_path)._scp_translate is False
+
+
+class TestScpTranslatesLocalSideOnly:
+    """Only the local path is parsed by the local scp binary, so only it may
+    be drive-letter translated; the remote path must be passed through verbatim.
+    """
+
+    def _make(self, mocker, translate):
+        mocker.patch("plumbum.machines.ssh_machine.BaseRemoteMachine")
+        m = SshMachine("host", ssh_command=local["ssh"], scp_command=local["scp"])
+        m._scp_translate = translate
+        m._scp_command = mocker.MagicMock()
+        return m
+
+    def test_download_translates_only_local_dst(self, mocker):
+        m = self._make(mocker, translate=True)
+        # remote src has a colon (legal in POSIX filenames); local dst is Windows
+        m.download("/tmp/a:b", r"c:\Users\foo")
+        local_remote = m._scp_command.call_args[0]
+        # remote src passed through untouched (colon preserved, no /c rewrite)
+        assert local_remote[0] == "host:/tmp/a:b"
+        # local dst translated
+        assert local_remote[1] == "/c/Users/foo"
+
+    def test_upload_translates_only_local_src(self, mocker):
+        m = self._make(mocker, translate=True)
+        # local src is Windows; remote dst has a colon
+        m.upload(r"c:\Users\foo", "/tmp/a:b")
+        local_remote = m._scp_command.call_args[0]
+        # local src translated
+        assert local_remote[0] == "/c/Users/foo"
+        # remote dst passed through untouched
+        assert local_remote[1] == "host:/tmp/a:b"
+
+    def test_no_translation_when_disabled(self, mocker):
+        m = self._make(mocker, translate=False)
+        m.upload(r"c:\Users\foo", "/remote/dst")
+        local_remote = m._scp_command.call_args[0]
+        assert local_remote[0] == r"c:\Users\foo"

--- a/tests/test_ssh_paths.py
+++ b/tests/test_ssh_paths.py
@@ -1,0 +1,51 @@
+"""Tests for SshMachine local-path handling used by scp upload/download."""
+
+from __future__ import annotations
+
+import pytest
+
+from plumbum import SshMachine, local
+
+
+class TestTranslateDriveLetter:
+    def test_translates_windows_drive(self):
+        assert SshMachine._translate_drive_letter(r"c:\Users\foo") == "/c/Users/foo"
+
+    def test_leaves_posix_path_untouched(self):
+        assert SshMachine._translate_drive_letter("/home/foo") == "/home/foo"
+
+
+class TestScpUsesPosixPaths:
+    @pytest.mark.parametrize("dll", ["cygwin1.dll", "msys-2.0.dll"])
+    def test_detects_cygwin_msys_runtime(self, tmp_path, dll):
+        (tmp_path / dll).touch()
+        scp = local[tmp_path / "scp"]["-r"]
+        assert SshMachine._scp_uses_posix_paths(scp) is True
+
+    def test_native_scp_needs_no_translation(self, tmp_path):
+        scp = local[tmp_path / "scp"]["-r"]
+        assert SshMachine._scp_uses_posix_paths(scp) is False
+
+
+class TestScpTranslateGating:
+    def _make(self, mocker, tmp_path):
+        mocker.patch("plumbum.machines.ssh_machine.BaseRemoteMachine")
+        return SshMachine(
+            "host",
+            ssh_command=local[tmp_path / "ssh"],
+            scp_command=local[tmp_path / "scp"],
+        )
+
+    def test_no_translation_off_windows(self, mocker, tmp_path):
+        (tmp_path / "msys-2.0.dll").touch()
+        mocker.patch("plumbum.machines.ssh_machine.IS_WIN32", False)
+        assert self._make(mocker, tmp_path)._scp_translate is False
+
+    def test_translation_on_windows_with_cygwin_scp(self, mocker, tmp_path):
+        (tmp_path / "cygwin1.dll").touch()
+        mocker.patch("plumbum.machines.ssh_machine.IS_WIN32", True)
+        assert self._make(mocker, tmp_path)._scp_translate is True
+
+    def test_no_translation_on_windows_with_native_scp(self, mocker, tmp_path):
+        mocker.patch("plumbum.machines.ssh_machine.IS_WIN32", True)
+        assert self._make(mocker, tmp_path)._scp_translate is False


### PR DESCRIPTION
With `SshMachine`, if we were to use windows specific path, it translates into something like `/c/Users/...` which isn't a compatible path for the `scp` call in windows. I have changed the logic that calls the translation function to run only when the underlying platform isn't windows, which fixes the problem.

Also, some basic test cases fix to prevent `ImportError` when trying to get `printenv`  

 