### PR TITLE
Fix O(n^2) performance in StdinDataRedirection.popen

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -617,10 +617,7 @@ class StdinDataRedirection(BaseCommand):
         if isinstance(data, str) and encoding is not None:
             data = data.encode(encoding)
         f = TemporaryFile()
-        while data:
-            chunk = data[: self.CHUNK_SIZE]
-            f.write(chunk)  # type: ignore[arg-type]
-            data = data[self.CHUNK_SIZE :]
+        f.write(data)  # type: ignore[arg-type]
         f.seek(0)
         kwargs["stdin"] = f
         try:

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -586,7 +586,6 @@ ERROUT = _ERROUT(subprocess.STDOUT)
 
 class StdinDataRedirection(BaseCommand):
     __slots__ = ("cmd", "data")
-    CHUNK_SIZE = 16000
 
     cmd: BaseCommand
     data: bytes | str


### PR DESCRIPTION
## Summary

`StdinDataRedirection.popen` wrote data to a `TemporaryFile` in 16 KB chunks using `data = data[CHUNK_SIZE:]`. Each slice copies the entire remaining buffer, making the total work O(n^2). For a 242 MB input, this means ~1.8 TB of memory copies and the process hangs for hours.

Replace the chunked loop with a single `f.write(data)` call. `TemporaryFile.write()` handles arbitrarily large data, and the data is already fully materialized in memory, so chunking served no purpose.

## Context

I hit this when using [copier](https://github.com/copier-org/copier) to update a project. Copier pipes `git diff-tree` output through plumbum's stdin redirection (`cmd << diff_data`). A project with ~500 MB of tracked files produces a 242 MB diff, and copier hangs indefinitely at the `while data:` loop.

| Input size | Iterations | Total bytes copied | Wall time |
|-----------|-----------|-------------------|-----------|
| 1 MB | 63 | ~31 MB | instant |
| 50 MB | 3,125 | ~78 GB | seconds |
| 242 MB | 15,125 | ~1.8 TB | hours |

Fixes #797
