### PR TITLE
fix: make SwitchInfo frozen dataclass to fix unhashable type error with excludes/requires

### DIFF
--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -67,7 +67,7 @@ T = TypeVar("T", default=str)
 # ===================================================================================================
 # The switch decorator
 # ===================================================================================================
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class SwitchInfo:
     # Python 3.10+ can use slots=True
     __slots__ = (

--- a/tests/test_3_cli.py
+++ b/tests/test_3_cli.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from plumbum import cli
+from plumbum.cli.application import SwitchCombinationError
 
 
 class Main3Validator(cli.Application):
@@ -25,3 +28,32 @@ class TestProg4:
         _, rc = Main4Validator.run(["prog", "1", "2", "3", "4", "5"], exit=False)
         assert rc == 0
         assert "1 2 (3, 4, 5)" in capsys.readouterr()[0]
+
+
+class SwitchCombinationApp(cli.Application):
+    flag_a = cli.Flag("--flag-a")
+    flag_b = cli.Flag("--flag-b", excludes=["--flag-a"])
+    flag_c = cli.Flag("--flag-c", requires=["--flag-a"])
+
+    def main(self):
+        pass
+
+
+class TestSwitchCombination:
+    def test_excludes_no_crash(self):
+        # Regression: defining excludes= crashed with "unhashable type: SwitchInfo"
+        # before SwitchInfo was made a frozen dataclass
+        _, rc = SwitchCombinationApp.run(["prog", "--flag-b"], exit=False)
+        assert rc == 0
+
+    def test_excludes_raises_on_conflict(self):
+        with pytest.raises(SwitchCombinationError):
+            SwitchCombinationApp.run(["prog", "--flag-a", "--flag-b"], exit=False)
+
+    def test_requires_raises_when_missing(self):
+        with pytest.raises(SwitchCombinationError):
+            SwitchCombinationApp.run(["prog", "--flag-c"], exit=False)
+
+    def test_requires_ok_when_present(self):
+        _, rc = SwitchCombinationApp.run(["prog", "--flag-a", "--flag-c"], exit=False)
+        assert rc == 0


### PR DESCRIPTION
## Summary

- `SwitchInfo` was converted to a plain `@dataclasses.dataclass` in `975d8e6`, which sets `__hash__ = None` (because `__eq__` is auto-generated), making instances unhashable
- `application.py` builds a `set` of `SwitchInfo` objects when validating `excludes=`/`requires=` switch combinations, causing `TypeError: unhashable type: 'SwitchInfo'`
- Fix: use `@dataclasses.dataclass(frozen=True)` which generates a correct value-based `__hash__` and enforces the natural immutability invariant of switch metadata

Closes #816

## Test plan

- [ ] `test_excludes_no_crash` — regression test: defining `excludes=` no longer crashes with `unhashable type`
- [ ] `test_excludes_raises_on_conflict` — using two mutually exclusive flags raises `SwitchCombinationError`
- [ ] `test_requires_raises_when_missing` — using a flag without its required companion raises `SwitchCombinationError`
- [ ] `test_requires_ok_when_present` — valid combination passes cleanly