### PR TITLE
Make SwitchInfo hashable again so requires=/excludes= work (#816)

### DIFF
--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -67,7 +67,13 @@ T = TypeVar("T", default=str)
 # ===================================================================================================
 # The switch decorator
 # ===================================================================================================
-@dataclasses.dataclass
+# ``eq=False`` keeps the default identity-based ``__hash__`` (and ``__eq__``).
+# The dataclass has mutable ``list`` fields, so it cannot be value-hashed, yet
+# ``Application`` puts ``SwitchInfo`` objects into sets when validating
+# ``requires``/``excludes``. Identity semantics are correct here: each switch is
+# a unique descriptor. (A value-based ``__eq__`` sets ``__hash__ = None``, which
+# is what broke ``requires=``/``excludes=`` when this became a dataclass.)
+@dataclasses.dataclass(eq=False)
 class SwitchInfo:
     # Python 3.10+ can use slots=True
     __slots__ = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from plumbum import cli, local
+from plumbum.cli.switches import SwitchInfo
 from plumbum.cli.terminal import get_terminal_size
 
 
@@ -491,3 +492,65 @@ if __name__ == '__main__':
         )
         # No traceback should be in stderr
         assert "Traceback" not in result.stderr, f"Traceback in stderr: {result.stderr}"
+
+
+class ExcludesApp(cli.Application):
+    alpha = cli.Flag("--alpha")
+    beta = cli.Flag("--beta", excludes=["--alpha"])
+
+    def main(self):
+        pass
+
+
+class RequiresApp(cli.Application):
+    alpha = cli.Flag("--alpha")
+    beta = cli.Flag("--beta", requires=["--alpha"])
+
+    def main(self):
+        pass
+
+
+class TestSwitchCombinations:
+    """``requires=``/``excludes=`` switch combinations.
+
+    Regression test for #816: validating these put ``SwitchInfo`` objects into a
+    set, which crashed with ``TypeError: unhashable type: 'SwitchInfo'`` after
+    ``SwitchInfo`` became a (value-comparing, therefore unhashable) dataclass.
+    """
+
+    def test_excludes_runs_when_not_conflicting(self):
+        _, rc = ExcludesApp.run(["app", "--beta"], exit=False)
+        assert rc == 0
+
+    def test_excludes_rejects_conflicting_switches(self, capsys):
+        _, rc = ExcludesApp.run(["app", "--alpha", "--beta"], exit=False)
+        assert rc == 2
+        assert "invalid" in capsys.readouterr()[0]
+
+    def test_requires_runs_when_satisfied(self):
+        _, rc = RequiresApp.run(["app", "--alpha", "--beta"], exit=False)
+        assert rc == 0
+
+    def test_requires_rejects_when_dependency_missing(self, capsys):
+        _, rc = RequiresApp.run(["app", "--beta"], exit=False)
+        assert rc == 2
+        assert "missing" in capsys.readouterr()[0]
+
+    def test_switchinfo_is_hashable(self):
+        # The set membership above only works if SwitchInfo is hashable; the
+        # list fields mean it can only be hashed by identity, not by value.
+        info = SwitchInfo(
+            names=["--x"],
+            envname=None,
+            argtype=None,
+            list=False,
+            func=lambda: None,
+            mandatory=False,
+            overridable=False,
+            group="Switches",
+            requires=[],
+            excludes=[],
+            argname="VALUE",
+            help=None,
+        )
+        assert isinstance(hash(info), int)


### PR DESCRIPTION
Fixes #816.

## Problem

Since 2.0.0, any app using `requires=` or `excludes=` on a `Flag`/`SwitchAttr` crashes at parse time with:

```
TypeError: unhashable type: 'SwitchInfo'
```

`SwitchInfo` was changed from a `namedtuple` into a plain `@dataclass`. A value-comparing dataclass (the default, `eq=True`) sets `__hash__ = None`, but `Application` collects `SwitchInfo` objects into sets when checking `requires`/`excludes`:

```python
exclusions[swinfo.func] = {self._switches_by_name[exc] for exc in swinfo.excludes}
```

## Fix

`@dataclasses.dataclass(eq=False)` restores the default identity-based `__hash__` (and `__eq__`).

I used identity rather than the `frozen=True` suggested in the issue, because `SwitchInfo` has mutable `list` fields (`names`, `requires`, `excludes`): a value-based hash isn't possible, so `frozen=True` just trades the error for `TypeError: unhashable type: 'list'` the moment the hash is used. Identity is also the correct semantics here — these sets only deduplicate and iterate the canonical switch objects (the actual set algebra runs on `.func`), and the single `==` on `SwitchInfo` (help rendering) compares those same canonical instances, so identity equality is equivalent. I checked the rest of the namedtuple→dataclass change for other fallout (tuple unpacking/indexing) and found none — only the hashing broke.

## Tests

`requires=`/`excludes=` had no test coverage, which is how this slipped through. Added `TestSwitchCombinations` covering both (runs when satisfied, errors when violated) plus a direct hashability check. All five fail on `master` and pass with the fix.

Thanks to @zhan9san for the clear report and root-cause analysis.
