### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: "3.x"
     - uses: pre-commit/action@v3.0.1
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
     - name: pylint
       run: uvx nox -s pylint -- --output-format=github
 
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup uv (cached)
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         enable-cache: true
         cache-suffix: ${{ matrix.os }}-${{ matrix.python-version }}


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos