### PR TITLE
refactor: remove dead code and simplify a few spots

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -345,13 +345,11 @@ class Application:
         return wrapper(subapp)
 
     def _get_partial_matches(self, partialname: str) -> list[str]:
-        matches = []
-        for switch_ in self._switches_by_name:
-            if switch_.startswith(partialname):
-                matches += [
-                    switch_,
-                ]
-        return matches
+        return [
+            switch_
+            for switch_ in self._switches_by_name
+            if switch_.startswith(partialname)
+        ]
 
     def _parse_args(
         self, argv: list[str]
@@ -534,8 +532,8 @@ class Application:
         if not argv:
             return self._get_all_completions()
 
-        partial = argv[-1] if argv else ""
-        previous = argv[:-1] if len(argv) > 1 else []
+        partial = argv[-1]
+        previous = argv[:-1]
 
         if previous and previous[-1].startswith("-"):
             last_switch = previous[-1]

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -664,8 +664,6 @@ class ConcreteCommand(BaseCommand):
                 )
             else:
                 argv.append(shquote(a) if level >= self.QUOTE_LEVEL else str(a))
-        # if self.custom_encoding:
-        #    argv = [a.encode(self.custom_encoding) for a in argv if isinstance(a, str)]
         return argv
 
     @property

--- a/plumbum/machines/_windows.py
+++ b/plumbum/machines/_windows.py
@@ -14,12 +14,14 @@ def get_pe_subsystem(filename: str) -> int | None:
         if f.read(2) != b"MZ":
             return None
         f.seek(LFANEW_OFFSET)
-        lfanew = struct.unpack("L", f.read(4))[0]
+        # Explicit little-endian widths: the PE fields are fixed 32-/16-bit
+        # values, whereas native "L"/"H" sizes are platform-dependent.
+        lfanew = struct.unpack("<I", f.read(4))[0]
         f.seek(lfanew)
         if f.read(4) != b"PE\x00\x00":
             return None
         f.seek(FILE_HEADER_SIZE + SUBSYSTEM_OFFSET, 1)
-        return struct.unpack("H", f.read(2))[0]  # type: ignore[no-any-return]
+        return int(struct.unpack("<H", f.read(2))[0])
 
 
 # print(get_pe_subsystem("c:\\windows\\notepad.exe")) == 2

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -267,13 +267,6 @@ class LocalMachine(BaseMachine):
             parts2.append(self.env.expanduser(str(p)))
         return LocalPath(os.path.join(*parts2))
 
-    def __contains__(self, cmd: str) -> bool:
-        try:
-            self[cmd]
-        except CommandNotFound:
-            return False
-        return True
-
     def __getitem__(self, cmd: str | LocalPath) -> LocalCommand:
         """Returns a `Command` object representing the given program. ``cmd`` can be a string or
         a :class:`LocalPath <plumbum.path.local.LocalPath>`; if it is a path, a command

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -134,8 +134,8 @@ class ParamikoPopen(PopenAddons):
                 coll.append(line)
         self.wait()
         assert self.custom_encoding is not None
-        stdout_bytes = "".join(s for s in stdout).encode(self.custom_encoding)
-        stderr_bytes = "".join(s for s in stderr).encode(self.custom_encoding)
+        stdout_bytes = "".join(stdout).encode(self.custom_encoding)
+        stderr_bytes = "".join(stderr).encode(self.custom_encoding)
         return stdout_bytes, stderr_bytes
 
     def iter_lines(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Final batch from the pre-2.0 review — dead-code removal and small simplifications. No behavior changes.

## Changes

- **`LocalMachine.__contains__`** was an exact duplicate of `BaseMachine.__contains__` — removed the override (the base one even carries a docstring).
- **`ConcreteCommand.formulate`** had a long-commented-out `custom_encoding` block — removed.
- **`_windows.get_pe_subsystem`** now reads the PE header with explicit little-endian widths (`<I` / `<H`) instead of native `L` / `H`, whose sizes are platform-dependent (`struct.calcsize("L")` is 8 on LP64). The code only runs on Windows today (where it happens to work), but the explicit widths are unambiguously correct; an `int()` cast lets the `type: ignore` go.
- **`paramiko_machine`**: `"".join(x)` instead of the redundant `"".join(s for s in x)`.
- **`cli/application`**: `_get_partial_matches` is now a comprehension; dropped two dead guards in `get_completions` (`argv` is already known non-empty after the early return, and `argv[:-1]` already yields `[]` for a single element).

## Deliberately left out
- `cli/termsize` → `shutil.get_terminal_size` (different env-var / default semantics — a behavior change, not a pure cleanup).
- Adding `strict=True` to the `xfail_on_windows` / `xfail_on_pypy` markers (a behavior change I can't validate on this platform).

## Verification
- `prek -a` (ruff + mypy + codespell + …): clean
- `pytest`: `360 passed, 100 skipped` (the one failure, `test_chown`, is pre-existing on `master`; fixed separately in #808)