### PR TITLE
fix: quote paths, cwd, and env names in remote shell command lines

### DIFF
--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -21,7 +21,7 @@ from typing import IO, Any
 from plumbum.commands.base import shquote
 from plumbum.commands.processes import ProcessLineTimedOut, iter_lines
 from plumbum.machines.base import PopenAddons
-from plumbum.machines.remote import BaseRemoteMachine
+from plumbum.machines.remote import BaseRemoteMachine, _check_env_name
 from plumbum.machines.session import ShellSession
 from plumbum.path.local import LocalPath
 from plumbum.path.remote import RemotePath, RemoteStatRes
@@ -359,10 +359,12 @@ class ParamikoMachine(BaseRemoteMachine):
         envdelta = self.env.getdelta()
         if env:
             envdelta.update(env)
-        argv.extend(["cd", str(cwd or self.cwd), "&&"])
+        argv.extend(["cd", shquote(str(cwd or self.cwd)), "&&"])
         if envdelta:
             argv.append("env")
-            argv.extend(f"{k}={shquote(v)}" for k, v in envdelta.items())
+            argv.extend(
+                f"{_check_env_name(k)}={shquote(v)}" for k, v in envdelta.items()
+            )
         argv.extend(args.formulate())
         cmdline = " ".join(argv)
         logger.debug(cmdline)

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -5,7 +5,6 @@ __lazy_modules__ = {
     "plumbum.lib",
     "plumbum.path",
     "plumbum.path.local",
-    "re",
     "tempfile",
 }
 
@@ -28,6 +27,23 @@ if TYPE_CHECKING:
     from plumbum._compat.typing import Self
     from plumbum.commands.async_ import AsyncRemoteCommand
     from plumbum.machines.session import ShellSession
+
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _check_env_name(name: str) -> str:
+    """Validate a shell environment variable *name*.
+
+    Variable names are interpolated unquoted into remote shell command lines,
+    so a name containing shell metacharacters would allow command injection.
+    Only POSIX identifiers (``[A-Za-z_][A-Za-z0-9_]*``) are permitted.
+
+    :returns: the validated name (so it can be used inline)
+    """
+    if not _ENV_NAME_RE.match(name):
+        raise ValueError(f"Invalid environment variable name: {name!r}")
+    return name
 
 
 class RemoteEnv(BaseEnv[RemotePath]):
@@ -61,14 +77,17 @@ class RemoteEnv(BaseEnv[RemotePath]):
         self._orig = dict(self._curr)
 
     def __delitem__(self, name: str) -> None:
+        _check_env_name(name)
         BaseEnv.__delitem__(self, name)
         self.remote._session.run(f"unset {name}")
 
     def __setitem__(self, name: str, value: str) -> None:
+        _check_env_name(name)
         BaseEnv.__setitem__(self, name, value)
         self.remote._session.run(f"export {name}={shquote(value)}")
 
     def pop(self, name: str, *default: str) -> str | None:
+        _check_env_name(name)
         value = BaseEnv.pop(self, name, *default)
         self.remote._session.run(f"unset {name}")
         return value
@@ -76,7 +95,10 @@ class RemoteEnv(BaseEnv[RemotePath]):
     def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         BaseEnv.update(self, *args, **kwargs)
         self.remote._session.run(
-            "export " + " ".join(f"{k}={shquote(v)}" for k, v in self.getdict().items())
+            "export "
+            + " ".join(
+                f"{_check_env_name(k)}={shquote(v)}" for k, v in self.getdict().items()
+            )
         )
 
     def expand(self, expr: str) -> str:
@@ -492,34 +514,31 @@ class BaseRemoteMachine(BaseMachine):
         return files
 
     def _path_glob(self, fn: str, pattern: str) -> list[str]:
+        # Both branches enumerate the tree with POSIX ``find`` and match in
+        # Python rather than relying on the remote shell's globbing. This is
+        # portable across shells (``**`` only recurses in bash with
+        # ``globstar``) and avoids the shell-glob quirks -- injection and
+        # whitespace-mangling -- that bite directory names containing spaces or
+        # glob/shell metacharacters.
+        regex = re.compile(_glob_to_regex(pattern))
+        # ``find`` exits non-zero on partial errors (e.g. an unreadable
+        # subdirectory) while still printing the matches it did find, so match
+        # whatever was printed rather than discarding it -- this mirrors
+        # ``glob.glob``, which does not error on unreadable subdirs.
         if _is_recursive_glob(pattern):
-            # Recursive glob (``**``). The shell loop below cannot do this
-            # portably: ``/bin/sh`` is often dash, and ``**`` only recurses in
-            # bash with ``globstar`` enabled. Instead, enumerate the tree with
-            # POSIX ``find`` and match in Python, so the result is identical
-            # regardless of the remote shell -- and free of the shell-glob
-            # quirks that bite paths containing glob metacharacters.
-            regex = re.compile(_glob_to_regex(pattern))
-            # ``find`` exits non-zero on partial errors (e.g. an unreadable
-            # subdirectory) while still printing the matches it did find, so
-            # match whatever was printed rather than discarding it -- this
-            # mirrors ``glob.glob``, which does not error on unreadable subdirs.
-            _, out, _ = self._session.run(f"find {shquote(fn)}", retcode=None)
-            prefix = fn.rstrip("/") + "/"
-            return sorted(
-                line
-                for line in out.splitlines()
-                if line.startswith(prefix) and regex.match(line[len(prefix) :])
-            )
-        # shquote does not work here due to the way bash loops use space as a separator
-        pattern = pattern.replace(" ", r"\ ")
-        fn = fn.replace(" ", r"\ ")
-        matches = self._session.run(rf"for fn in {fn}/{pattern}; do echo $fn; done")[
-            1
-        ].splitlines()
-        if len(matches) == 1 and not self._path_stat(matches[0]):
-            return []  # pattern expansion failed
-        return matches
+            find_cmd = f"find {shquote(fn)}"
+        else:
+            # A non-recursive pattern spans a fixed number of path components,
+            # so cap ``find``'s depth to avoid descending the whole tree.
+            depth = pattern.count("/") + 1
+            find_cmd = f"find {shquote(fn)} -maxdepth {depth}"
+        _, out, _ = self._session.run(find_cmd, retcode=None)
+        prefix = fn.rstrip("/") + "/"
+        return sorted(
+            line
+            for line in out.splitlines()
+            if line.startswith(prefix) and regex.match(line[len(prefix) :])
+        )
 
     def _path_getuid(self, fn: str) -> list[str]:
         stat_cmd = (
@@ -623,11 +642,22 @@ class BaseRemoteMachine(BaseMachine):
         return self._session.run(f"echo {expr}")[1].strip()
 
     def expanduser(self, expr: str) -> str:
-        if not any(part.startswith("~") for part in expr.split("/")):
+        # Only a leading ``~`` (i.e. ``~`` or ``~user`` as the first path
+        # component) is meaningful, exactly like os.path.expanduser.
+        if not expr.startswith("~"):
             return expr
-        # we escape all $ signs to avoid expanding env-vars
-        expr_repl = expr.replace("$", "\\$")
-        return self._session.run(f"echo {expr_repl}")[1].strip()
+        head, sep, tail = expr.partition("/")
+        # Tilde expansion happens only on an *unquoted* leading ``~``/``~user``;
+        # shquote would suppress it. A tilde-prefix can only name a login, so we
+        # accept ``~`` or ``~user`` for a safe username and otherwise leave the
+        # path untouched (matching os.path.expanduser, which returns the input
+        # unchanged when the user is unknown/unexpandable).
+        if head != "~" and not re.fullmatch(r"~[A-Za-z0-9_][A-Za-z0-9_.-]*", head):
+            return expr
+        expanded = self._session.run(f"echo {head}")[1].strip()
+        # The remainder of the path is treated as a literal string; it is never
+        # passed through the shell, so metacharacters cannot inject or expand.
+        return expanded + sep + tail
 
 
 class AsyncRemoteMachine:

--- a/plumbum/machines/ssh_machine.py
+++ b/plumbum/machines/ssh_machine.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 from plumbum.commands import BaseCommand, ProcessExecutionError, shquote
 from plumbum.lib import IS_WIN32
 from plumbum.machines.local import local
-from plumbum.machines.remote import BaseRemoteMachine, RemoteEnv
+from plumbum.machines.remote import BaseRemoteMachine, RemoteEnv, _check_env_name
 from plumbum.machines.session import ShellSession
 from plumbum.path.local import LocalPath
 from plumbum.path.remote import RemotePath, RemoteWorkdir
@@ -218,10 +218,12 @@ class SshMachine(BaseRemoteMachine):
             if cwd is None:
                 cwd = getattr(self, "cwd", None)
             if cwd:
-                cmdline.extend(["cd", str(cwd), "&&"])
+                cmdline.extend(["cd", shquote(str(cwd)), "&&"])
             if envdelta:
                 cmdline.append("env")
-                cmdline.extend(f"{k}={shquote(v)}" for k, v in envdelta.items())
+                cmdline.extend(
+                    f"{_check_env_name(k)}={shquote(v)}" for k, v in envdelta.items()
+                )
             if isinstance(args, (tuple, list)):
                 cmdline.extend(args)
             else:
@@ -249,13 +251,16 @@ class SshMachine(BaseRemoteMachine):
         if stderr is None:
             stderr = "&1"
 
-        args = [] if str(cwd) == "." else ["cd", str(cwd), "&&"]
+        args = [] if str(cwd) == "." else ["cd", shquote(str(cwd)), "&&"]
         args.append("nohup")
         args.extend(command.formulate())
+        # ``&1`` (i.e. ``2>&1``) is a shell redirection operand, not a path, so
+        # it must stay unquoted; everything else is a filename and is quoted.
+        stderr_target = "&1" if stderr == "&1" else shquote(str(stderr))
         args.extend(
             [
-                (">>" if append else ">") + str(stdout),
-                "2" + (">>" if (append and stderr != "&1") else ">") + str(stderr),
+                (">>" if append else ">") + shquote(str(stdout)),
+                "2" + (">>" if (append and stderr != "&1") else ">") + stderr_target,
                 "</dev/null",
             ]
         )

--- a/tests/test_remote_quoting.py
+++ b/tests/test_remote_quoting.py
@@ -1,0 +1,179 @@
+"""Regression tests for remote shell-quoting / injection holes (issue #820).
+
+These tests exercise the command-string construction without needing a live
+SSH connection: a fake session records every command passed to ``run`` and
+returns canned output.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from plumbum.machines.remote import (
+    BaseRemoteMachine,
+    RemoteEnv,
+    _check_env_name,
+)
+
+
+class FakeSession:
+    """Records commands and returns a fixed (rc, stdout, stderr) tuple."""
+
+    def __init__(self, stdout: str = "") -> None:
+        self.commands: list[str] = []
+        self.stdout = stdout
+
+    def run(self, cmd, retcode=0):  # noqa: ARG002
+        self.commands.append(cmd)
+        return (0, self.stdout, "")
+
+
+class FakeRemote:
+    """A stand-in for BaseRemoteMachine exposing just what we need."""
+
+    def __init__(self, stdout: str = "") -> None:
+        self._session = FakeSession(stdout)
+        self.uname = "Linux"
+
+    # borrow the real implementations under test
+    expanduser = BaseRemoteMachine.expanduser
+    expand = BaseRemoteMachine.expand
+    _path_glob = BaseRemoteMachine._path_glob
+    _path_stat = BaseRemoteMachine._path_stat
+
+
+class TestCheckEnvName:
+    @pytest.mark.parametrize("name", ["X", "_x", "FOO_BAR", "a1", "_"])
+    def test_valid(self, name):
+        assert _check_env_name(name) == name
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "X; rm -rf ~",
+            "1FOO",
+            "FOO BAR",
+            "FOO=BAR",
+            "$(touch pwned)",
+            "`id`",
+            "FOO-BAR",
+            "",
+        ],
+    )
+    def test_invalid(self, name):
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _check_env_name(name)
+
+
+class TestRemoteEnvValidation:
+    def _make_env(self):
+        env = object.__new__(RemoteEnv)
+        env.remote = FakeRemote()
+        return env
+
+    def test_setitem_rejects_injection(self):
+        env = self._make_env()
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            env["X; rm -rf ~"] = "1"
+        # nothing should have been sent to the session
+        assert env.remote._session.commands == []
+
+    def test_delitem_rejects_injection(self):
+        env = self._make_env()
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            del env["BAD;NAME"]
+        assert env.remote._session.commands == []
+
+    def test_pop_rejects_injection(self):
+        env = self._make_env()
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            env.pop("`id`")
+        assert env.remote._session.commands == []
+
+
+class TestExpanduser:
+    def test_no_tilde_returns_unchanged(self):
+        rem = FakeRemote()
+        assert rem.expanduser("/abs/path") == "/abs/path"
+        assert rem.expanduser("rel/path") == "rel/path"
+        assert rem.expanduser("./~notfirst") == "./~notfirst"
+        # the session must not be touched at all
+        assert rem._session.commands == []
+
+    def test_literal_suffix_is_not_executed(self):
+        # The home dir is expanded but the dangerous suffix must round-trip
+        # literally and must NOT be passed through the shell.
+        rem = FakeRemote(stdout="/home/me")
+        result = rem.expanduser("~/a b; rm -rf c")
+        assert result == "/home/me/a b; rm -rf c"
+        # only a single safe "echo ~" was run; the suffix never reached a command
+        assert rem._session.commands == ["echo ~"]
+        assert not any("rm -rf" in c for c in rem._session.commands)
+
+    def test_glob_metachars_in_suffix_round_trip(self):
+        rem = FakeRemote(stdout="/home/me")
+        result = rem.expanduser("~/a*?$(touch x)`id`")
+        assert result == "/home/me/a*?$(touch x)`id`"
+        assert rem._session.commands == ["echo ~"]
+
+    def test_named_user_expands(self):
+        rem = FakeRemote(stdout="/home/john")
+        result = rem.expanduser("~john/sub dir")
+        assert result == "/home/john/sub dir"
+        assert rem._session.commands == ["echo ~john"]
+
+    def test_unsafe_username_left_untouched(self):
+        # A "~user" whose user part is not a safe login name is not expanded
+        # (mirroring os.path.expanduser returning the input unchanged), and is
+        # never sent to the shell.
+        rem = FakeRemote()
+        expr = "~ev;il/foo"
+        assert rem.expanduser(expr) == expr
+        assert rem._session.commands == []
+
+
+class TestPathGlobQuoting:
+    def test_non_recursive_quotes_directory(self):
+        rem = FakeRemote(stdout="")
+        rem._path_glob("/tmp/a b; rm -rf c", "*.txt")
+        cmd = rem._session.commands[0]
+        # directory is shquoted and there is no echo-of-unquoted-var
+        assert "'/tmp/a b; rm -rf c'" in cmd
+        assert "echo $fn" not in cmd
+        assert cmd.startswith("find ")
+
+    def test_non_recursive_matches_and_preserves_whitespace(self):
+        # find returns full paths; whitespace in matched names must survive.
+        out = "/dir/a b.txt\n/dir/c.txt\n/dir/skip.log\n"
+        rem = FakeRemote(stdout=out)
+        matches = rem._path_glob("/dir", "*.txt")
+        assert matches == ["/dir/a b.txt", "/dir/c.txt"]
+
+    def test_recursive_still_quotes_directory(self):
+        rem = FakeRemote(stdout="")
+        rem._path_glob("/tmp/x;y", "**/*.py")
+        cmd = rem._session.commands[0]
+        assert "'/tmp/x;y'" in cmd
+        assert cmd.startswith("find ")
+
+
+class TestSshPopenQuoting:
+    def test_cwd_and_env_quoted(self):
+        # Build the command line the way SshMachine.popen does, without a
+        # connection, by driving the quoting logic directly.
+        from plumbum.commands import shquote
+
+        cwd = "/a dir; rm -rf x"
+        assert shquote(cwd) == "'/a dir; rm -rf x'"
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _check_env_name("BAD;NAME")
+        assert _check_env_name("GOOD_NAME") == "GOOD_NAME"
+
+
+def test_env_name_regex_anchored():
+    # guard against partial matches sneaking through
+    assert re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", "OK_1")
+    with pytest.raises(ValueError, match="Invalid"):
+        _check_env_name("OK\nrm -rf /")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the review in #820. Hardens remote shell command construction against quoting bugs and shell injection. Command *arguments* were already `shquote`d; these paths were not.

- **`expanduser` (`machines/remote.py`)** ran `echo {expr}` through the session shell escaping only `$`, so a path part like `~/a b; rm -rf c` could inject or get mangled. Now only the leading `~`/`~user` component is expanded (username validated), and the remainder is treated literally.
- **`SshMachine.popen` / `ParamikoMachine.popen`** inserted `cwd` unquoted into the remote `cd … &&` line — a cwd with a space or `;`/backtick broke or injected after a `chdir()`. Now `shquote`d. Env-var **names** are now validated (values were already quoted).
- **`RemoteEnv`** (`__setitem__`/`__delitem__`/`pop`/`update`) validated raw variable names before building `export`/`unset`, so a name like `X; rm -rf ~` raises rather than executing.
- **`_path_glob`** non-recursive branch escaped only spaces and used unquoted `echo $fn`; unified with the recursive branch (`find` + Python regex matcher, `shquote`d dir).

New shared helper `_check_env_name` / `_ENV_NAME_RE`. Adds `tests/test_remote_quoting.py` (26 tests, no live SSH needed).

`prek -a` clean; `uv run pytest` green (pre-existing sandbox-only failures unrelated).
