### PR TITLE
tests: need ImportError for plumbum.cmd

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,7 +5,7 @@ import contextlib
 from plumbum import local
 from plumbum._testtools import skip_on_windows
 
-with contextlib.suppress(ModuleNotFoundError):
+with contextlib.suppress(ImportError):
     from plumbum.cmd import printenv
 
 


### PR DESCRIPTION
This probably got incorrectly replaced at one point; it's a general ImportError, not a ModuleNotFoundError, as it's not missing a module if a command is not found.
