### PR TITLE
fix(colorlib): correctness fixes (stdout guard, Color(0), from_ansi, bold-off)

### DIFF
--- a/plumbum/colorlib/factories.py
+++ b/plumbum/colorlib/factories.py
@@ -105,7 +105,8 @@ class ColorFactory(Generic[S]):
         try:
             return self.full(val)
         except ColorNotFound:
-            assert not isinstance(val, int)
+            if isinstance(val, int):
+                raise ColorNotFound(f"Color number {val!r} is out of range") from None
             return self.hex(val)
 
     def __call__(

--- a/plumbum/colorlib/styles.py
+++ b/plumbum/colorlib/styles.py
@@ -55,7 +55,11 @@ def get_color_repr() -> int:
         return 0
     if os.environ.get("FORCE_COLOR", "") in {"0", "1", "2", "3", "4"}:
         return int(os.environ["FORCE_COLOR"])
-    if not sys.stdout.isatty():
+    if (
+        sys.stdout is None
+        or not hasattr(sys.stdout, "isatty")
+        or not sys.stdout.isatty()
+    ):
         return 0
 
     term = os.environ.get("TERM", "")
@@ -164,8 +168,13 @@ class Color:
         self.exact = True
         "This is false if the named color does not match the real color"
 
-        if None in (g, b):
-            if not r_or_color:
+        if (g is None) != (b is None):
+            raise ColorNotFound(
+                "Color requires either no g/b arguments or both g and b together"
+            )
+
+        if g is None and b is None:
+            if r_or_color is None or r_or_color == "":
                 return
             try:
                 self._from_simple(r_or_color)
@@ -173,7 +182,10 @@ class Color:
                 try:
                     self._from_full(r_or_color)
                 except ColorNotFound:
-                    assert isinstance(r_or_color, str)
+                    if not isinstance(r_or_color, str):
+                        raise ColorNotFound(
+                            "Did not find color: " + repr(r_or_color)
+                        ) from None
                     self._from_hex(r_or_color)
 
         elif isinstance(r_or_color, int) and g is not None and b is not None:
@@ -639,8 +651,9 @@ class Style(metaclass=ABCMeta):
             codes.extend(self.fg.ansi_codes)
 
         if self.bg:
-            self.bg.fg = False
-            codes.extend(self.bg.ansi_codes)
+            bg = copy(self.bg)
+            bg.fg = False
+            codes.extend(bg.ansi_codes)
 
         return codes
 
@@ -689,8 +702,7 @@ class Style(metaclass=ABCMeta):
     def from_ansi(cls, ansi_string: str, filter_resets: bool = False) -> Self:
         """This generated a style from an ansi string. Will ignore resets if filter_resets is True."""
         result = cls()
-        res = cls.ANSI_REG.search(ansi_string)
-        if res is not None:
+        for res in cls.ANSI_REG.finditer(ansi_string):
             for group in res.groups():
                 sequence = map(int, group.split(";"))
                 result.add_ansi(sequence, filter_resets)
@@ -756,6 +768,15 @@ class Style(metaclass=ABCMeta):
                     for name, att_value in attributes_ansi.items():
                         if value == att_value:
                             self.attributes[name] = True
+                elif value == 22:
+                    # ANSI 22 = "normal intensity": clears both bold (1) and dim (2).
+                    # ansi_codes emits 22 for bold=False (not 21) to match terminal
+                    # behaviour, so we must parse 22 as bold=False here to round-trip.
+                    if filter_resets is False:
+                        if "bold" in self.attribute_names:
+                            self.attributes["bold"] = False
+                        if "dim" in self.attribute_names:
+                            self.attributes["dim"] = False
                 elif value in (20 + n for n in attributes_ansi.values()):
                     if filter_resets is False:
                         for name, att_value in attributes_ansi.items():

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,7 +1,12 @@
 # Just check to see if this file is importable
 from __future__ import annotations
 
+import sys
+
+import pytest
+
 from plumbum.cli.image import Image  # noqa: F401
+from plumbum.colorlib.factories import ColorFactory
 from plumbum.colorlib.names import FindNearest, color_html
 from plumbum.colorlib.styles import (  # noqa: F401
     ANSIStyle,
@@ -92,3 +97,78 @@ class TestNearestColorAgain:
                 for b in myrange:
                     near = FindNearest(r, g, b)
                     assert near.all_slow() == near.all_fast(), f"Tested: {r}, {g}, {b}"
+
+
+class TestColorlibCorrectness:
+    """Regression tests for colorlib correctness fixes (issue #820)."""
+
+    def test_stdout_none_import(self, monkeypatch):
+        """get_color_repr() must not raise when sys.stdout is None (fix 1)."""
+        import plumbum.colorlib.styles as styles_mod
+
+        monkeypatch.setattr(sys, "stdout", None)
+        # Should return 0 instead of raising AttributeError
+        result = styles_mod.get_color_repr()
+        assert result == 0
+
+    def test_stdout_no_isatty(self, monkeypatch):
+        """get_color_repr() must not raise when sys.stdout lacks isatty (fix 1)."""
+        import plumbum.colorlib.styles as styles_mod
+
+        class NoIsatty:
+            pass
+
+        monkeypatch.setattr(sys, "stdout", NoIsatty())
+        result = styles_mod.get_color_repr()
+        assert result == 0
+
+    def test_color_zero_is_black(self):
+        """Color(0) must produce black, not the reset color (fix 2)."""
+        black = Color(0)
+        assert not black.isreset, "Color(0) should be black, not reset"
+        assert black.number == 0
+
+    def test_color_none_is_reset(self):
+        """Color() and Color(None) must produce the reset color (fix 2)."""
+        assert Color().isreset
+        assert Color(None).isreset
+
+    def test_color_empty_string_is_reset(self):
+        """Color('') must produce the reset color (fix 2)."""
+        assert Color("").isreset
+
+    def test_color_missing_b_raises(self):
+        """Color(r, g) with only two ints must raise ColorNotFound (fix 2)."""
+        with pytest.raises(ColorNotFound):
+            Color(255, 128)
+
+    def test_color_out_of_range_raises(self):
+        """Color(300) must raise ColorNotFound, not AssertionError (fix 3)."""
+        with pytest.raises(ColorNotFound):
+            Color(300)
+
+    def test_colorfactory_out_of_range_raises(self):
+        """ColorFactory[300] must raise ColorNotFound, not AssertionError (fix 3)."""
+        factory = ColorFactory(True, ANSIStyle)
+        with pytest.raises(ColorNotFound):
+            factory[300]
+
+    def test_from_ansi_multiple_sequences(self):
+        """from_ansi must parse all escape sequences, not just the first (fix 4)."""
+        ANSIStyle.use_color = 4
+        style = ANSIStyle.from_ansi("\033[1m\033[31m")
+        # Both bold and red fg must be present
+        assert style.attributes.get("bold") is True, "bold must be set"
+        assert style.fg is not None, "fg must be present"
+        assert not style.fg.isreset, "fg must be red (not reset)"
+
+    def test_bold_off_roundtrip(self):
+        """ANSIStyle(attributes={'bold': False}) must round-trip through ANSI (fix 5)."""
+        ANSIStyle.use_color = 4
+        original = ANSIStyle(attributes={"bold": False})
+        ansi_str = str(original)
+        assert ansi_str, "Expected non-empty ANSI sequence for bold=False"
+        recovered = ANSIStyle.from_ansi(ansi_str)
+        assert recovered.attributes.get("bold") is False, (
+            f"bold must be False after round-trip, got attributes={recovered.attributes!r}"
+        )

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -106,6 +106,10 @@ class TestColorlibCorrectness:
         """get_color_repr() must not raise when sys.stdout is None (fix 1)."""
         import plumbum.colorlib.styles as styles_mod
 
+        # FORCE_COLOR/NO_COLOR short-circuit before the stdout check (and CI
+        # sets FORCE_COLOR), so clear them to exercise the isatty path.
+        monkeypatch.delenv("FORCE_COLOR", raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
         monkeypatch.setattr(sys, "stdout", None)
         # Should return 0 instead of raising AttributeError
         result = styles_mod.get_color_repr()
@@ -118,6 +122,8 @@ class TestColorlibCorrectness:
         class NoIsatty:
             pass
 
+        monkeypatch.delenv("FORCE_COLOR", raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
         monkeypatch.setattr(sys, "stdout", NoIsatty())
         result = styles_mod.get_color_repr()
         assert result == 0


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the review in #820. Five colorlib correctness bugs (+ one optional).

- **`get_color_repr` (`colorlib/styles.py`)** called `sys.stdout.isatty()` unguarded at import time, so `import plumbum` crashed under `pythonw`/GUI embedding where `sys.stdout is None`. Now guarded.
- **`Color(0)`** returned the *reset* color instead of black (falsy-zero check). Guard is now `is None or == ""`. `Color(r, g)` with one of g/b missing now raises instead of silently dropping it.
- **Out-of-range/unknown int colors** raised `AssertionError` (and behaved differently under `python -O`); now raise `ColorNotFound`.
- **`Style.from_ansi`** parsed only the first escape sequence (`groups()` vs `finditer`); now parses all, like `from_ansi_string`.
- **Bold-off round-trip** — emitted ANSI `22` but parsed it back as dim-off; `22` (normal intensity) now clears both bold and dim, so styles round-trip.
- *(optional)* `ansi_codes` getter no longer mutates shared `Color` state.

Adds 10 regression tests to `tests/test_color.py`. `prek -a` clean; pytest green (pre-existing sandbox-only failures unrelated).
