### PR TITLE
feat: add more Path API

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -47,13 +47,14 @@ class Path(str, ABC):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self}>"
 
-    def __truediv__(self, other: str | Self) -> Self:
+    def __truediv__(self, other: str | Path) -> Self:
         """Joins two paths"""
         return self.join(other)
 
-    def __rtruediv__(self, other: str | Self) -> Self:
+    def __rtruediv__(self, other: str | Path) -> Self:
         """Joins two paths when this path appears on the right-hand side."""
-        return self._form(str(other)) / self
+        other = self._form(other)
+        return other / self
 
     @typing.overload
     def __getitem__(self, key: str | Path) -> Self: ...
@@ -118,16 +119,17 @@ class Path(str, ABC):
             return (self / item).exists()  # type: ignore[operator]
 
     @abstractmethod
-    def _form(self, *parts: typing.Any) -> Self:
+    def _form(self, *parts: str) -> Self:
         pass
 
     def up(self, count: int = 1) -> Self:
         """Go up in ``count`` directories (the default is 1)"""
         return self.join("../" * count)
 
-    def joinpath(self, *others: str | Path) -> Self:
+    # Currently, typed as just "str" to match .join, though Path should mostly work too.
+    def joinpath(self, *others: str) -> Self:
         """Pathlib-compatible alias of :meth:`join`."""
-        return self.join(*(str(other) for other in others))
+        return self.join(*others)
 
     def walk(
         self,
@@ -460,8 +462,7 @@ class Path(str, ABC):
 
         Creates a symbolic link at ``self`` that points to ``target``.
         """
-        if not isinstance(target, Path):
-            target = self._form(target)
+        target = self._form(target)
         target.symlink(self)
 
     def hardlink_to(self, target: Self | str) -> None:
@@ -469,8 +470,7 @@ class Path(str, ABC):
 
         Creates a hard link at ``self`` that points to ``target``.
         """
-        if not isinstance(target, Path):
-            target = self._form(target)
+        target = self._form(target)
         target.link(self)
 
     @abstractmethod
@@ -519,8 +519,7 @@ class Path(str, ABC):
 
     def is_relative_to(self, other: Self | str) -> bool:
         """Returns ``True`` when this path is within ``other``."""
-        if not isinstance(other, Path):
-            other = self._form(other)
+        other = self._form(other)
         if self.anchor != other.anchor:
             return False
 
@@ -534,8 +533,7 @@ class Path(str, ABC):
 
     def samefile(self, other: Self | str) -> bool:
         """Returns ``True`` if this path and ``other`` point to the same file."""
-        if not isinstance(other, Path):
-            other = self._form(other)
+        other = self._form(other)
         st = self.stat()
         other_st = other.stat()
         return (st.st_dev, st.st_ino) == (other_st.st_dev, other_st.st_ino)
@@ -576,8 +574,7 @@ class Path(str, ABC):
             /var/log/messages - /opt              = [.., var, log, messages]
             /var/log/messages - /opt/lib          = [.., .., var, log, messages]
         """
-        if not isinstance(source, Path):
-            source = self._form(source)
+        source = self._form(source)
         parts = self.split()
         baseparts = source.split()
         ancestors = len(

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -54,7 +54,7 @@ class LocalPath(Path):
 
     CASE_SENSITIVE = not IS_WIN32
 
-    def __new__(cls, *parts: str) -> Self:
+    def __new__(cls, *parts: str | Path) -> Self:
         if (
             len(parts) == 1
             and isinstance(parts[0], cls)
@@ -76,7 +76,7 @@ class LocalPath(Path):
     def _get_info(self) -> str:
         return self._path
 
-    def _form(self, *parts: str) -> LocalPath:
+    def _form(self, *parts: str | Path) -> LocalPath:
         return LocalPath(*parts)
 
     @property

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -99,7 +99,7 @@ class RemotePath(Path):
     __slots__ = ("CASE_SENSITIVE", "remote")
     remote: BaseRemoteMachine
 
-    def __new__(cls, remote: BaseRemoteMachine, *parts_str: str) -> Self:
+    def __new__(cls, remote: BaseRemoteMachine, *parts_str: str | Path) -> Self:
         if not parts_str:
             raise TypeError("At least one path part is required (none given)")
         windows = remote.uname.lower() == "windows"
@@ -143,7 +143,7 @@ class RemotePath(Path):
         self.remote = remote
         return self
 
-    def _form(self, *parts: str) -> RemotePath:
+    def _form(self, *parts: str | Path) -> RemotePath:
         return RemotePath(self.remote, *parts)
 
     @property

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -234,6 +234,9 @@ class TestLocalPath:
             renamed = nested.with_stem("renamed")
             assert renamed.name == "renamed.txt"
 
+            long_name = tmp / "file.with.many.dots.txt"
+            assert long_name.with_stem("new").name == "new.with.many.dots.txt"
+
             assert nested.match("*.txt")
             assert nested.match("b/*.txt")
             assert not nested.match("*.py")


### PR DESCRIPTION
I checked for missing API, then asked copilot in VSCode to fill in some of the easiest missing API. Remaining API:

```pycon
>>> set(n for n in dir(pathlib.Path) if not n.startswith("_")) - set(dir(plumbum.path.base.Path))
{'parser', 'from_uri', 'group', 'is_char_device'
 'is_reserved', 'copy_into', 'info', 'is_fifo',
 'home', 'is_junction', 'is_mount', 'cwd', 'move_into',
 'is_socket', 'lchmod', 'expanduser', 'readlink',
 'full_match', 'is_block_device', 'with_segments', 'owner'}
```
