### PR TITLE
feat: drop atexit for colors

### DIFF
--- a/docs/api/colors.rst
+++ b/docs/api/colors.rst
@@ -3,7 +3,6 @@ Package plumbum.colors
 
 .. automodule:: plumbum.colors
    :members:
-   :special-members:
 
 plumbum.colorlib
 ----------------

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -257,6 +257,14 @@ Output:
     </font>Not red color or bold.<br/>
     <font color="#800080"><b>This is bold and colorful!</b></font> And this is not.</p>
 
+
+You can also call :func:`plumbum.colors.ensure_reset` to have your program emit
+a clear color code on exit. It might cause an empty line to be shown on your terminal.
+
+.. versionadded:: 2.0
+
+   This was default before 2.0, now it's an opt-in function.
+
 Style Combinations
 ^^^^^^^^^^^^^^^^^^
 

--- a/plumbum/colors.py
+++ b/plumbum/colors.py
@@ -12,11 +12,20 @@ import sys
 from plumbum.colorlib import ansicolors, main
 
 _reset = ansicolors.reset.now
-if __name__ == "__main__":
-    main()
-else:  # Don't register an exit if this is called using -m!
+
+
+def ensure_colors_reset() -> None:
+    """
+    Call this to ensure colors are reset when the program exits. Might add an
+    extra blank line.
+    """
     atexit.register(_reset)
+
 
 sys.modules[__name__ + ".fg"] = ansicolors.fg  # type: ignore[assignment]
 sys.modules[__name__ + ".bg"] = ansicolors.bg  # type: ignore[assignment]
 sys.modules[__name__] = ansicolors  # type: ignore[assignment]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This can cause an unwanted blank line, is not as commonly needed (due to more colors on the CLI today), so making it opt-in instead for 2.0.
