### PR TITLE
chore: make module import lazy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           os: ubuntu-latest
         - python-version: '3.15'
           os: ubuntu-latest
+        - python-version: '3.15'
+          os: macos-latest
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,10 @@ repos:
   - id: rst-backticks
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
+
+- repo: https://github.com/henryiii/flake8-lazy
+  rev: v0.8.1
+  hooks:
+    - id: flake8-lazy
+      args: [--apply=set]
+      files: "^plumbum"

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"argparse"}
+
 import argparse
 
 import nox

--- a/plumbum/__init__.py
+++ b/plumbum/__init__.py
@@ -37,6 +37,8 @@ See https://plumbum.readthedocs.io for full details
 
 from __future__ import annotations
 
+__lazy_modules__ = {"plumbum.colorlib", "plumbum.commands", "plumbum.machines.local"}
+
 import typing
 
 # Avoids a circular import error later
@@ -54,7 +56,12 @@ from plumbum.commands import (
     ProcessLineTimedOut,
     ProcessTimedOut,
 )
-from plumbum.machines import BaseRemoteMachine, PuttyMachine, SshMachine, local
+from plumbum.machines import (
+    BaseRemoteMachine,
+    PuttyMachine,
+    SshMachine,
+    local,
+)
 from plumbum.machines.local import async_local
 from plumbum.path import LocalPath, Path, RemotePath
 from plumbum.version import version

--- a/plumbum/_testtools.py
+++ b/plumbum/_testtools.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"tempfile"}
+
 import os
 import platform
 import sys

--- a/plumbum/cli/__init__.py
+++ b/plumbum/cli/__init__.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    f"{__spec__.parent}.application",
+    f"{__spec__.parent}.config",
+    f"{__spec__.parent}.switches",
+}
+
 from .application import Application
 from .config import Config, ConfigINI
 from .switches import (

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "contextlib",
+    f"{__spec__.parent}.terminal",
+    "functools",
+    "inspect",
+    "plumbum.colorlib",
+    "plumbum.colorlib.styles",
+    "plumbum.lib",
+    "textwrap",
+}
+
 import contextlib
 import functools
 import inspect

--- a/plumbum/cli/config.py
+++ b/plumbum/cli/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"configparser", "contextlib"}
+
 import contextlib
 from abc import ABC, abstractmethod
 from configparser import ConfigParser, NoOptionError, NoSectionError

--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"gettext", "importlib", "importlib.resources"}
+
 import locale
 
 # High performance method for English (no translation needed)

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {f"{__spec__.parent}.termsize"}
+
 import sys
 import typing
 

--- a/plumbum/cli/progress.py
+++ b/plumbum/cli/progress.py
@@ -5,6 +5,8 @@ Progress bar
 
 from __future__ import annotations
 
+__lazy_modules__ = {"plumbum.cli.termsize", "warnings"}
+
 import abc
 import sys
 import time

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "inspect", "plumbum.lib"}
+
 import builtins
 import contextlib
 import dataclasses

--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -5,6 +5,12 @@ Terminal-related utilities
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    f"{__spec__.parent}.progress",
+    f"{__spec__.parent}.termsize",
+}
+
 import contextlib
 import os
 import sys

--- a/plumbum/cli/termsize.py
+++ b/plumbum/cli/termsize.py
@@ -5,6 +5,8 @@ Terminal size utility
 
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "platform", "struct", "warnings"}
+
 import contextlib
 import os
 import platform

--- a/plumbum/colorlib/__init__.py
+++ b/plumbum/colorlib/__init__.py
@@ -6,6 +6,8 @@ underlined text. It also provides ``reset`` to recover the normal font.
 
 from __future__ import annotations
 
+__lazy_modules__ = {"typing"}
+
 import sys
 from typing import Any
 

--- a/plumbum/colorlib/_ipython_ext.py
+++ b/plumbum/colorlib/_ipython_ext.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"io", "typing"}
+
 import sys
 from io import StringIO
 from typing import Any

--- a/plumbum/colorlib/factories.py
+++ b/plumbum/colorlib/factories.py
@@ -4,6 +4,8 @@ Color-related factories. They produce Styles.
 
 from __future__ import annotations
 
+__lazy_modules__ = {f"{__spec__.parent}.names", "functools", "operator"}
+
 import functools
 import operator
 import sys

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -9,6 +9,8 @@ With the ``Style`` class, any color can be directly called or given to a with st
 
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "copy", "platform", "re"}
+
 import contextlib
 import dataclasses
 import os

--- a/plumbum/colors.py
+++ b/plumbum/colors.py
@@ -6,6 +6,8 @@ all the standard syntax for colors.
 
 from __future__ import annotations
 
+__lazy_modules__ = {"atexit"}
+
 import atexit
 import sys
 

--- a/plumbum/commands/__init__.py
+++ b/plumbum/commands/__init__.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "plumbum.commands.base",
+    "plumbum.commands.modifiers",
+    "plumbum.commands.processes",
+}
+
 from plumbum.commands.base import (
     ERROUT,
     BaseCommand,

--- a/plumbum/commands/_daemon_launcher.py
+++ b/plumbum/commands/_daemon_launcher.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"pickle", "traceback"}
+
 import os
 import pickle
 import sys

--- a/plumbum/commands/async_.py
+++ b/plumbum/commands/async_.py
@@ -53,6 +53,14 @@ Example Usage
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "asyncio",
+    "contextlib",
+    "plumbum.commands.processes",
+    "plumbum.machines.local",
+    "typing_extensions",
+}
+
 import asyncio
 import contextlib
 import os

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "functools",
+    "plumbum.commands.modifiers",
+    "plumbum.commands.processes",
+    "shlex",
+    "tempfile",
+    "types",
+}
+
 import contextlib
 import functools
 import shlex

--- a/plumbum/commands/daemons.py
+++ b/plumbum/commands/daemons.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "pickle", "plumbum.commands.processes", "subprocess"}
+
 import contextlib
 import errno
 import os

--- a/plumbum/commands/modifiers.py
+++ b/plumbum/commands/modifiers.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "logging",
+    "plumbum.commands.base",
+    "plumbum.commands.processes",
+    "plumbum.lib",
+    "select",
+    "subprocess",
+}
+
 import sys
 import typing
 from logging import DEBUG, INFO

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"atexit", "contextlib", "heapq"}
+
 import atexit
 import contextlib
 import enum

--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -4,6 +4,8 @@ Atomic file operations
 
 from __future__ import annotations
 
+__lazy_modules__ = {"atexit", "msvcrt", "plumbum.machines.local", "threading"}
+
 import atexit
 import contextlib
 import os

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"inspect", "io"}
+
 import inspect
 import os
 import sys

--- a/plumbum/machines/__init__.py
+++ b/plumbum/machines/__init__.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "plumbum.machines.local",
+    "plumbum.machines.remote",
+    "plumbum.machines.ssh_machine",
+}
+
 from plumbum.machines.local import LocalCommand, LocalMachine, local
 from plumbum.machines.remote import BaseRemoteMachine, RemoteCommand
 from plumbum.machines.ssh_machine import PuttyMachine, SshMachine

--- a/plumbum/machines/_windows.py
+++ b/plumbum/machines/_windows.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"struct"}
+
 import struct
 
 LFANEW_OFFSET = 30 * 2

--- a/plumbum/machines/base.py
+++ b/plumbum/machines/base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"plumbum.commands", "plumbum.commands.processes"}
+
 import abc
 import os
 import typing

--- a/plumbum/machines/env.py
+++ b/plumbum/machines/env.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "copy"}
+
 import copy
 import os
 import typing

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "platform",
+    "plumbum.commands.daemons",
+    "plumbum.commands.processes",
+    "plumbum.machines._windows",
+    "plumbum.machines.session",
+    "plumbum.path",
+    "plumbum.path.remote",
+    "re",
+    "subprocess",
+    "tempfile",
+}
+
 import contextlib
 import logging
 import os

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "plumbum.commands",
+    "plumbum.commands.processes",
+    "plumbum.machines.session",
+    "plumbum.path",
+    "plumbum.path.local",
+    "plumbum.path.remote",
+}
+
 import contextlib
 import errno
 import logging

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "plumbum.lib",
+    "plumbum.path",
+    "plumbum.path.local",
+    "re",
+    "tempfile",
+}
+
 import contextlib
 import re
 import typing

--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"contextlib", "plumbum.commands", "random", "threading"}
+
 import contextlib
 import logging
 import random

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "plumbum.commands",
+    "plumbum.lib",
+    "plumbum.machines.local",
+    "plumbum.machines.session",
+    "plumbum.path",
+    "plumbum.path.local",
+    "plumbum.path.remote",
+    "re",
+    "socket",
+    "warnings",
+}
+
 import re
 import socket
 import warnings

--- a/plumbum/path/__init__.py
+++ b/plumbum/path/__init__.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "plumbum.path.base",
+    "plumbum.path.local",
+    "plumbum.path.remote",
+    "plumbum.path.utils",
+}
+
 from plumbum.path.base import FSUser, Path, RelativePath
 from plumbum.path.local import LocalPath, LocalWorkdir
 from plumbum.path.remote import RemotePath, RemoteWorkdir

--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"fnmatch", "functools", "itertools", "operator", "warnings"}
+
 import fnmatch
 import itertools
 import operator

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "glob",
+    "grp",
+    "plumbum.lib",
+    "plumbum.path.remote",
+    "pwd",
+    "shutil",
+    "urllib",
+    "urllib.parse",
+    "urllib.request",
+}
+
 import errno
 import glob
 import logging

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "copy",
+    "plumbum.commands",
+    "urllib",
+    "urllib.request",
+}
+
 import copy
 import errno
 import os

--- a/plumbum/path/utils.py
+++ b/plumbum/path/utils.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "plumbum.machines.local",
+    "plumbum.path.base",
+    "plumbum.path.local",
+    "plumbum.path.remote",
+}
+
 import os
 
 from plumbum.machines.local import local

--- a/plumbum/typed_env.py
+++ b/plumbum/typed_env.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"inspect"}
+
 import abc
 import inspect
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,3 +241,7 @@ exclude_also = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
 ]
+
+# Fixed in CPython 3.15.0b2
+[tool.flake8-lazy.standalone]
+lazy-exclude-modules = ["plumbum.machines"]


### PR DESCRIPTION
Faster imports on Python 3.15. One workaround for a beta 1 bug, fixed in beta 2.
