### PR TITLE
fix: make `**` glob recursively like pathlib (#628)

### DIFF
--- a/docs/paths.rst
+++ b/docs/paths.rst
@@ -83,6 +83,11 @@ subdirectories recursively::
     >>> local.cwd // "**/*.rst"
     [<LocalPath d:\workspace\plumbum\docs\cli.rst>, ...]
 
+.. versionchanged:: 2.0
+
+    The ``**`` pattern now recurses into subdirectories, matching :mod:`pathlib`.
+    Previously it behaved like a single ``*``.
+
 
 .. versionadded:: 1.6
 

--- a/docs/paths.rst
+++ b/docs/paths.rst
@@ -77,6 +77,12 @@ Globing can be easily performed using ``//`` (floor division)::
     >>> local.cwd / "docs" // "*.rst"
     [<LocalPath d:\workspace\plumbum\docs\cli.rst>, ...]
 
+As in :mod:`pathlib`, the ``**`` pattern matches this directory and all
+subdirectories recursively::
+
+    >>> local.cwd // "**/*.rst"
+    [<LocalPath d:\workspace\plumbum\docs\cli.rst>, ...]
+
 
 .. versionadded:: 1.6
 

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -164,6 +164,38 @@ class ClosedRemote:
         raise ClosedRemoteMachine(f"{self._obj!r} has been closed")
 
 
+def _glob_to_regex(pattern: str) -> str:
+    """Translate a glob pattern into an anchored regex with pathlib-like ``**``.
+
+    ``**`` (optionally followed by ``/``) matches any number of directories,
+    while ``*`` and ``?`` match within a single path segment (i.e. they do not
+    cross ``/``). Used to match recursive globs in Python instead of relying on
+    shell-specific recursion support.
+    """
+    out = []
+    i, n = 0, len(pattern)
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if pattern[i : i + 2] == "**":
+                i += 2
+                if pattern[i : i + 1] == "/":
+                    i += 1
+                    out.append("(?:.*/)?")  # ``**/`` -- zero or more directories
+                else:
+                    out.append(".*")
+                continue
+            out.append("[^/]*")
+        elif c == "?":
+            out.append("[^/]")
+        elif c == "/":
+            out.append("/")
+        else:
+            out.append(re.escape(c))
+        i += 1
+    return "(?s:" + "".join(out) + r")\Z"
+
+
 class BaseRemoteMachine(BaseMachine):
     """Represents a *remote machine*; serves as an entry point to everything related to that
     remote machine, such as working directory and environment manipulation, command creation,
@@ -395,14 +427,29 @@ class BaseRemoteMachine(BaseMachine):
         return files
 
     def _path_glob(self, fn: str, pattern: str) -> list[str]:
+        if "**" in pattern:
+            # Recursive glob (``**``). The shell loop below cannot do this
+            # portably: ``/bin/sh`` is often dash, and ``**`` only recurses in
+            # bash with ``globstar`` enabled. Instead, enumerate the tree with
+            # POSIX ``find`` and match in Python, so the result is identical
+            # regardless of the remote shell -- and free of the shell-glob
+            # quirks that bite paths containing glob metacharacters.
+            regex = re.compile(_glob_to_regex(pattern))
+            rc, out, _ = self._session.run(f"find {shquote(fn)}", retcode=None)
+            if rc != 0:
+                return []
+            prefix = fn.rstrip("/") + "/"
+            return [
+                line
+                for line in out.splitlines()
+                if line.startswith(prefix) and regex.match(line[len(prefix) :])
+            ]
         # shquote does not work here due to the way bash loops use space as a separator
         pattern = pattern.replace(" ", r"\ ")
         fn = fn.replace(" ", r"\ ")
-        # ``shopt -s globstar`` makes ``**`` recurse like pathlib/glob(recursive=True);
-        # it is silently ignored by shells that do not support it.
-        matches = self._session.run(
-            rf"shopt -s globstar 2>/dev/null; for fn in {fn}/{pattern}; do echo $fn; done"
-        )[1].splitlines()
+        matches = self._session.run(rf"for fn in {fn}/{pattern}; do echo $fn; done")[
+            1
+        ].splitlines()
         if len(matches) == 1 and not self._path_stat(matches[0]):
             return []  # pattern expansion failed
         return matches

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -164,35 +164,91 @@ class ClosedRemote:
         raise ClosedRemoteMachine(f"{self._obj!r} has been closed")
 
 
+def _is_recursive_glob(pattern: str) -> bool:
+    """Whether ``pattern`` uses ``**`` as a recursive wildcard.
+
+    As in :mod:`glob`/:mod:`pathlib`, ``**`` is only special when it is a whole
+    path segment; ``a**b`` is just two ``*`` wildcards within one segment.
+    """
+    return "**" in pattern.split("/")
+
+
+def _segment_to_regex(segment: str) -> str:
+    """Translate a single (slash-free) glob segment into a regex fragment.
+
+    Supports ``*``, ``?`` and ``[...]`` character classes, all confined to a
+    single path component (they never cross ``/``). A leading wildcard does not
+    match a leading dot, mirroring :func:`glob.glob` (which skips dotfiles
+    unless the pattern segment starts with a literal ``.``).
+    """
+    out = []
+    # A wildcard at the start of a segment must not match a leading dot.
+    if segment[:1] in ("*", "?", "["):
+        out.append(r"(?!\.)")
+    i, n = 0, len(segment)
+    while i < n:
+        c = segment[i]
+        if c == "*":
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c == "[":
+            j = i + 1
+            if j < n and segment[j] == "!":
+                j += 1
+            if j < n and segment[j] == "]":
+                j += 1
+            while j < n and segment[j] != "]":
+                j += 1
+            if j >= n:  # no closing bracket -- treat "[" as a literal
+                out.append(re.escape("["))
+                i += 1
+            else:
+                stuff = segment[i + 1 : j].replace("\\", r"\\")
+                if stuff[0] == "!":
+                    stuff = "^" + stuff[1:]
+                elif stuff[0] in ("^", "["):
+                    stuff = "\\" + stuff
+                out.append(f"[{stuff}]")
+                i = j + 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return "".join(out)
+
+
 def _glob_to_regex(pattern: str) -> str:
     """Translate a glob pattern into an anchored regex with pathlib-like ``**``.
 
-    ``**`` (optionally followed by ``/``) matches any number of directories,
-    while ``*`` and ``?`` match within a single path segment (i.e. they do not
-    cross ``/``). Used to match recursive globs in Python instead of relying on
+    ``**`` as a whole path segment matches any number of (non-hidden)
+    directories; ``*``, ``?`` and ``[...]`` match within a single path segment.
+    Dotfiles are not matched unless the relevant pattern segment starts with a
+    literal ``.`` -- matching :func:`glob.glob`, which is the local backend.
+    Used to match recursive globs in Python instead of relying on
     shell-specific recursion support.
     """
+    segments = pattern.split("/")
     out = []
-    i, n = 0, len(pattern)
-    while i < n:
-        c = pattern[i]
-        if c == "*":
-            if pattern[i : i + 2] == "**":
-                i += 2
-                if pattern[i : i + 1] == "/":
-                    i += 1
-                    out.append("(?:.*/)?")  # ``**/`` -- zero or more directories
-                else:
-                    out.append(".*")
-                continue
-            out.append("[^/]*")
-        elif c == "?":
-            out.append("[^/]")
-        elif c == "/":
+    need_sep = False  # whether a "/" must precede the next fragment
+    for i, segment in enumerate(segments):
+        if segment == "**":
+            if need_sep:
+                out.append("/")
+            if i == len(segments) - 1:
+                # trailing ``**``: one or more non-hidden path components
+                out.append(r"(?!\.)[^/]+(?:/(?!\.)[^/]+)*")
+                need_sep = False
+            else:
+                # ``**/``: zero or more non-hidden directories (slash included)
+                out.append(r"(?:(?!\.)[^/]+/)*")
+                need_sep = False
+            continue
+        if need_sep:
             out.append("/")
-        else:
-            out.append(re.escape(c))
-        i += 1
+        out.append(_segment_to_regex(segment))
+        need_sep = True
     return "(?s:" + "".join(out) + r")\Z"
 
 
@@ -427,7 +483,7 @@ class BaseRemoteMachine(BaseMachine):
         return files
 
     def _path_glob(self, fn: str, pattern: str) -> list[str]:
-        if "**" in pattern:
+        if _is_recursive_glob(pattern):
             # Recursive glob (``**``). The shell loop below cannot do this
             # portably: ``/bin/sh`` is often dash, and ``**`` only recurses in
             # bash with ``globstar`` enabled. Instead, enumerate the tree with
@@ -439,11 +495,11 @@ class BaseRemoteMachine(BaseMachine):
             if rc != 0:
                 return []
             prefix = fn.rstrip("/") + "/"
-            return [
+            return sorted(
                 line
                 for line in out.splitlines()
                 if line.startswith(prefix) and regex.match(line[len(prefix) :])
-            ]
+            )
         # shquote does not work here due to the way bash loops use space as a separator
         pattern = pattern.replace(" ", r"\ ")
         fn = fn.replace(" ", r"\ ")

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -398,9 +398,11 @@ class BaseRemoteMachine(BaseMachine):
         # shquote does not work here due to the way bash loops use space as a separator
         pattern = pattern.replace(" ", r"\ ")
         fn = fn.replace(" ", r"\ ")
-        matches = self._session.run(rf"for fn in {fn}/{pattern}; do echo $fn; done")[
-            1
-        ].splitlines()
+        # ``shopt -s globstar`` makes ``**`` recurse like pathlib/glob(recursive=True);
+        # it is silently ignored by shells that do not support it.
+        matches = self._session.run(
+            rf"shopt -s globstar 2>/dev/null; for fn in {fn}/{pattern}; do echo $fn; done"
+        )[1].splitlines()
         if len(matches) == 1 and not self._path_stat(matches[0]):
             return []  # pattern expansion failed
         return matches

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -491,9 +491,11 @@ class BaseRemoteMachine(BaseMachine):
             # regardless of the remote shell -- and free of the shell-glob
             # quirks that bite paths containing glob metacharacters.
             regex = re.compile(_glob_to_regex(pattern))
-            rc, out, _ = self._session.run(f"find {shquote(fn)}", retcode=None)
-            if rc != 0:
-                return []
+            # ``find`` exits non-zero on partial errors (e.g. an unreadable
+            # subdirectory) while still printing the matches it did find, so
+            # match whatever was printed rather than discarding it -- this
+            # mirrors ``glob.glob``, which does not error on unreadable subdirs.
+            _, out, _ = self._session.run(f"find {shquote(fn)}", retcode=None)
             prefix = fn.rstrip("/") + "/"
             return sorted(
                 line

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -164,7 +164,9 @@ class LocalPath(Path):
             pattern,
             lambda pat: [
                 LocalPath(m)
-                for m in glob.glob(os.path.join(glob.escape(str(self)), pat))
+                for m in glob.glob(
+                    os.path.join(glob.escape(str(self)), pat), recursive=True
+                )
             ],
         )
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1196,6 +1196,18 @@ def test_local_glob_recursive(tmpdir):
         ("src/**/*.py", "other/a.py", False),
         ("a?c/*.txt", "abc/x.txt", True),
         ("a?c/*.txt", "ac/x.txt", False),  # ``?`` requires exactly one char
+        # dotfiles: a leading wildcard does not match a leading dot, but an
+        # explicit ``.`` does -- matching glob.glob (the local backend)
+        ("**/*.zip", ".secret.zip", False),
+        ("**/*.zip", ".hidden/h.zip", False),  # ``**`` skips hidden dirs
+        ("**/*.zip", "sub/.b.zip", False),
+        (".*", ".secret", True),
+        ("**/.*", "sub/.b", True),
+        # character classes
+        ("**/[ts]*.zip", "top.zip", True),
+        ("**/[ts]*.zip", "sub/a.zip", False),
+        ("**/[!t]*.zip", "top.zip", False),
+        ("**/[!t]*.zip", "sub/a.zip", True),
     ],
 )
 def test_glob_to_regex(pattern, path, expected):
@@ -1204,3 +1216,20 @@ def test_glob_to_regex(pattern, path, expected):
     from plumbum.machines.remote import _glob_to_regex
 
     assert bool(re.match(_glob_to_regex(pattern), path)) is expected
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("**/*.zip", True),
+        ("a/**/b", True),
+        ("**", True),
+        ("*.zip", False),
+        ("a**b", False),  # ``**`` is only special as a whole path segment
+        ("a**b/**/*", True),
+    ],
+)
+def test_is_recursive_glob(pattern, expected):
+    from plumbum.machines.remote import _is_recursive_glob
+
+    assert _is_recursive_glob(pattern) is expected

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pickle
+import re
 import signal
 import sys
 import time
@@ -1179,3 +1180,27 @@ def test_local_glob_recursive(tmpdir):
 
     # a plain ``*`` is still non-recursive
     assert {p.name for p in base // "*.zip"} == {"top.zip"}
+
+
+@pytest.mark.parametrize(
+    ("pattern", "path", "expected"),
+    [
+        ("**/*.zip", "top.zip", True),
+        ("**/*.zip", "foo/bar/sample.zip", True),
+        ("**/*.zip", "foo/bar", False),
+        ("*.zip", "top.zip", True),
+        ("*.zip", "foo/sample.zip", False),  # ``*`` does not cross ``/``
+        ("**", "a/b/c", True),
+        ("src/**/*.py", "src/a.py", True),  # ``**/`` matches zero directories
+        ("src/**/*.py", "src/a/b.py", True),
+        ("src/**/*.py", "other/a.py", False),
+        ("a?c/*.txt", "abc/x.txt", True),
+        ("a?c/*.txt", "ac/x.txt", False),  # ``?`` requires exactly one char
+    ],
+)
+def test_glob_to_regex(pattern, path, expected):
+    # Pure-function coverage for the matcher used by remote recursive globbing,
+    # which does not require an SSH connection (see test_remote for integration).
+    from plumbum.machines.remote import _glob_to_regex
+
+    assert bool(re.match(_glob_to_regex(pattern), path)) is expected

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1164,3 +1164,18 @@ def test_local_glob_path(tmpdir):
 
     pp = LocalPath(str(p))
     assert len(pp // "*.txt") == 2
+
+
+def test_local_glob_recursive(tmpdir):
+    base = LocalPath(str(tmpdir))
+    (base / "top.zip").touch()
+    nested = base / "foo" / "bar"
+    nested.mkdir()
+    (nested / "sample.zip").touch()
+
+    # ``**`` should recurse like pathlib, not behave like a single ``*``
+    found = {p.name for p in base // "**/*.zip"}
+    assert found == {"top.zip", "sample.zip"}
+
+    # a plain ``*`` is still non-recursive
+    assert {p.name for p in base // "*.zip"} == {"top.zip"}

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -347,6 +347,20 @@ s.close()
             filenames = [f.name for f in rem.cwd // ("*with space.txt")]
             assert "file with space.txt" in filenames
 
+    def test_glob_recursive(self):
+        with self._connect() as rem, rem.tempdir() as tmp:
+            (tmp / "top.zip").touch()
+            nested = tmp / "foo" / "bar"
+            nested.mkdir()
+            (nested / "sample.zip").touch()
+
+            # ``**`` should recurse like pathlib, not behave like a single ``*``
+            found = {p.name for p in tmp // "**/*.zip"}
+            assert found == {"top.zip", "sample.zip"}
+
+            # a plain ``*`` is still non-recursive
+            assert {p.name for p in tmp // "*.zip"} == {"top.zip"}
+
     def test_cmd(self):
         with self._connect() as rem:
             rem.cmd.ls("/tmp")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #628.

## What

The `//` glob operator treated `**` like a single `*`, so recursive patterns never descended into subdirectories:

```python
>>> local.cwd // "**/*.zip"
[]   # before: empty even when foo/bar/sample.zip exists
```

After this change `**` behaves like `pathlib` ("this directory and all subdirectories, recursively"):

```python
>>> local.cwd // "**/*.zip"
[<LocalPath /tmp/pbtest/foo/bar/sample.zip>]
```

## How

- **Local** (`plumbum/path/local.py`): pass `recursive=True` to `glob.glob`. The base path is still `glob.escape`d, so paths that look like glob patterns keep working.
- **Remote** (`plumbum/machines/remote.py`): the remote glob session runs over `/bin/sh` — dash on Linux, bash 3.2 on macOS — and **neither supports `globstar`**, so a shell-based `**` cannot recurse portably. Instead, when a pattern contains `**`, enumerate the tree with POSIX `find` and match the results in Python via a new `_glob_to_regex` helper implementing pathlib-like `**` semantics (`**` crosses directories; `*`/`?` stay within a path segment). This is shell-independent and also sidesteps the shell-glob quirks that bite paths containing glob metacharacters. Non-recursive patterns keep the existing fast shell-loop path.
- Added a `.. versionchanged:: 2.0` note in `docs/paths.rst`.

## Tests

- `test_local_glob_recursive` — local `**` recursion (and that plain `*` stays shallow).
- `test_glob_to_regex` (in `test_local.py`, **no SSH required**) — parametrized coverage of the `**`/`*`/`?` matcher, runs on every CI platform.
- `test_glob_recursive` (in `test_remote.py`) — SSH integration test for recursive remote globbing.

## Notes for reviewers

- This is a targeted fix rather than a full `pathlib.Path.glob` rewrite — that would change behavior across Python versions (e.g. 3.13 changed how `**` matches) and risk regressions in tuple-pattern and case-sensitivity handling.
- `include_hidden` (raised in the issue thread) is Python 3.11+ and isn't needed for `**` recursion; `pathlib` also does not match hidden files by default, so behavior stays aligned.
- Verified locally against the issue's reproduction, the new unit tests, and the full local suite. The remote `find`-based logic was verified end-to-end against a real `find`; the SSH integration test runs in CI (which configures passwordless SSH to localhost).

Assisted-by: Claude:claude-opus-4.8