### PR TITLE
ci: test on prerelease of 3.15

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -50,14 +50,6 @@ class Path(str, ABC):
         """Joins two paths"""
         return self.join(other)
 
-    def __add__(self, other: str | Self) -> Self:
-        """Attaches text to path"""
-        return self.__class__(str(self) + str(other))
-
-    def __radd__(self, other: str) -> Self:
-        """Attaches text to path"""
-        return self.__class__(other + str(self))
-
     @typing.overload
     def __getitem__(self, key: str | Path) -> Self: ...
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -133,7 +133,7 @@ class TestLocalPath:
             local.path("/opt/lib"),
         ]:
             delta = p.relative_to(src)
-            assert src + delta == p
+            assert src / delta == p
 
     def test_read_write(self):
         with local.tempdir() as dir:


### PR DESCRIPTION
Fix #761.

We should probably consider options for later, but for now, don't test `+`. Users should join paths with `/`.