### PR TITLE
refactor(typing): tighten loose annotations across the public API

### DIFF
--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -26,8 +26,8 @@ async def main() -> None:
     print(f"Concurrent: {len(results)} tasks completed")
 
     # Error handling
-    result = await async_local["false"].run(retcode=None)
-    print(f"Error handling: exit code = {result.returncode}")
+    run_result = await async_local["false"].run(retcode=None)
+    print(f"Error handling: exit code = {run_result.returncode}")
 
     print("\nAll examples completed!")
 

--- a/plumbum/async_cmd.py
+++ b/plumbum/async_cmd.py
@@ -18,8 +18,6 @@ to allow direct imports of commands as async versions.
 
 from __future__ import annotations
 
-from typing import cast
-
 import plumbum
 
 
@@ -46,8 +44,6 @@ def __getattr__(name: str) -> plumbum.commands.async_.AsyncLocalCommand:
             output = await (ls | grep["test"])()
     """
     try:
-        return cast(
-            "plumbum.commands.async_.AsyncLocalCommand", plumbum.async_local[name]
-        )
+        return plumbum.async_local[name]
     except plumbum.commands.CommandNotFound:
         raise AttributeError(name) from None

--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -25,7 +25,6 @@ __all__ = [
     "ask",
     "choose",
     "get_terminal_size",
-    "get_terminal_size",
     "prompt",
     "readline",
 ]

--- a/plumbum/commands/async_.py
+++ b/plumbum/commands/async_.py
@@ -57,7 +57,7 @@ import asyncio
 import contextlib
 import os
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TextIO
 
 from plumbum.commands.base import BoundCommand, BoundEnvCommand, Pipeline
 from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut
@@ -713,7 +713,7 @@ class _AsyncTEE(AsyncExecutionModifier):
         stderr_lines: list[str] = []
 
         async def read_stream(
-            stream: asyncio.StreamReader | None, output_list: list[str], target: Any
+            stream: asyncio.StreamReader | None, output_list: list[str], target: TextIO
         ) -> None:
             """Read from stream line by line, display, and collect output."""
             if stream is None:
@@ -730,7 +730,7 @@ class _AsyncTEE(AsyncExecutionModifier):
                 target.flush()
 
         async def drain_stream(
-            stream: asyncio.StreamReader | None, target: Any
+            stream: asyncio.StreamReader | None, target: TextIO
         ) -> None:
             """Display a stream in fixed-size chunks (no line buffering).
 

--- a/plumbum/machines/env.py
+++ b/plumbum/machines/env.py
@@ -122,7 +122,7 @@ class BaseEnv(typing.Generic[AnyPath]):
         """Returns the keys of the current environment (like dict.keys)"""
         return self._curr.keys()
 
-    def items(self) -> ItemsView[tuple[str, str]]:  # type: ignore[type-arg]
+    def items(self) -> ItemsView[str, str]:
         """Returns the items of the current environment (like dict.items)"""
         return self._curr.items()
 

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -29,6 +29,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Sequence
     from types import TracebackType
 
+    from plumbum.commands.async_ import AsyncLocalCommand
     from plumbum.commands.base import BaseCommand
 
 
@@ -541,7 +542,7 @@ class AsyncLocalMachine:
     .. versionadded:: 1.11
     """
 
-    def __getitem__(self, cmd: str | LocalPath) -> Any:
+    def __getitem__(self, cmd: str | LocalPath) -> AsyncLocalCommand:
         """Get an async command by name or path.
 
         This delegates to local[cmd] to get the sync command, then wraps it.
@@ -577,7 +578,7 @@ class AsyncLocalMachine:
         return local.env
 
     @staticmethod
-    def path(*parts: str) -> Any:
+    def path(*parts: str) -> LocalPath:
         """Create a LocalPath from parts."""
         return local.path(*parts)
 

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -4,7 +4,7 @@ import contextlib
 import re
 import typing
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from plumbum.commands import CommandNotFound, ConcreteCommand, shquote
 from plumbum.lib import ProcInfo
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
     from plumbum._compat.typing import Self
+    from plumbum.commands.async_ import AsyncRemoteCommand
     from plumbum.machines.session import ShellSession
 
 
@@ -540,7 +541,7 @@ class AsyncRemoteMachine:
         """
         self._sync_machine = sync_machine
 
-    def __getitem__(self, cmd: str | RemotePath | LocalPath) -> Any:
+    def __getitem__(self, cmd: str | RemotePath | LocalPath) -> AsyncRemoteCommand:
         """Get an async remote command by name or path.
 
         This delegates to the sync machine for command lookup, then wraps it.
@@ -564,12 +565,12 @@ class AsyncRemoteMachine:
         return cmd in self._sync_machine
 
     @property
-    def cwd(self) -> Any:
+    def cwd(self) -> RemoteWorkdir:
         """Current working directory on remote machine."""
         return self._sync_machine.cwd
 
     @property
-    def env(self) -> Any:
+    def env(self) -> RemoteEnv:
         """Environment variables on remote machine."""
         return self._sync_machine.env
 

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -9,15 +9,16 @@ from typing import TYPE_CHECKING, Any
 from plumbum.commands import BaseCommand, ProcessExecutionError, shquote
 from plumbum.lib import IS_WIN32
 from plumbum.machines.local import local
-from plumbum.machines.remote import BaseRemoteMachine
+from plumbum.machines.remote import BaseRemoteMachine, RemoteEnv
 from plumbum.machines.session import ShellSession
 from plumbum.path.local import LocalPath
-from plumbum.path.remote import RemotePath
+from plumbum.path.remote import RemotePath, RemoteWorkdir
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from plumbum._compat.typing import Self
+    from plumbum.commands.async_ import AsyncRemoteCommand
     from plumbum.machines.base import PopenWithAddons
 
 
@@ -540,7 +541,7 @@ class AsyncSshMachine:
         )
         self._sync_machine = sync_machine
 
-    def __getitem__(self, cmd: str | RemotePath | LocalPath) -> Any:
+    def __getitem__(self, cmd: str | RemotePath | LocalPath) -> AsyncRemoteCommand:
         """Get an async remote command by name or path."""
         from plumbum.commands.async_ import AsyncRemoteCommand
 
@@ -552,12 +553,12 @@ class AsyncSshMachine:
         return cmd in self._sync_machine
 
     @property
-    def cwd(self) -> Any:
+    def cwd(self) -> RemoteWorkdir:
         """Current working directory on remote machine."""
         return self._sync_machine.cwd
 
     @property
-    def env(self) -> Any:
+    def env(self) -> RemoteEnv:
         """Environment variables on remote machine."""
         return self._sync_machine.env
 

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -605,16 +605,21 @@ class Path(str, ABC):
         return self
 
     @property
-    def parents(self) -> tuple[str, ...]:
+    def parents(self) -> tuple[Self, ...]:
         """Pathlib like sequence of ancestors"""
+        # reduce() infers ``str`` here because Path subclasses str, but each
+        # element is really a freshly-formed Self (from ``_form`` / ``/``).
         as_list = (
-            reduce(lambda x, y: self._form(x) / y, self.parts[:i], self.parts[0])
+            typing.cast(
+                "Self",
+                reduce(lambda x, y: self._form(x) / y, self.parts[:i], self.parts[0]),
+            )
             for i in range(len(self.parts) - 1, 0, -1)
         )
         return tuple(as_list)
 
     @property
-    def parent(self) -> str:
+    def parent(self) -> Self:
         """Pathlib like parent of the path."""
         return self.parents[0]
 


### PR DESCRIPTION
:robot: Third batch from the pre-2.0 review — the typing tightenings. All changes are mypy-strict-verified; no runtime behavior changes.

## Changes

- **`Path.parent` / `Path.parents`** were annotated `-> str` / `-> tuple[str, ...]` but return `Path` objects. Now `Self` / `tuple[Self, ...]`. (A `cast` is needed because `reduce` infers `str` — `Path` subclasses `str` — even though each element is a freshly-formed `Self`.)
- **`BaseEnv.items()`** had `ItemsView[tuple[str, str]]` (one type arg, papered over with `# type: ignore[type-arg]`); corrected to `ItemsView[str, str]`.
- **Async machine wrappers** (`AsyncLocalMachine`, `AsyncRemoteMachine`, `AsyncSshMachine`) returned `Any` from `__getitem__`, `cwd`, `env`, and `path`. They now declare concrete types (the wrapping async command, `LocalPath`/`RemoteWorkdir`, `LocalEnv`/`RemoteEnv`). This also made the `cast` in `async_cmd.__getattr__` redundant, so it's removed.
- **`commands/async_`**: `read_stream`/`drain_stream` `target` params typed `TextIO` instead of `Any`.
- **`cli/terminal`**: removed the duplicate `get_terminal_size` entry in `__all__`.
- **`examples/async_example`**: the async-machine typing surfaced a latent issue — `result` was reused for both the `str` from `cmd(...)` and the `AsyncResult` from `cmd.run(...)` (only type-checked before because the command was `Any`). Split into a distinct variable.

## Considered but not changed
- `colorlib.factories.StyleFactory.filter` — widening it to `str | S` to reflect the `Style` branch pessimizes the many call sites (e.g. in `application.py`) that rely on `filter() -> str`, so it was left as-is.
- `commands/async_`'s `AsyncPipelineProcess.__getattr__ -> Any` and the `node` traversal are inherently dynamic; `Any` is defensible there.
- The `# type: ignore[arg-type]` in `paramiko_machine.py` is **not** reported unused by the pinned mypy, so it stays.
- `limit_representation(rep: int)` already accepts `bool` (a subtype of `int`), so no change was needed.

## Verification
- `prek -a` (ruff + mypy + codespell + …): clean
- `pytest`: `360 passed, 100 skipped` (the one failure, `test_chown`, is pre-existing on `master`; fixed separately in #808)