### PR TITLE
docs: prepare for 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,61 @@
+2.0.0
+-----
+
+Features:
+
+* Support async mode by @yajo in https://github.com/tomerfiliba/plumbum/pull/768
+* Support color string processing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/774
+* Remove pywin32 dependency and replace WinAPI calls with a custom ctypes wrapper by @karpierz in https://github.com/tomerfiliba/plumbum/pull/766
+* Full static typing
+    * Add paramiko machine typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/746
+    * Add remote typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/744
+    * Add sshmachine typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/745
+    * Add typing for color by @henryiii in https://github.com/tomerfiliba/plumbum/pull/730
+    * Add typing for fs by @henryiii in https://github.com/tomerfiliba/plumbum/pull/737
+    * Add typing for local machine by @henryiii in https://github.com/tomerfiliba/plumbum/pull/743
+    * Typing paths by @henryiii in https://github.com/tomerfiliba/plumbum/pull/733
+    * Adding rest of typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/739
+    * Enable tc ruff check by @henryiii in https://github.com/tomerfiliba/plumbum/pull/752
+    * More safe types by @henryiii in https://github.com/tomerfiliba/plumbum/pull/741
+    * Should be safe types by @henryiii in https://github.com/tomerfiliba/plumbum/pull/740
+    * Type only session by @henryiii in https://github.com/tomerfiliba/plumbum/pull/742
+    * Types for Application by @henryiii in https://github.com/tomerfiliba/plumbum/pull/735
+    * Typing for commands by @henryiii in https://github.com/tomerfiliba/plumbum/pull/738
+    * Type examples too by @henryiii in https://github.com/tomerfiliba/plumbum/pull/748
+    * Typing fixes from Ruff by @henryiii in https://github.com/tomerfiliba/plumbum/pull/749
+
+
+Fixes:
+
+* HTMLStyle should respect the color setting by @henryiii in https://github.com/tomerfiliba/plumbum/pull/776
+* Make cache clear abstract by @henryiii in https://github.com/tomerfiliba/plumbum/pull/747
+* Use ``perf_counter`` instead of datetime for Progress by @henryiii in https://github.com/tomerfiliba/plumbum/pull/754
+* ``BrokenPipeError`` when piping CLI help output to head by @Copilot in https://github.com/tomerfiliba/plumbum/pull/727
+
+Tests:
+
+* Need ``ImportError`` for ``plumbum.cmd`` by @henryiii in https://github.com/tomerfiliba/plumbum/pull/769
+* Set ``LANG=C`` in pytest to fix locale-dependent test failures by @yajo in https://github.com/tomerfiliba/plumbum/pull/772
+* Support pytest 9 by @henryiii in https://github.com/tomerfiliba/plumbum/pull/757
+* pytest ``log_level`` is better than ``log_cli_level`` by @henryiii in https://github.com/tomerfiliba/plumbum/pull/756
+
+
+Internal:
+
+* Adding more slots by @henryiii in https://github.com/tomerfiliba/plumbum/pull/750
+* Even more slots by @henryiii in https://github.com/tomerfiliba/plumbum/pull/751
+* tid imports by @henryiii in https://github.com/tomerfiliba/plumbum/pull/753
+* Fix badge showing wrong branch by @henryiii in https://github.com/tomerfiliba/plumbum/pull/736
+* Fix links in changelog by @henryiii in https://github.com/tomerfiliba/plumbum/pull/732
+
+CI:
+
+* Test on prerelease of 3.15 by @henryiii in https://github.com/tomerfiliba/plumbum/pull/771
+* Update versions by @henryiii in https://github.com/tomerfiliba/plumbum/pull/763
+* Updating ssh script by @henryiii in https://github.com/tomerfiliba/plumbum/pull/764
+* Use PyPy 3.11 by @henryiii in https://github.com/tomerfiliba/plumbum/pull/770
+
+
 1.10.0
 ------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,57 +3,58 @@
 
 Features:
 
-* Support async mode by @yajo in https://github.com/tomerfiliba/plumbum/pull/768
-* Support color string processing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/774
-* Remove pywin32 dependency and replace WinAPI calls with a custom ctypes wrapper by @karpierz in https://github.com/tomerfiliba/plumbum/pull/766
+* Support async mode by @yajo (`#768 <https://github.com/tomerfiliba/plumbum/pull/768>`_)
+* More pathlib API supported by @henryiii (`#779 <https://github.com/tomerfiliba/plumbum/pull/779>`_)
+* Support color string processing by @henryiii (`#774 <https://github.com/tomerfiliba/plumbum/pull/774>`_)
+* Remove pywin32 dependency and replace WinAPI calls with a custom ctypes wrapper by @karpierz (`#766 <https://github.com/tomerfiliba/plumbum/pull/766>`_)
 * Full static typing
-    * Add paramiko machine typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/746
-    * Add remote typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/744
-    * Add sshmachine typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/745
-    * Add typing for color by @henryiii in https://github.com/tomerfiliba/plumbum/pull/730
-    * Add typing for fs by @henryiii in https://github.com/tomerfiliba/plumbum/pull/737
-    * Add typing for local machine by @henryiii in https://github.com/tomerfiliba/plumbum/pull/743
-    * Typing paths by @henryiii in https://github.com/tomerfiliba/plumbum/pull/733
-    * Adding rest of typing by @henryiii in https://github.com/tomerfiliba/plumbum/pull/739
-    * Enable tc ruff check by @henryiii in https://github.com/tomerfiliba/plumbum/pull/752
-    * More safe types by @henryiii in https://github.com/tomerfiliba/plumbum/pull/741
-    * Should be safe types by @henryiii in https://github.com/tomerfiliba/plumbum/pull/740
-    * Type only session by @henryiii in https://github.com/tomerfiliba/plumbum/pull/742
-    * Types for Application by @henryiii in https://github.com/tomerfiliba/plumbum/pull/735
-    * Typing for commands by @henryiii in https://github.com/tomerfiliba/plumbum/pull/738
-    * Type examples too by @henryiii in https://github.com/tomerfiliba/plumbum/pull/748
-    * Typing fixes from Ruff by @henryiii in https://github.com/tomerfiliba/plumbum/pull/749
+    * Add paramiko machine typing by @henryiii (`#746 <https://github.com/tomerfiliba/plumbum/pull/746>`_)
+    * Add remote typing by @henryiii (`#744 <https://github.com/tomerfiliba/plumbum/pull/744>`_)
+    * Add sshmachine typing by @henryiii (`#745 <https://github.com/tomerfiliba/plumbum/pull/745>`_)
+    * Add typing for color by @henryiii (`#730 <https://github.com/tomerfiliba/plumbum/pull/730>`_)
+    * Add typing for fs by @henryiii (`#737 <https://github.com/tomerfiliba/plumbum/pull/737>`_)
+    * Add typing for local machine by @henryiii (`#743 <https://github.com/tomerfiliba/plumbum/pull/743>`_)
+    * Typing paths by @henryiii (`#733 <https://github.com/tomerfiliba/plumbum/pull/733>`_)
+    * Adding rest of typing by @henryiii (`#739 <https://github.com/tomerfiliba/plumbum/pull/739>`_)
+    * Enable tc ruff check by @henryiii (`#752 <https://github.com/tomerfiliba/plumbum/pull/752>`_)
+    * More safe types by @henryiii (`#741 <https://github.com/tomerfiliba/plumbum/pull/741>`_)
+    * Should be safe types by @henryiii (`#740 <https://github.com/tomerfiliba/plumbum/pull/740>`_)
+    * Type only session by @henryiii (`#742 <https://github.com/tomerfiliba/plumbum/pull/742>`_)
+    * Types for Application by @henryiii (`#735 <https://github.com/tomerfiliba/plumbum/pull/735>`_)
+    * Typing for commands by @henryiii (`#738 <https://github.com/tomerfiliba/plumbum/pull/738>`_)
+    * Type examples too by @henryiii (`#748 <https://github.com/tomerfiliba/plumbum/pull/748>`_)
+    * Typing fixes from Ruff by @henryiii (`#749 <https://github.com/tomerfiliba/plumbum/pull/749>`_)
 
 
 Fixes:
 
-* HTMLStyle should respect the color setting by @henryiii in https://github.com/tomerfiliba/plumbum/pull/776
-* Make cache clear abstract by @henryiii in https://github.com/tomerfiliba/plumbum/pull/747
-* Use ``perf_counter`` instead of datetime for Progress by @henryiii in https://github.com/tomerfiliba/plumbum/pull/754
-* ``BrokenPipeError`` when piping CLI help output to head by @Copilot in https://github.com/tomerfiliba/plumbum/pull/727
+* HTMLStyle should respect the color setting by @henryiii (`#776 <https://github.com/tomerfiliba/plumbum/pull/776>`_)
+* Make cache clear abstract by @henryiii (`#747 <https://github.com/tomerfiliba/plumbum/pull/747>`_)
+* Use ``perf_counter`` instead of datetime for Progress by @henryiii (`#754 <https://github.com/tomerfiliba/plumbum/pull/754>`_)
+* ``BrokenPipeError`` when piping CLI help output to head by @Copilot (`#727 <https://github.com/tomerfiliba/plumbum/pull/727>`_)
 
 Tests:
 
-* Need ``ImportError`` for ``plumbum.cmd`` by @henryiii in https://github.com/tomerfiliba/plumbum/pull/769
-* Set ``LANG=C`` in pytest to fix locale-dependent test failures by @yajo in https://github.com/tomerfiliba/plumbum/pull/772
-* Support pytest 9 by @henryiii in https://github.com/tomerfiliba/plumbum/pull/757
-* pytest ``log_level`` is better than ``log_cli_level`` by @henryiii in https://github.com/tomerfiliba/plumbum/pull/756
+* Need ``ImportError`` for ``plumbum.cmd`` by @henryiii (`#769 <https://github.com/tomerfiliba/plumbum/pull/769>`_)
+* Set ``LANG=C`` in pytest to fix locale-dependent test failures by @yajo (`#772 <https://github.com/tomerfiliba/plumbum/pull/772>`_)
+* Support pytest 9 by @henryiii (`#757 <https://github.com/tomerfiliba/plumbum/pull/757>`_)
+* pytest ``log_level`` is better than ``log_cli_level`` by @henryiii (`#756 <https://github.com/tomerfiliba/plumbum/pull/756>`_)
 
 
 Internal:
 
-* Adding more slots by @henryiii in https://github.com/tomerfiliba/plumbum/pull/750
-* Even more slots by @henryiii in https://github.com/tomerfiliba/plumbum/pull/751
-* tid imports by @henryiii in https://github.com/tomerfiliba/plumbum/pull/753
-* Fix badge showing wrong branch by @henryiii in https://github.com/tomerfiliba/plumbum/pull/736
-* Fix links in changelog by @henryiii in https://github.com/tomerfiliba/plumbum/pull/732
+* Adding more slots by @henryiii (`#750 <https://github.com/tomerfiliba/plumbum/pull/750>`_)
+* Even more slots by @henryiii (`#751 <https://github.com/tomerfiliba/plumbum/pull/751>`_)
+* tid imports by @henryiii (`#753 <https://github.com/tomerfiliba/plumbum/pull/753>`_)
+* Fix badge showing wrong branch by @henryiii (`#736 <https://github.com/tomerfiliba/plumbum/pull/736>`_)
+* Fix links in changelog by @henryiii (`#732 <https://github.com/tomerfiliba/plumbum/pull/732>`_)
 
 CI:
 
-* Test on prerelease of 3.15 by @henryiii in https://github.com/tomerfiliba/plumbum/pull/771
-* Update versions by @henryiii in https://github.com/tomerfiliba/plumbum/pull/763
-* Updating ssh script by @henryiii in https://github.com/tomerfiliba/plumbum/pull/764
-* Use PyPy 3.11 by @henryiii in https://github.com/tomerfiliba/plumbum/pull/770
+* Test on prerelease of 3.15 by @henryiii (`#771 <https://github.com/tomerfiliba/plumbum/pull/771>`_)
+* Update versions by @henryiii (`#763 <https://github.com/tomerfiliba/plumbum/pull/763>`_)
+* Updating ssh script by @henryiii (`#764 <https://github.com/tomerfiliba/plumbum/pull/764>`_)
+* Use PyPy 3.11 by @henryiii (`#770 <https://github.com/tomerfiliba/plumbum/pull/770>`_)
 
 
 1.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,15 @@ Features:
   * Application instances now provide bash and fish completions out of the box (`#782 <https://github.com/tomerfiliba/plumbum/pull/782>`_)
   * Drop use of ``atexit`` for color handling to avoid teardown issues (`#785 <https://github.com/tomerfiliba/plumbum/pull/785>`_)
 
+Removed:
+
+* Removed the long-deprecated path aliases ``.basename``, ``.isdir()``, ``.isfile()``, and ``.islink()``; use ``.name``, ``.is_dir()``, ``.is_file()``, and ``.is_symlink()`` instead.
+* Removed the deprecated ``SshMachine.nohup()`` method; use the command ``.nohup`` modifier or ``daemonic_popen()`` instead.
+
+Deprecated:
+
+* ``Style.print_`` (a Python 2 era shortcut) now emits a ``FutureWarning``; use ``.print`` instead.
+
 Fixes:
 
 * HTMLStyle should respect the color setting by @henryiii (`#776 <https://github.com/tomerfiliba/plumbum/pull/776>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Fixes:
 * Only register shutdown if a timeout was requested to avoid spurious handlers (`#784 <https://github.com/tomerfiliba/plumbum/pull/784>`_)
 * Reduce various warnings reported by linters and at runtime (`#781 <https://github.com/tomerfiliba/plumbum/pull/781>`_)
 * Fix O(n^2) performance in ``StdinDataRedirection.popen`` by @ustunb (`#798 <https://github.com/tomerfiliba/plumbum/pull/798>`_)
+* Correct async remote streaming, pipeline TEE, and command binding (`#806 <https://github.com/tomerfiliba/plumbum/pull/806>`_)
+* Fix a sweep of pre-2.0 bugs across cli, paths, and commands (`#808 <https://github.com/tomerfiliba/plumbum/pull/808>`_)
+* Fix assorted pre-2.0 correctness issues, including ``stem``, the SSH tunnel timeout, and ``Set`` completion (`#809 <https://github.com/tomerfiliba/plumbum/pull/809>`_)
 
 Tests:
 
@@ -59,6 +62,8 @@ Internal:
 * Fix badge showing wrong branch by @henryiii (`#736 <https://github.com/tomerfiliba/plumbum/pull/736>`_)
 * Fix links in changelog by @henryiii (`#732 <https://github.com/tomerfiliba/plumbum/pull/732>`_)
 * Add ``AGENTS.md`` and avoid extra files by @henryiii (`#803 <https://github.com/tomerfiliba/plumbum/pull/803>`_)
+* Remove dead code and simplify a few spots (`#811 <https://github.com/tomerfiliba/plumbum/pull/811>`_)
+* Tighten loose type annotations across the public API (`#810 <https://github.com/tomerfiliba/plumbum/pull/810>`_)
 
 Docs:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Fixes:
 * Fix a sweep of pre-2.0 bugs across cli, paths, and commands (`#808 <https://github.com/tomerfiliba/plumbum/pull/808>`_)
 * Fix assorted pre-2.0 correctness issues, including ``stem``, the SSH tunnel timeout, and ``Set`` completion (`#809 <https://github.com/tomerfiliba/plumbum/pull/809>`_)
 * Make ``**`` glob recursively like pathlib (`#628 <https://github.com/tomerfiliba/plumbum/pull/628>`_, `#812 <https://github.com/tomerfiliba/plumbum/pull/812>`_)
+* Fix SSH drive-letter path handling on Windows by @SuvarnaNarayanan (`#762 <https://github.com/tomerfiliba/plumbum/pull/762>`_)
 
 Tests:
 
@@ -65,6 +66,7 @@ Internal:
 * Add ``AGENTS.md`` and avoid extra files by @henryiii (`#803 <https://github.com/tomerfiliba/plumbum/pull/803>`_)
 * Remove dead code and simplify a few spots (`#811 <https://github.com/tomerfiliba/plumbum/pull/811>`_)
 * Tighten loose type annotations across the public API (`#810 <https://github.com/tomerfiliba/plumbum/pull/810>`_)
+* Make module import lazy by @henryiii (`#814 <https://github.com/tomerfiliba/plumbum/pull/814>`_)
 
 Docs:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Fixes:
 * Correct async remote streaming, pipeline TEE, and command binding (`#806 <https://github.com/tomerfiliba/plumbum/pull/806>`_)
 * Fix a sweep of pre-2.0 bugs across cli, paths, and commands (`#808 <https://github.com/tomerfiliba/plumbum/pull/808>`_)
 * Fix assorted pre-2.0 correctness issues, including ``stem``, the SSH tunnel timeout, and ``Set`` completion (`#809 <https://github.com/tomerfiliba/plumbum/pull/809>`_)
+* Make ``**`` glob recursively like pathlib (`#628 <https://github.com/tomerfiliba/plumbum/pull/628>`_, `#812 <https://github.com/tomerfiliba/plumbum/pull/812>`_)
 
 Tests:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 Features:
 
 * Support async mode by @yajo (`#768 <https://github.com/tomerfiliba/plumbum/pull/768>`_)
+    * Support ``popen`` on async pipelines (`#795 <https://github.com/tomerfiliba/plumbum/pull/795>`_, `#804 <https://github.com/tomerfiliba/plumbum/pull/804>`_)
 * More pathlib API supported by @henryiii (`#779 <https://github.com/tomerfiliba/plumbum/pull/779>`_)
 * Support color string processing by @henryiii (`#774 <https://github.com/tomerfiliba/plumbum/pull/774>`_)
 * Remove pywin32 dependency and replace WinAPI calls with a custom ctypes wrapper by @karpierz (`#766 <https://github.com/tomerfiliba/plumbum/pull/766>`_)
@@ -24,6 +25,7 @@ Features:
     * Typing for commands by @henryiii (`#738 <https://github.com/tomerfiliba/plumbum/pull/738>`_)
     * Type examples too by @henryiii (`#748 <https://github.com/tomerfiliba/plumbum/pull/748>`_)
     * Typing fixes from Ruff by @henryiii (`#749 <https://github.com/tomerfiliba/plumbum/pull/749>`_)
+    * Minor typing updates by @henryiii (`#780 <https://github.com/tomerfiliba/plumbum/pull/780>`_)
 * New daemon implementation avoiding fork in certain code paths to improve portability (`#783 <https://github.com/tomerfiliba/plumbum/pull/783>`_)
     * Make the daemon launcher private to avoid exposing internals (`#794 <https://github.com/tomerfiliba/plumbum/pull/794>`_)
   * Application instances now provide bash and fish completions out of the box (`#782 <https://github.com/tomerfiliba/plumbum/pull/782>`_)
@@ -39,6 +41,7 @@ Fixes:
 * Fix quoting inconsistency between standalone commands and pipelines (`#792 <https://github.com/tomerfiliba/plumbum/pull/792>`_)
 * Only register shutdown if a timeout was requested to avoid spurious handlers (`#784 <https://github.com/tomerfiliba/plumbum/pull/784>`_)
 * Reduce various warnings reported by linters and at runtime (`#781 <https://github.com/tomerfiliba/plumbum/pull/781>`_)
+* Fix O(n^2) performance in ``StdinDataRedirection.popen`` by @ustunb (`#798 <https://github.com/tomerfiliba/plumbum/pull/798>`_)
 
 Tests:
 
@@ -55,6 +58,7 @@ Internal:
 * tid imports by @henryiii (`#753 <https://github.com/tomerfiliba/plumbum/pull/753>`_)
 * Fix badge showing wrong branch by @henryiii (`#736 <https://github.com/tomerfiliba/plumbum/pull/736>`_)
 * Fix links in changelog by @henryiii (`#732 <https://github.com/tomerfiliba/plumbum/pull/732>`_)
+* Add ``AGENTS.md`` and avoid extra files by @henryiii (`#803 <https://github.com/tomerfiliba/plumbum/pull/803>`_)
 
 Docs:
 
@@ -68,6 +72,7 @@ CI:
 * Update versions by @henryiii (`#763 <https://github.com/tomerfiliba/plumbum/pull/763>`_)
 * Updating ssh script by @henryiii (`#764 <https://github.com/tomerfiliba/plumbum/pull/764>`_)
 * Use PyPy 3.11 by @henryiii (`#770 <https://github.com/tomerfiliba/plumbum/pull/770>`_)
+* Bump ``setup-uv`` to maintained tag scheme by @henryiii (`#799 <https://github.com/tomerfiliba/plumbum/pull/799>`_)
 
 
 1.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,10 @@ Features:
     * Typing for commands by @henryiii (`#738 <https://github.com/tomerfiliba/plumbum/pull/738>`_)
     * Type examples too by @henryiii (`#748 <https://github.com/tomerfiliba/plumbum/pull/748>`_)
     * Typing fixes from Ruff by @henryiii (`#749 <https://github.com/tomerfiliba/plumbum/pull/749>`_)
-
+* New daemon implementation avoiding fork in certain code paths to improve portability (`#783 <https://github.com/tomerfiliba/plumbum/pull/783>`_)
+    * Make the daemon launcher private to avoid exposing internals (`#794 <https://github.com/tomerfiliba/plumbum/pull/794>`_)
+  * Application instances now provide bash and fish completions out of the box (`#782 <https://github.com/tomerfiliba/plumbum/pull/782>`_)
+  * Drop use of ``atexit`` for color handling to avoid teardown issues (`#785 <https://github.com/tomerfiliba/plumbum/pull/785>`_)
 
 Fixes:
 
@@ -32,6 +35,10 @@ Fixes:
 * Make cache clear abstract by @henryiii (`#747 <https://github.com/tomerfiliba/plumbum/pull/747>`_)
 * Use ``perf_counter`` instead of datetime for Progress by @henryiii (`#754 <https://github.com/tomerfiliba/plumbum/pull/754>`_)
 * ``BrokenPipeError`` when piping CLI help output to head by @Copilot (`#727 <https://github.com/tomerfiliba/plumbum/pull/727>`_)
+* Fill out ``all`` and ``dir`` for modules to improve introspection (`#793 <https://github.com/tomerfiliba/plumbum/pull/793>`_)
+* Fix quoting inconsistency between standalone commands and pipelines (`#792 <https://github.com/tomerfiliba/plumbum/pull/792>`_)
+* Only register shutdown if a timeout was requested to avoid spurious handlers (`#784 <https://github.com/tomerfiliba/plumbum/pull/784>`_)
+* Reduce various warnings reported by linters and at runtime (`#781 <https://github.com/tomerfiliba/plumbum/pull/781>`_)
 
 Tests:
 
@@ -39,7 +46,7 @@ Tests:
 * Set ``LANG=C`` in pytest to fix locale-dependent test failures by @yajo (`#772 <https://github.com/tomerfiliba/plumbum/pull/772>`_)
 * Support pytest 9 by @henryiii (`#757 <https://github.com/tomerfiliba/plumbum/pull/757>`_)
 * pytest ``log_level`` is better than ``log_cli_level`` by @henryiii (`#756 <https://github.com/tomerfiliba/plumbum/pull/756>`_)
-
+* Increased test coverage and related test improvements (`#789 <https://github.com/tomerfiliba/plumbum/pull/789>`_)
 
 Internal:
 
@@ -48,6 +55,12 @@ Internal:
 * tid imports by @henryiii (`#753 <https://github.com/tomerfiliba/plumbum/pull/753>`_)
 * Fix badge showing wrong branch by @henryiii (`#736 <https://github.com/tomerfiliba/plumbum/pull/736>`_)
 * Fix links in changelog by @henryiii (`#732 <https://github.com/tomerfiliba/plumbum/pull/732>`_)
+
+Docs:
+
+* Converted docs and changelog formatting, moved to Furo theme and fixed local build issues and links (`#787 <https://github.com/tomerfiliba/plumbum/pull/787>`_, `#786 <https://github.com/tomerfiliba/plumbum/pull/786>`_)
+* Fixed various documentation warnings and added missing API docs (`#791 <https://github.com/tomerfiliba/plumbum/pull/791>`_)
+* Filled out older NEWS/changes entries and added a couple of missing docs files (`#790 <https://github.com/tomerfiliba/plumbum/pull/790>`_, `#788 <https://github.com/tomerfiliba/plumbum/pull/788>`_)
 
 CI:
 

--- a/docs/async_support.rst
+++ b/docs/async_support.rst
@@ -1,7 +1,7 @@
 Async Support
 =============
 
-.. versionadded:: 1.11
+.. versionadded:: 2.0
 
 Plumbum includes full support for asyncio, allowing you to run commands
 asynchronously using Python's ``async``/``await`` syntax.

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -296,7 +296,7 @@ is customized to handle closing tags correctly. For example::
 
     html = htmlcolors.sequence_to_string(htmlcolors.from_ansi_string(help_output))
 
-.. versionadded:: 1.11
+.. versionadded:: 2.0
 
 
 See Also

--- a/docs/paths.rst
+++ b/docs/paths.rst
@@ -22,6 +22,11 @@ with a few improvements and extra features.
     ``match``, ``rglob``, ``rmdir``, ``lstat``, ``symlink_to``, ``hardlink_to``, and the
     ``read_text``/``read_bytes``/``write_text``/``write_bytes`` helpers.
 
+.. versionchanged:: 2.0
+
+    The long-deprecated ``.basename``, ``.isdir()``, ``.isfile()``, and ``.islink()`` aliases
+    have been removed; use ``.name``, ``.is_dir()``, ``.is_file()``, and ``.is_symlink()`` instead.
+
 The primary ways to create paths are from ``.cwd``, ``.env.home``, or ``.path(...)`` on a local
 or remote machine, with ``/``, ``//`` or ``[]`` for composition.
 

--- a/docs/paths.rst
+++ b/docs/paths.rst
@@ -15,6 +15,13 @@ with a few improvements and extra features.
 
     Paths now support more pathlib like syntax, several old names have been depreciated, like ``.basename``
 
+.. versionadded:: 2.0
+
+    Many more pathlib-compatible members are now available, including ``joinpath``, ``with_stem``,
+    ``anchor``, ``as_posix``, ``absolute``, ``is_absolute``, ``is_relative_to``, ``samefile``,
+    ``match``, ``rglob``, ``rmdir``, ``lstat``, ``symlink_to``, ``hardlink_to``, and the
+    ``read_text``/``read_bytes``/``write_text``/``write_bytes`` helpers.
+
 The primary ways to create paths are from ``.cwd``, ``.env.home``, or ``.path(...)`` on a local
 or remote machine, with ``/``, ``//`` or ``[]`` for composition.
 

--- a/docs/quickref.rst
+++ b/docs/quickref.rst
@@ -98,7 +98,6 @@ Subtraction       Relative path
 Property                                            Description                 Compare to Pathlib
 =================================================== =========================== ==================
 ``.name``                                           The file name               ✓
-``.basename``                                       DEPRECATED
 ``.stem``                                           Name without extension      ✓
 ``.dirname``                                        Directory name              ✗
 ``.root``                                           The file tree root          ✓
@@ -128,11 +127,8 @@ Method                                              Description                 
 ``.list()``                                         Files in directory          ✗ (shortcut)
 ``.iterdir()``                                      Fast iterator over dir      ✓
 ``.is_dir()``                                       If path is dir              ✓
-``.isdir()``                                        DEPRECATED
 ``.is_file()``                                      If is file                  ✓
-``.isfile()``                                       DEPRECATED
 ``.is_symlink()``                                   If is symlink               ✓
-``.islink()``                                       DEPRECATED
 ``.exists()``                                       If file exists              ✓
 ``.stat()``                                         Return OS stats             ✓
 ``.with_name(name)``                                Replace filename            ✓

--- a/plumbum/colorlib/factories.py
+++ b/plumbum/colorlib/factories.py
@@ -181,11 +181,17 @@ class StyleFactory(ColorFactory[S]):
         return self._style.from_ansi(ansi_sequence)
 
     def from_ansi_string(self, ansi_string: str) -> Iterator[S | str]:
-        """Calling this is a shortcut for creating a style from an ANSI string."""
+        """Calling this is a shortcut for creating a style from an ANSI string.
+
+        .. versionadded:: 2.0
+        """
         return self._style.from_ansi_string(ansi_string)
 
     def sequence_to_string(self, sequence: Iterable[S | str]) -> str:
-        """Converts a sequence of styles and strings into a single string with ANSI codes."""
+        """Converts a sequence of styles and strings into a single string with ANSI codes.
+
+        .. versionadded:: 2.0
+        """
         return self._style.sequence_to_string(sequence)
 
     @property

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -9,7 +9,7 @@ With the ``Style`` class, any color can be directly called or given to a with st
 
 from __future__ import annotations
 
-__lazy_modules__ = {"contextlib", "copy", "platform", "re"}
+__lazy_modules__ = {"contextlib", "copy", "platform", "re", "warnings"}
 
 import contextlib
 import dataclasses
@@ -18,6 +18,7 @@ import platform
 import re
 import sys
 import typing
+import warnings
 from abc import ABCMeta, abstractmethod
 from copy import copy
 from typing import Any, ClassVar, Literal, TextIO, TypeVar
@@ -583,8 +584,10 @@ class Style(metaclass=ABCMeta):
             # OSError (errno 22, EINVAL) is raised on Windows when the pipe is closed
             pass
 
-    print_ = print
-    """DEPRECATED: Shortcut from classic Python 2"""
+    def print_(self, *printables: object, **kargs: Any) -> None:
+        """DEPRECATED: Shortcut from classic Python 2; use ``.print`` instead."""
+        warnings.warn("Use .print instead", FutureWarning, stacklevel=2)
+        self.print(*printables, **kargs)
 
     def __getitem__(self, wrapped: str) -> str:
         """The [] syntax is supported for wrapping"""

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -695,7 +695,10 @@ class Style(metaclass=ABCMeta):
 
     @classmethod
     def from_ansi_string(cls, ansi_string: str) -> Iterator[str | Self]:
-        """This will read in a string with interleaved codes"""
+        """This will read in a string with interleaved codes
+
+        .. versionadded:: 2.0
+        """
         last_end = 0
         for res in cls.ANSI_REG.finditer(ansi_string):
             if res.start() > last_end:
@@ -711,7 +714,10 @@ class Style(metaclass=ABCMeta):
 
     @classmethod
     def sequence_to_string(cls, sequence: Iterable[Style | str]) -> str:
-        """This is the opposite of from_ansi_string, it takes a list of styles and strings and concatenates them."""
+        """This is the opposite of from_ansi_string, it takes a list of styles and strings and concatenates them.
+
+        .. versionadded:: 2.0
+        """
         return "".join(str(s) for s in sequence)
 
     def add_ansi(self, sequence: Iterable[int], filter_resets: bool = False) -> None:

--- a/plumbum/commands/async_.py
+++ b/plumbum/commands/async_.py
@@ -48,7 +48,7 @@ Example Usage
         result = await (async_local["ls"] | async_local["grep"]["py"])()
         print(result)
 
-.. versionadded:: 1.11
+.. versionadded:: 2.0
 """
 
 from __future__ import annotations
@@ -550,7 +550,7 @@ class AsyncRemoteCommand(AsyncCommand):
             ls = rem["ls"]
             result = await ls("-la")
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     __slots__ = ()
@@ -609,7 +609,7 @@ class _AsyncTF(AsyncExecutionModifier):
         # Check for specific exit code
         result = await (async_local["grep"]["pattern", "file.txt"] & AsyncTF(retcode=(0, 1)))
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     __slots__ = ("retcode", "timeout")
@@ -652,7 +652,7 @@ class _AsyncRETCODE(AsyncExecutionModifier):
         code = await (async_local["ls"]["/nonexistent"] & AsyncRETCODE)
         print(f"Exit code: {code}")
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     __slots__ = ("timeout",)
@@ -688,7 +688,7 @@ class _AsyncTEE(AsyncExecutionModifier):
         # With custom expected return code
         retcode, stdout, stderr = await (async_local["grep"]["pattern"] & AsyncTEE(retcode=(0, 1)))
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     __slots__ = ("retcode", "timeout")

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -546,7 +546,7 @@ class AsyncLocalMachine:
         # Execution is async
         result = await ls("-la")
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     def __getitem__(self, cmd: str | LocalPath) -> AsyncLocalCommand:
@@ -603,7 +603,7 @@ Use this to access async commands::
         result = await async_local["ls"]("-la")
         print(result)
 
-.. versionadded:: 1.11
+.. versionadded:: 2.0
 """
 
 __all__ = [

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -644,7 +644,7 @@ class AsyncRemoteMachine:
             ls = rem["ls"]
             result = await ls("-la")
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     __slots__ = ("_sync_machine",)

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -531,7 +531,7 @@ class AsyncSshMachine:
                 rem["echo"]("task2"),
             )
 
-    .. versionadded:: 1.11
+    .. versionadded:: 2.0
     """
 
     __slots__ = ("_sync_machine",)

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -11,12 +11,10 @@ __lazy_modules__ = {
     "plumbum.path.remote",
     "re",
     "socket",
-    "warnings",
 }
 
 import re
 import socket
-import warnings
 from contextlib import closing
 from typing import TYPE_CHECKING, Any
 
@@ -229,19 +227,6 @@ class SshMachine(BaseRemoteMachine):
             else:
                 cmdline.append(args)  # type: ignore[arg-type]
         return self._ssh_command[tuple(cmdline)].popen(**kwargs)
-
-    def nohup(self, command: BaseCommand) -> None:
-        """
-        Runs the given command using ``nohup`` and redirects std handles,
-        allowing the command to run "detached" from its controlling TTY or parent.
-        Does not return anything. Depreciated (use command.nohup or daemonic_popen).
-        """
-        warnings.warn(
-            "Use .nohup on the command or use daemonic_popen)",
-            FutureWarning,
-            stacklevel=2,
-        )
-        self.daemonic_popen(command, cwd=".", stdout=None, stderr=None, append=False)
 
     def daemonic_popen(
         self,

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -130,7 +130,10 @@ class Path(str, ABC):
 
     # Currently, typed as just "str" to match .join, though Path should mostly work too.
     def joinpath(self, *others: str) -> Self:
-        """Pathlib-compatible alias of :meth:`join`."""
+        """Pathlib-compatible alias of :meth:`join`.
+
+        .. versionadded:: 2.0
+        """
         return self.join(*others)
 
     def walk(
@@ -280,7 +283,10 @@ class Path(str, ABC):
         return self if len(self.suffixes) > 0 else self.with_suffix(suffix)
 
     def with_stem(self, stem: str) -> Self:
-        """Returns a path with the stem replaced."""
+        """Returns a path with the stem replaced.
+
+        .. versionadded:: 2.0
+        """
         return self.with_name(stem + "".join(self.suffixes))
 
     @abstractmethod
@@ -300,7 +306,10 @@ class Path(str, ABC):
         return self.move(self.up() / newname)
 
     def rmdir(self) -> None:
-        """Removes this directory if it is empty."""
+        """Removes this directory if it is empty.
+
+        .. versionadded:: 2.0
+        """
         if not self.is_dir():
             raise NotADirectoryError(str(self))
         if any(True for _ in self.iterdir()):
@@ -343,7 +352,10 @@ class Path(str, ABC):
         """opens this path as a file"""
 
     def read_bytes(self) -> bytes:
-        """Returns the contents of this file as ``bytes``."""
+        """Returns the contents of this file as ``bytes``.
+
+        .. versionadded:: 2.0
+        """
         try:
             with self.open("rb") as f:
                 data = f.read()
@@ -357,7 +369,10 @@ class Path(str, ABC):
         return data
 
     def read_text(self, encoding: str | None = None, errors: str | None = None) -> str:
-        """Returns the contents of this file as ``str``."""
+        """Returns the contents of this file as ``str``.
+
+        .. versionadded:: 2.0
+        """
         if errors not in {None, "strict"}:
             raise NotImplementedError("Only errors='strict' is currently supported")
         data = self.read(encoding=encoding or "utf-8")
@@ -376,7 +391,10 @@ class Path(str, ABC):
         or ``'utf8'``"""
 
     def write_bytes(self, data: bytes) -> int:
-        """Writes bytes to this file and returns the number of bytes written."""
+        """Writes bytes to this file and returns the number of bytes written.
+
+        .. versionadded:: 2.0
+        """
         if not isinstance(data, bytes):
             raise TypeError("data must be bytes")
         self.write(data)
@@ -389,7 +407,10 @@ class Path(str, ABC):
         errors: str | None = None,
         newline: str | None = None,
     ) -> int:
-        """Writes text to this file and returns the number of characters written."""
+        """Writes text to this file and returns the number of characters written.
+
+        .. versionadded:: 2.0
+        """
         if errors not in {None, "strict"}:
             raise NotImplementedError("Only errors='strict' is currently supported")
         if newline is not None:
@@ -463,6 +484,8 @@ class Path(str, ABC):
         """Pathlib-compatible symbolic-link creation.
 
         Creates a symbolic link at ``self`` that points to ``target``.
+
+        .. versionadded:: 2.0
         """
         target = self._form(target)
         target.symlink(self)
@@ -471,6 +494,8 @@ class Path(str, ABC):
         """Pathlib-compatible hard-link creation.
 
         Creates a hard link at ``self`` that points to ``target``.
+
+        .. versionadded:: 2.0
         """
         target = self._form(target)
         target.link(self)
@@ -480,7 +505,10 @@ class Path(str, ABC):
         """Deletes a symbolic link"""
 
     def lstat(self) -> os.stat_result:
-        """Like :meth:`stat`. Backends may override for symlink-specific behavior."""
+        """Like :meth:`stat`. Backends may override for symlink-specific behavior.
+
+        .. versionadded:: 2.0
+        """
         return self.stat()
 
     def split(self, *_args: object, **_kargs: object) -> builtins.list[str]:
@@ -501,26 +529,41 @@ class Path(str, ABC):
 
     @property
     def anchor(self) -> str:
-        """Pathlib-compatible anchor (drive + root)."""
+        """Pathlib-compatible anchor (drive + root).
+
+        .. versionadded:: 2.0
+        """
         return self.drive + self.root
 
     def as_posix(self) -> str:
-        """Returns the path string with POSIX separators."""
+        """Returns the path string with POSIX separators.
+
+        .. versionadded:: 2.0
+        """
         return str(self).replace("\\", "/")
 
     def absolute(self) -> Self:
-        """Returns an absolute version of this path."""
+        """Returns an absolute version of this path.
+
+        .. versionadded:: 2.0
+        """
         return self.resolve()
 
     def is_absolute(self) -> bool:
-        """Returns ``True`` if this path is absolute."""
+        """Returns ``True`` if this path is absolute.
+
+        .. versionadded:: 2.0
+        """
         path = str(self)
         return path.startswith(("/", "\\")) or (
             len(path) >= 3 and path[1] == ":" and path[2] in ("/", "\\")
         )
 
     def is_relative_to(self, other: Self | str) -> bool:
-        """Returns ``True`` when this path is within ``other``."""
+        """Returns ``True`` when this path is within ``other``.
+
+        .. versionadded:: 2.0
+        """
         other = self._form(other)
         if self.anchor != other.anchor:
             return False
@@ -534,14 +577,20 @@ class Path(str, ABC):
         return len(parts) >= len(base_parts) and parts[: len(base_parts)] == base_parts
 
     def samefile(self, other: Self | str) -> bool:
-        """Returns ``True`` if this path and ``other`` point to the same file."""
+        """Returns ``True`` if this path and ``other`` point to the same file.
+
+        .. versionadded:: 2.0
+        """
         other = self._form(other)
         st = self.stat()
         other_st = other.stat()
         return (st.st_dev, st.st_ino) == (other_st.st_dev, other_st.st_ino)
 
     def match(self, pattern: str) -> bool:
-        """Tests if this path matches a glob-style pattern."""
+        """Tests if this path matches a glob-style pattern.
+
+        .. versionadded:: 2.0
+        """
         path = self.as_posix()
         pat = pattern.replace("\\", "/")
         if not self.CASE_SENSITIVE:
@@ -562,7 +611,10 @@ class Path(str, ABC):
         return fnmatch.fnmatchcase(right_side, "/".join(pat_parts))
 
     def rglob(self, pattern: str) -> builtins.list[Self]:
-        """Recursively glob under this path."""
+        """Recursively glob under this path.
+
+        .. versionadded:: 2.0
+        """
         return [path for path in self.walk() if path.match(pattern)]
 
     def relative_to(self, source: Self | str) -> RelativePath:

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-__lazy_modules__ = {"fnmatch", "functools", "itertools", "operator", "warnings"}
+__lazy_modules__ = {"fnmatch", "functools", "itertools", "operator"}
 
 import fnmatch
 import itertools
 import operator
 import os
 import typing
-import warnings
 from abc import ABC, abstractmethod
 from functools import reduce
 from typing import IO, SupportsIndex, TypeVar
@@ -162,12 +161,6 @@ class Path(str, ABC):
         """The basename component of this path"""
 
     @property
-    def basename(self) -> str:
-        """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use .name instead", FutureWarning, stacklevel=2)
-        return self.name
-
-    @property
     @abstractmethod
     def stem(self) -> str:
         """The name without an extension, or the last component of the path"""
@@ -235,24 +228,9 @@ class Path(str, ABC):
     def is_dir(self) -> bool:
         """Returns ``True`` if this path is a directory, ``False`` otherwise"""
 
-    def isdir(self) -> bool:
-        """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use .is_dir() instead", FutureWarning, stacklevel=2)
-        return self.is_dir()
-
     @abstractmethod
     def is_file(self) -> bool:
         """Returns ``True`` if this path is a regular file, ``False`` otherwise"""
-
-    def isfile(self) -> bool:
-        """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use .is_file() instead", FutureWarning, stacklevel=2)
-        return self.is_file()
-
-    def islink(self) -> bool:
-        """Included for compatibility with older Plumbum code"""
-        warnings.warn("Use is_symlink instead", FutureWarning, stacklevel=2)
-        return self.is_symlink()
 
     @abstractmethod
     def is_symlink(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development :: Build Tools",
     "Topic :: System :: Systems Administration",
     "Typing :: Typed",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -365,6 +365,7 @@ s.close()
         with self._connect() as rem:
             rem.cmd.ls("/tmp")
 
+    @pytest.mark.xfail(env.PYPY, reason="PyPy sometimes fails here", strict=False)
     @pytest.mark.usefixtures("testdir")
     def test_download_upload(self):
         with self._connect() as rem:


### PR DESCRIPTION
- [x] Convert all 2.0.0 CHANGELOG entries from plain URL format to RST link format (`#NNN <url>`_)
- [x] Add "More pathlib API supported by @henryiii (#779)" entry to Features section

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.