### PR TITLE
fix(async): correct remote streaming, pipeline TEE, and command binding

### DIFF
--- a/plumbum/commands/async_.py
+++ b/plumbum/commands/async_.py
@@ -715,7 +715,7 @@ class _AsyncTEE(AsyncExecutionModifier):
         async def read_stream(
             stream: asyncio.StreamReader | None, output_list: list[str], target: Any
         ) -> None:
-            """Read from stream, display, and collect output."""
+            """Read from stream line by line, display, and collect output."""
             if stream is None:
                 return
 
@@ -729,13 +729,46 @@ class _AsyncTEE(AsyncExecutionModifier):
                 target.write(text)
                 target.flush()
 
-        # Read stdout and stderr concurrently
+        async def drain_stream(
+            stream: asyncio.StreamReader | None, target: Any
+        ) -> None:
+            """Display a stream in fixed-size chunks (no line buffering).
+
+            Used for upstream pipeline stderr, where output may be large and
+            without newlines -- ``readline`` would raise once a line exceeds the
+            stream's buffer limit, so read by chunk instead.
+            """
+            if stream is None:
+                return
+
+            while True:
+                chunk = await stream.read(4096)
+                if not chunk:
+                    break
+
+                target.write(chunk.decode(encoding, errors="ignore"))
+                target.flush()
+
+        # ``proc.stdout``/``proc.stderr`` are the pipeline's *final* stage. Each
+        # upstream stage of a pipeline has its own stderr pipe that must also be
+        # drained -- otherwise a chatty upstream stderr fills its buffer and
+        # deadlocks the wait() below (only communicate() drains every stage). We
+        # display these too, like a shell pipeline; the returned stderr stays the
+        # final stage's, matching ``popen().communicate()``. The loop adds nothing
+        # for a plain command (no upstream stages).
+        readers = [
+            read_stream(proc.stdout, stdout_lines, sys.stdout),
+            read_stream(proc.stderr, stderr_lines, sys.stderr),
+        ]
+        node: Any = proc
+        while isinstance(node, AsyncPipelineProcess):
+            node = node.srcproc
+            readers.append(drain_stream(node.stderr, sys.stderr))
+
+        # Read every stage's streams concurrently
         try:
             await asyncio.wait_for(
-                asyncio.gather(
-                    read_stream(proc.stdout, stdout_lines, sys.stdout),
-                    read_stream(proc.stderr, stderr_lines, sys.stderr),
-                ),
+                asyncio.gather(*readers),
                 timeout=self.timeout,
             )
         except asyncio.TimeoutError:

--- a/plumbum/commands/async_.py
+++ b/plumbum/commands/async_.py
@@ -243,14 +243,44 @@ class AsyncCommandMixin:
         """
         self._base_cmd = base_cmd
 
-    def __getitem__(self, args: Any) -> AsyncCommand:
+    @property
+    def _concrete(self) -> BaseCommand:
+        """The innermost command, unwrapping any ``Bound``/``BoundEnv`` layers.
+
+        Binding arguments or an environment wraps the base command, so the
+        concrete command (the one carrying ``executable``/``remote``) lives
+        underneath. This is used by the subclass ``executable``/``remote``
+        properties so they keep working after ``[...]``/``with_env``/``with_cwd``.
+        """
+        cmd = self._base_cmd
+        while isinstance(cmd, (BoundCommand, BoundEnvCommand)):
+            cmd = cmd.cmd
+        return cmd
+
+    def __getitem__(self, args: Any) -> Self:
         """Bind arguments using the base command's logic.
 
         This delegates to the sync command's __getitem__ method, which handles
-        all the argument binding logic, then wraps the result in an AsyncCommand.
+        all the argument binding logic, then re-wraps the result in the same
+        async type as ``self`` (preserving e.g. ``AsyncLocalCommand``).
         """
         bound = self._base_cmd[args]
-        return AsyncCommand(bound)
+        return self.__class__(bound)
+
+    def with_env(self, **env: str) -> Self:
+        """Return a new async command with the given environment variables.
+
+        Delegates to the sync command's ``with_env`` (which produces a
+        ``BoundEnvCommand``) and re-wraps it in the same async type.
+        """
+        return self.__class__(self._base_cmd.with_env(**env))
+
+    def with_cwd(self, path: Any) -> Self:
+        """Return a new async command with the given working directory.
+
+        Delegates to the sync command's ``with_cwd`` and re-wraps the result.
+        """
+        return self.__class__(self._base_cmd.with_cwd(path))
 
     def __call__(self, *args: Any, **kwargs: Any) -> Coroutine[Any, Any, str]:
         """Execute the command asynchronously and return stdout.
@@ -309,7 +339,7 @@ class AsyncCommandMixin:
             ProcessExecutionError: If return code doesn't match expected
             asyncio.TimeoutError: If timeout is exceeded
         """
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def _run_sync() -> tuple[int, str, str]:
             retcode_val, stdout, stderr = self._base_cmd.run(
@@ -335,6 +365,12 @@ class AsyncCommandMixin:
         This is useful for long-running processes or when you need to
         interact with stdin/stdout/stderr.
 
+        .. note::
+            Streaming is only supported for **local** commands. Remote commands
+            raise :class:`NotImplementedError` here -- run them with ``.run()``
+            or by calling the command directly (those execute the underlying
+            sync command in a thread).
+
         Args:
             args: Additional arguments to pass to the command
             cwd: Working directory for the command
@@ -354,9 +390,9 @@ class AsyncCommandMixin:
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
-        stdin: int = asyncio.subprocess.PIPE,
-        stdout: int = asyncio.subprocess.PIPE,
-        stderr: int = asyncio.subprocess.PIPE,
+        stdin: int | None = asyncio.subprocess.PIPE,
+        stdout: int | None = asyncio.subprocess.PIPE,
+        stderr: int | None = asyncio.subprocess.PIPE,
     ) -> asyncio.subprocess.Process | AsyncPipelineProcess:
         """Spawn the subprocess, threading stdin/stdout through pipeline stages.
 
@@ -364,32 +400,38 @@ class AsyncCommandMixin:
         pipelines need to connect one stage's stdout to the next stage's stdin,
         so this internal helper exposes those handles.
         """
-        base = self._base_cmd
+        # Streaming via ``asyncio.create_subprocess_exec`` only works for local
+        # commands -- a RemoteCommand would be formulated without its ssh wrapper
+        # and silently run on *this* machine. Remote commands are still supported
+        # through ``run()``/``__call__`` (which delegate to the sync command in a
+        # thread); fail loudly here rather than executing the wrong thing.
+        if self._base_cmd.machine is not local:
+            raise NotImplementedError(
+                "Async popen/streaming (popen, AsyncTEE) is only supported for "
+                "local commands. Use .run() or call the command directly for "
+                "remote commands -- those execute the sync command in a thread."
+            )
 
-        # A bound pipeline -- e.g. (a | b)["--flag"] or (a | b).with_env(...) --
-        # wraps the Pipeline in BoundCommand/BoundEnvCommand. Unwrap those to find
-        # the pipeline and thread the bound args/env/cwd into its stages. The
-        # plain ``formulate`` path below keeps using the original command, so its
-        # shell-quoting level (which differs for remote commands) is unchanged.
-        pipe_base: BaseCommand = base
-        pipe_args = list(args)
-        pipe_env = env
-        pipe_cwd = cwd
-        while isinstance(pipe_base, (BoundCommand, BoundEnvCommand)):
-            if isinstance(pipe_base, BoundCommand):
-                pipe_args = [*pipe_base.args, *pipe_args]
+        # Binding args/env/cwd wraps the command in BoundCommand/BoundEnvCommand
+        # (possibly around a Pipeline -- e.g. (a | b)["--flag"]). Unwrap those to
+        # reach the concrete command (or Pipeline) and thread the bound
+        # args/env/cwd inward, so they take effect for plain commands too.
+        base: BaseCommand = self._base_cmd
+        cmd_args = list(args)
+        cmd_env = env
+        cmd_cwd = cwd
+        while isinstance(base, (BoundCommand, BoundEnvCommand)):
+            if isinstance(base, BoundCommand):
+                cmd_args = [*base.args, *cmd_args]
             else:
-                pipe_env = {**pipe_base.env, **(pipe_env or {})}
-                pipe_cwd = pipe_base.cwd if pipe_cwd is None else pipe_cwd
-            pipe_base = pipe_base.cmd
+                cmd_env = {**base.env, **(cmd_env or {})}
+                cmd_cwd = base.cwd if cmd_cwd is None else cmd_cwd
+            base = base.cmd
 
         # A pipeline has no single argv; connect the two stages with an OS pipe,
-        # mirroring the synchronous Pipeline.popen.
-        if isinstance(pipe_base, Pipeline):
-            base = pipe_base
-            args = pipe_args
-            env = pipe_env
-            cwd = pipe_cwd
+        # mirroring the synchronous Pipeline.popen (extra args go to the head
+        # stage, as in that implementation).
+        if isinstance(base, Pipeline):
             read_fd, write_fd = os.pipe()
             # The parent closes each fd once the child has inherited it. The
             # nested try ensures both fds are closed even if either spawn raises
@@ -397,9 +439,9 @@ class AsyncCommandMixin:
             try:
                 try:
                     srcproc = await self.__class__(base.srccmd)._popen(
-                        args,
-                        cwd=cwd,
-                        env=env,
+                        cmd_args,
+                        cwd=cmd_cwd,
+                        env=cmd_env,
                         stdin=stdin,
                         stdout=write_fd,
                         stderr=stderr,
@@ -409,8 +451,8 @@ class AsyncCommandMixin:
 
                 try:
                     dstproc = await self.__class__(base.dstcmd)._popen(
-                        cwd=cwd,
-                        env=env,
+                        cwd=cmd_cwd,
+                        env=cmd_env,
                         stdin=read_fd,
                         stdout=stdout,
                         stderr=stderr,
@@ -431,17 +473,15 @@ class AsyncCommandMixin:
             # the synchronous Pipeline.popen).
             return AsyncPipelineProcess(dstproc, srcproc)
 
-        argv = base.formulate(0, args)
+        # Formulate at level 0 (no shell-quoting -- we exec the argv directly),
+        # matching the synchronous LocalCommand.popen.
+        argv = base.formulate(0, cmd_args)
 
         full_env = dict(local.env.getdict())
-        base_env = getattr(base, "env", None)
-        if base_env:
-            full_env.update(base_env)
-        if env:
-            full_env.update(env)
+        if cmd_env:
+            full_env.update(cmd_env)
 
-        base_cwd = getattr(base, "cwd", None)
-        working_dir = cwd or base_cwd or str(local.cwd)
+        working_dir = cmd_cwd or str(local.cwd)
 
         return await asyncio.create_subprocess_exec(
             *argv,
@@ -486,9 +526,8 @@ class AsyncLocalCommand(AsyncCommand):
     @property
     def executable(self) -> Any:
         """The path to the executable."""
-        # Access the executable attribute from the base command
-        # This is safe because LocalCommand has this attribute
-        return self._base_cmd.executable  # type: ignore[attr-defined]
+        # Unwrap any bound layers; the concrete LocalCommand carries `executable`.
+        return self._concrete.executable  # type: ignore[attr-defined]
 
 
 class AsyncRemoteCommand(AsyncCommand):
@@ -511,7 +550,8 @@ class AsyncRemoteCommand(AsyncCommand):
     @property
     def remote(self) -> Any:
         """The remote machine this command belongs to."""
-        return self._base_cmd.remote  # type: ignore[attr-defined]
+        # Unwrap any bound layers; the concrete RemoteCommand carries `remote`.
+        return self._concrete.remote  # type: ignore[attr-defined]
 
 
 # ===================================================================================================
@@ -661,30 +701,12 @@ class _AsyncTEE(AsyncExecutionModifier):
 
     async def __rand__(self, cmd: AsyncCommandMixin) -> tuple[int, str, str]:
         """Execute command, display output, and return (retcode, stdout, stderr)."""
-        # Get encoding from base command
         encoding = cmd._base_cmd._get_encoding() or local.custom_encoding
 
-        # Merge environment
-        full_env = dict(local.env.getdict())
-        base_env = getattr(cmd._base_cmd, "env", None)
-        if base_env:
-            full_env.update(base_env)
-
-        # Use base command's cwd if set
-        base_cwd = getattr(cmd._base_cmd, "cwd", None)
-        working_dir = base_cwd or str(local.cwd)
-
-        # Formulate command
-        argv = cmd._base_cmd.formulate(0, ())
-
-        # Create subprocess
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=working_dir,
-            env=full_env,
-        )
+        # Reuse ``_popen`` so this works for pipelines too (its own
+        # create_subprocess_exec path only handled single commands), and so the
+        # local-only guard applies. stdin is inherited from the parent process.
+        proc = await cmd._popen((), stdin=None)
 
         # Collect output while displaying it
         stdout_lines: list[str] = []
@@ -721,12 +743,13 @@ class _AsyncTEE(AsyncExecutionModifier):
             await proc.wait()
             raise
 
-        # Wait for process to complete
+        # Wait for process to complete (reaps every pipeline stage)
         await proc.wait()
 
         # Combine output
         stdout = "".join(stdout_lines)
         stderr = "".join(stderr_lines)
+        retcode = proc.returncode
 
         # Check return code
         if self.retcode is not None:
@@ -734,15 +757,15 @@ class _AsyncTEE(AsyncExecutionModifier):
                 {self.retcode} if isinstance(self.retcode, int) else set(self.retcode)  # type: ignore[call-overload]
             )
 
-            if proc.returncode not in expected_codes:
+            if retcode not in expected_codes:
                 raise ProcessExecutionError(
-                    argv=argv,
-                    retcode=proc.returncode,
+                    argv=cmd.formulate(0, ()),
+                    retcode=retcode,
                     stdout=stdout,
                     stderr=stderr,
                 )
 
-        return proc.returncode or 0, stdout, stderr
+        return (retcode or 0), stdout, stderr
 
 
 # Singleton instances

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -7,6 +7,7 @@ import platform
 import re
 import subprocess
 import sys
+import threading
 import time
 import typing
 from contextlib import AbstractContextManager, contextmanager
@@ -77,6 +78,13 @@ if IS_WIN32:
 
 logger = logging.getLogger("plumbum.local")
 
+# ``expand``/``expanduser`` below temporarily swap out the global ``os.environ``
+# while expanding. Without serialization, two threads interleaving their
+# save/restore can permanently leave ``os.environ`` pointing at a throwaway
+# dict. This matters now that the async layer runs sync commands in executor
+# threads. The lock keeps the swap/restore atomic with respect to each other.
+_environ_lock = threading.RLock()
+
 
 # ===================================================================================================
 # Environment
@@ -101,12 +109,13 @@ class LocalEnv(BaseEnv[LocalPath]):
                      home shortcuts (as ``~/.bashrc``)
 
         :returns: The expanded string"""
-        prev = os.environ
-        os.environ = self.getdict()  # type: ignore[assignment] # noqa: B003
-        try:
-            output = os.path.expanduser(os.path.expandvars(expr))
-        finally:
-            os.environ = prev  # noqa: B003
+        with _environ_lock:
+            prev = os.environ
+            os.environ = self.getdict()  # type: ignore[assignment] # noqa: B003
+            try:
+                output = os.path.expanduser(os.path.expandvars(expr))
+            finally:
+                os.environ = prev  # noqa: B003
         return output
 
     def expanduser(self, expr: str) -> str:
@@ -115,12 +124,13 @@ class LocalEnv(BaseEnv[LocalPath]):
         :param expr: An expression containing home shortcuts
 
         :returns: The expanded string"""
-        prev = os.environ
-        os.environ = self.getdict()  # type: ignore[assignment] # noqa: B003
-        try:
-            output = os.path.expanduser(expr)
-        finally:
-            os.environ = prev  # noqa: B003
+        with _environ_lock:
+            prev = os.environ
+            os.environ = self.getdict()  # type: ignore[assignment] # noqa: B003
+            try:
+                output = os.path.expanduser(expr)
+            finally:
+                os.environ = prev  # noqa: B003
         return output
 
 

--- a/tests/test_async_local.py
+++ b/tests/test_async_local.py
@@ -1073,3 +1073,27 @@ class TestAsyncCommandReview:
         retcode, stdout, _stderr = await ((printer | upper) & AsyncTEE)
         assert retcode == 0
         assert "HELLO TEE" in stdout
+
+    @pytest.mark.asyncio
+    async def test_tee_on_pipeline_drains_upstream_stderr(self):
+        """AsyncTEE drains a chatty upstream stderr without deadlocking (#806 review).
+
+        The upstream stage writes far more to stderr than a pipe buffer holds; if
+        AsyncTEE only drained the final stage's streams, the upstream would block
+        on its full stderr pipe and ``wait()`` would hang.
+        """
+        from plumbum.commands.async_ import AsyncTEE
+
+        noisy = async_local[sys.executable][
+            "-c",
+            "import sys; sys.stderr.write('e' * 500000); sys.stdout.write('ok\\n')",
+        ]
+        upper = async_local[sys.executable][
+            "-c", "import sys\nfor line in sys.stdin:\n    print(line.strip().upper())"
+        ]
+
+        retcode, stdout, _stderr = await asyncio.wait_for(
+            (noisy | upper) & AsyncTEE, timeout=30
+        )
+        assert retcode == 0
+        assert "OK" in stdout

--- a/tests/test_async_local.py
+++ b/tests/test_async_local.py
@@ -1017,3 +1017,59 @@ class TestAsyncIntegration:
 
         assert "sync" in sync_result
         assert "async" in async_result
+
+
+class TestAsyncCommandReview:
+    """Regression tests for issues found in the pre-2.0 review (#805)."""
+
+    @pytest.mark.asyncio
+    async def test_getitem_preserves_subtype(self):
+        """Binding args keeps the concrete async type and its properties (#4)."""
+        ls = async_local["ls"]
+        bound = ls["-la"]
+        assert isinstance(bound, AsyncLocalCommand)
+        # `.executable` must keep working after binding (unwraps BoundCommand).
+        assert str(bound.executable) == str(ls.executable)
+
+    @pytest.mark.asyncio
+    @skip_on_windows
+    async def test_with_env(self):
+        """with_env is exposed on async commands and takes effect (#3, #5)."""
+        printenv = async_local["printenv"]
+        cmd = printenv.with_env(TEST_VAR="from_with_env")
+        assert isinstance(cmd, AsyncLocalCommand)
+        result = await cmd("TEST_VAR", retcode=None)
+        assert "from_with_env" in result
+
+    @pytest.mark.asyncio
+    @skip_on_windows
+    async def test_with_cwd(self):
+        """with_cwd is exposed on async commands and takes effect (#3, #5)."""
+        pwd = async_local["pwd"]
+        result = await pwd.with_cwd("/tmp")()
+        assert "/tmp" in result
+
+    @pytest.mark.asyncio
+    async def test_with_env_via_popen(self):
+        """with_env reaches the subprocess through the popen path too (#5)."""
+        printer = async_local[sys.executable][
+            "-c", "import os; print(os.environ.get('TEST_VAR', 'unset'))"
+        ]
+        proc = await printer.with_env(TEST_VAR="from_popen").popen()
+        out = (await proc.stdout.read()).decode().strip()
+        await proc.wait()
+        assert out == "from_popen"
+
+    @pytest.mark.asyncio
+    async def test_tee_on_pipeline(self):
+        """AsyncTEE works on a pipeline, not just a single command (#2)."""
+        from plumbum.commands.async_ import AsyncTEE
+
+        printer = async_local[sys.executable]["-c", "print('hello tee')"]
+        upper = async_local[sys.executable][
+            "-c", "import sys\nfor line in sys.stdin:\n    print(line.strip().upper())"
+        ]
+
+        retcode, stdout, _stderr = await ((printer | upper) & AsyncTEE)
+        assert retcode == 0
+        assert "HELLO TEE" in stdout

--- a/tests/test_async_remote.py
+++ b/tests/test_async_remote.py
@@ -173,14 +173,17 @@ class TestAsyncRemoteModifiers:
             assert retcode == 0
 
     @pytest.mark.asyncio
-    async def test_async_tee_remote(self):
-        """Test AsyncTEE with remote command."""
+    async def test_async_tee_remote_not_supported(self):
+        """AsyncTEE (like popen) streams locally, so it rejects remote commands.
+
+        Remote commands are supported through ``.run()``/``__call__`` instead;
+        streaming a remote command locally would silently run it on this machine.
+        """
 
         async with AsyncSshMachine(TEST_HOST) as rem:
             echo = rem["echo"]
-            retcode, stdout, _stderr = await (echo["hello"] & AsyncTEE)
-            assert retcode == 0
-            assert "hello" in stdout
+            with pytest.raises(NotImplementedError):
+                await (echo["hello"] & AsyncTEE)
 
 
 class TestAsyncRemotePipelineSemantics:


### PR DESCRIPTION
:robot:

Fixes #805 — a set of latent bugs and inconsistencies in the new async support, found while reviewing for the 2.0 release.

## What changed

| # | Issue | Fix |
|---|-------|-----|
| 1 | Async `popen()`/`AsyncTEE` ran **remote commands locally** (formulated without the ssh wrapper) | `_popen` now guards `machine is not local` and raises `NotImplementedError` directing users to `.run()` (which correctly delegates to the sync command in a thread) |
| 2 | `AsyncTEE` broken on **pipelines** (fed a formulated pipe string, incl. a literal `\|`, to `create_subprocess_exec`) | Reimplemented `_AsyncTEE` on top of `_popen`, gaining pipeline support + the local-only guard |
| 3 | Documented `with_env()`/`with_cwd()` **didn't exist** (raised `AttributeError`) | Added both methods, delegating to sync and re-wrapping in the same async type |
| 4 | `__getitem__` **dropped the concrete subtype** (`AsyncLocalCommand` → `AsyncCommand`) | Returns `self.__class__(bound)`; `executable`/`remote` unwrap bound layers via a new `_concrete` helper so they keep working after binding |
| 5 | Inconsistent env/cwd unwrapping in `_popen` (nested bound env/cwd ignored on the non-pipeline path) | Non-pipeline path now threads nested bound env/cwd inward, formulating at level 0 like sync `LocalCommand.popen` |
| 6 | `asyncio.get_event_loop()` | → `asyncio.get_running_loop()` |
| 8 | `LocalEnv.expand`/`expanduser` mutate the global `os.environ`; interleaved save/restore across threads could permanently corrupt it (now relevant since async runs sync commands in executor threads) | Wrapped the swap/restore in a module-level `RLock` |

Item **#7** from the issue (the `srcproc`/`_dstproc` naming asymmetry in `AsyncPipelineProcess`) was intentionally left as-is: `srcproc` is public by design to mirror the sync API, and tests rely on it.

## Notes on the remote streaming decision (#1, #2)

True async streaming uses `asyncio.create_subprocess_exec`, which only works for local commands. Rather than building an async ssh transport (or silently running remote commands locally as before), remote `popen`/`AsyncTEE` now fail loudly. Remote commands remain fully supported through `.run()`/`__call__`, which delegate to the sync command in a thread. Async-over-ssh streaming could be a follow-up.

## Tests / validation

- Added `TestAsyncCommandReview` (subtype preservation, `with_env`/`with_cwd` via both call and popen paths, `AsyncTEE` on a pipeline).
- Updated `test_async_tee_remote` to assert the new `NotImplementedError`.
- `prek -a` (ruff + mypy + codespell + …): clean
- `pylint`: 10.00/10
- Full suite: 359 passed, 100 skipped (the only failure, `test_chown`, is a pre-existing environment issue that also fails on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
