### PR TITLE
fix: assorted pre-2.0 correctness issues (stem, ssh tunnel timeout, Set completion)

### DIFF
--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -573,6 +573,9 @@ class Set(Validator[str]):
         choices = {opt if isinstance(opt, str) else f"({opt})" for opt in self.values}
         choices |= self.all_markers
         if partial:
+            if self.case_sensitive:
+                return {opt for opt in choices if opt.startswith(partial)}
+            partial = partial.lower()
             return {opt for opt in choices if opt.lower().startswith(partial)}
         return choices
 

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -291,7 +291,7 @@ class SshMachine(BaseRemoteMachine):
         dport: int | str,
         lhost: str | None = "localhost",
         dhost: str | None = "localhost",
-        connect_timeout: float = 5,  # noqa: ARG002
+        connect_timeout: float = 5,
         reverse: bool = False,
     ) -> SshTunnel:
         r"""Creates an SSH tunnel from the TCP port (``lport``) of the local machine
@@ -360,9 +360,7 @@ class SshMachine(BaseRemoteMachine):
         )
         proc = self.popen((), ssh_opts=ssh_opts, new_session=True)
         return SshTunnel(
-            ShellSession(
-                proc, self.custom_encoding, connect_timeout=self.connect_timeout
-            ),
+            ShellSession(proc, self.custom_encoding, connect_timeout=connect_timeout),
             lport,
             dport,
             reverse,

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -291,7 +291,7 @@ class SshMachine(BaseRemoteMachine):
         dport: int | str,
         lhost: str | None = "localhost",
         dhost: str | None = "localhost",
-        connect_timeout: float = 5,
+        connect_timeout: float | None = 5,
         reverse: bool = False,
     ) -> SshTunnel:
         r"""Creates an SSH tunnel from the TCP port (``lport``) of the local machine

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -291,7 +291,7 @@ class SshMachine(BaseRemoteMachine):
         dport: int | str,
         lhost: str | None = "localhost",
         dhost: str | None = "localhost",
-        connect_timeout: float | None = 5,
+        connect_timeout: float | None = None,
         reverse: bool = False,
     ) -> SshTunnel:
         r"""Creates an SSH tunnel from the TCP port (``lport``) of the local machine
@@ -342,6 +342,9 @@ class SshMachine(BaseRemoteMachine):
                 sock = socket.socket()
                 sock.connect(("localhost", 1234))
                 # sock is now tunneled to the MySQL socket on megazord
+
+        The ``connect_timeout`` is the time to wait for the tunnel's shell prompt;
+        if not given, the machine-level ``connect_timeout`` is used.
         """
         formatted_lhost = "" if lhost is None else f"[{lhost}]:"
         formatted_dhost = "" if dhost is None else f"[{dhost}]:"
@@ -359,6 +362,8 @@ class SshMachine(BaseRemoteMachine):
             ]
         )
         proc = self.popen((), ssh_opts=ssh_opts, new_session=True)
+        if connect_timeout is None:
+            connect_timeout = self.connect_timeout
         return SshTunnel(
             ShellSession(proc, self.custom_encoding, connect_timeout=connect_timeout),
             lport,

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -146,7 +146,7 @@ class LocalPath(Path):
 
     @property
     def stem(self) -> str:
-        return self.name.rsplit(os.path.extsep)[0]
+        return os.path.splitext(self.name)[0]
 
     def with_suffix(self, suffix: str, depth: int | None = 1) -> LocalPath:
         if (

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -390,7 +390,7 @@ class RemotePath(Path):
 
     @property
     def stem(self) -> str:
-        return self.name.rsplit(".")[0]
+        return os.path.splitext(self.name)[0]
 
     @property
     def root(self) -> str:

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -204,6 +204,19 @@ class TestSwitchInfoHelpers:
             assert "debug" in completions
 
 
+class TestSetChoices:
+    def test_case_insensitive_uppercase_partial(self):
+        # case-insensitive sets should complete uppercase partials too
+        s = cli.Set("TCP", "UDP", case_sensitive=False)
+        assert s.choices("TC") == {"TCP"}
+        assert s.choices("tc") == {"TCP"}
+
+    def test_case_sensitive_partial(self):
+        s = cli.Set("TCP", "UDP", case_sensitive=True)
+        assert s.choices("TC") == {"TCP"}
+        assert s.choices("tc") == set()
+
+
 class TestPositionalArgCompletions:
     def test_positional_args_not_implemented_by_default(self):
         inst = CompletionApp("completionapp")

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -164,6 +164,10 @@ class TestLocalPath:
         assert self.longpath.stem == "file"
         p = local.path("/some/directory")
         assert p.stem == "directory"
+        # only the final suffix is removed (like pathlib)
+        assert local.path("/some/archive.tar.gz").stem == "archive.tar"
+        # leading-dot names have no suffix to remove
+        assert local.path("/home/user/.bashrc").stem == ".bashrc"
 
     def test_root_drive(self):
         pathlib = pytest.importorskip("pathlib")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -114,6 +114,9 @@ class TestRemotePath:
         # only the final suffix is removed (like pathlib)
         p = RemotePath(self._connect(), "/some/archive.tar.gz")
         assert p.stem == "archive.tar"
+        # leading-dot names have no suffix to remove
+        p = RemotePath(self._connect(), "/home/user/.bashrc")
+        assert p.stem == ".bashrc"
 
     def test_suffix(self):
         p1 = RemotePath(self._connect(), "/some/long/path/to/file.txt")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -111,6 +111,9 @@ class TestRemotePath:
         assert p.stem == "file"
         p = RemotePath(self._connect(), "/some/long/path/")
         assert p.stem == "path"
+        # only the final suffix is removed (like pathlib)
+        p = RemotePath(self._connect(), "/some/archive.tar.gz")
+        assert p.stem == "archive.tar"
 
     def test_suffix(self):
         p1 = RemotePath(self._connect(), "/some/long/path/to/file.txt")


### PR DESCRIPTION
:robot: Second batch from the pre-2.0 review — the "worth fixing" correctness items (the lower-severity siblings of #808).

## Changes

- **`SshMachine.tunnel(connect_timeout=...)` was ignored.** The parameter was accepted (and marked `# noqa: ARG002`) but the code always used the machine's own `self.connect_timeout`. Now the per-tunnel argument is honored.
- **`stem` stripped *all* suffixes.** `LocalPath`/`RemotePath` `.stem` returned `archive` for `archive.tar.gz`, disagreeing with `pathlib` (which returns `archive.tar`). Both now use `os.path.splitext`, removing only the final suffix; leading-dot names like `.bashrc` keep their full name. Added regression assertions to the local and remote `test_stem` tests.
- **`Set.choices` partial matching was case-broken.** For case-insensitive sets it compared a lowercased option against the raw partial, so `--mode TC` would not complete `TCP`. It now lowercases the partial (and respects `case_sensitive=True`).

## Deliberately left out
A few items flagged in the review were intentionally **not** changed here, as they're behavior changes that warrant their own discussion rather than a quiet pre-release fix:
- `ShellSession.returncode = "Unknown"` — the string is a deliberate sentinel; `None` would trip `wait()`'s `assert returncode is not None`.
- `ConfigBase.get(option, default)` writing the default back — enforced by `test_only_string`, so it appears intended.
- `i18n` locale detection (`locale.getlocale()[0]`) and the `getdict`/`getdelta` `PATH` sync — load-bearing with broad implications.

## Verification
- `prek -a` (ruff + mypy + codespell + …): clean
- `pytest`: `360 passed, 100 skipped` (the one failure, `test_chown`, is pre-existing on `master` and fixed separately in #808)