### PR TITLE
tests: set LANG=C in pytest to fix locale-dependent test failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,9 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    # Consistent locale for tests
+    os.environ["LANG"] = "C"
+
     # register all optional tests declared in ini file as markers
     # https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers
 


### PR DESCRIPTION
Configure pytest to use LANG=C environment variable to ensure
consistent command output across different system locales.

Fixes test_redirection and test_iter_lines_buffer_size which were
failing on systems with non-English locales (e.g., Spanish) because
they expected English output from system commands like grep. For
example, test_redirection expected "usage" but received "modo de
empleo" from grep's help message.

@moduon MT-6769
