### PR TITLE
fix(cli): correct several CLI parsing and terminal bugs

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -13,6 +13,7 @@ __lazy_modules__ = {
 }
 
 import contextlib
+import errno
 import functools
 import inspect
 import os
@@ -1028,10 +1029,14 @@ complete -F _{prog_name}_completion {prog_name}
             if exit:
                 # surface an EPIPE now, while we can still handle it below
                 sys.stdout.flush()
-        except BrokenPipeError:
-            # The reader closed the pipe (e.g. output piped to ``head``).
+        except OSError as exc:
+            # The reader closed the pipe (e.g. output piped to ``head``). On
+            # POSIX this is BrokenPipeError (EPIPE); on Windows the flush
+            # raises OSError EINVAL instead. Re-raise anything else.
             # Never change the SIGPIPE disposition instead: that would make a
             # socket send() to a closed peer kill the whole process.
+            if not isinstance(exc, BrokenPipeError) and exc.errno != errno.EINVAL:
+                raise
             retcode = 1
             if exit:
                 # Point stdout at devnull so the interpreter's final flush

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -408,13 +408,12 @@ class Application:
                 # [--name], [--name=XXX], [--name, XXX], [--name, ==, XXX],
                 # [--name=, XXX], [--name, =XXX]
                 eqsign = a.find("=")
-                if eqsign >= 0:
+                has_eq = eqsign >= 0
+                if has_eq:
                     name = a[2:eqsign]
                     argv.insert(0, a[eqsign:])
-                    has_eq = True
                 else:
                     name = a[2:]
-                    has_eq = False
 
                 # An exact match always wins over abbreviation (argparse-style).
                 if self.ALLOW_ABBREV and name not in self._switches_by_name:

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -206,6 +206,9 @@ class Application:
     parent: Self | None = None
     nested_command: tuple[type[Application], list[str]] | None = None
     _unbound_switches: ClassVar[tuple[str, ...]] = ()
+    # Set transiently by ``helpall`` so that ``help`` demotes meta-switches for
+    # the nested render only, without mutating the shared SwitchInfo objects.
+    _hide_meta_switches: bool = False
 
     def __new__(cls, executable: object | None = None) -> Self:
         """Allows running the class directly as a shortcut for main.
@@ -363,6 +366,20 @@ class Application:
             if switch_.startswith(partialname)
         ]
 
+    def _lookup_switch(self, name: str, swinfo: SwitchInfo) -> SwitchInfo:
+        try:
+            return self._switches_by_name[name]
+        except KeyError:
+            raise SwitchError(
+                T_(
+                    "Switch {0} refers to an unknown switch {1} "
+                    "in its requires/excludes"
+                ).format(
+                    ("-" if len(swinfo.names[0]) == 1 else "--") + swinfo.names[0],
+                    name,
+                )
+            ) from None
+
     def _parse_args(
         self, argv: list[str]
     ) -> tuple[dict[Callable[..., None], Any], list[str]]:
@@ -394,10 +411,13 @@ class Application:
                 if eqsign >= 0:
                     name = a[2:eqsign]
                     argv.insert(0, a[eqsign:])
+                    has_eq = True
                 else:
                     name = a[2:]
+                    has_eq = False
 
-                if self.ALLOW_ABBREV:
+                # An exact match always wins over abbreviation (argparse-style).
+                if self.ALLOW_ABBREV and name not in self._switches_by_name:
                     partials = self._get_partial_matches(name)
                     if len(partials) == 1:
                         name = partials[0]
@@ -410,6 +430,10 @@ class Application:
                 if name not in self._switches_by_name:
                     raise UnknownSwitch(T_("Unknown switch {0}").format(swname))
                 swinfo = self._switches_by_name[name]
+                if not swinfo.argtype and has_eq:
+                    raise SwitchError(
+                        T_("Switch {0} does not take an argument").format(swname)
+                    )
                 if swinfo.argtype:
                     if not argv:
                         raise MissingArgument(
@@ -806,10 +830,10 @@ complete -F _{prog_name}_completion {prog_name}
                     )
                 )
             requirements[swinfo.func] = {
-                self._switches_by_name[req] for req in swinfo.requires
+                self._lookup_switch(req, swinfo) for req in swinfo.requires
             }
             exclusions[swinfo.func] = {
-                self._switches_by_name[exc] for exc in swinfo.excludes
+                self._lookup_switch(exc, swinfo) for exc in swinfo.excludes
             }
 
         # TODO: compute topological order
@@ -1123,9 +1147,12 @@ complete -F _{prog_name}_completion {prog_name}
             for name, subcls in sorted(self._subcommands.items()):
                 subapp = (subcls.get())(f"{self.PROGNAME} {name}")
                 subapp.parent = self
-                for si in subapp._switches_by_func.values():
-                    if si.group == "Meta-switches":
-                        si.group = "Hidden-switches"
+                # Demote meta-switches in the nested help output. This must NOT
+                # mutate the shared SwitchInfo objects (which live on the
+                # function objects and are reused by every Application in the
+                # process); instead flag this instance so help() regroups them
+                # locally for this render only.
+                subapp._hide_meta_switches = True
                 subapp.helpall()
 
     @switch(
@@ -1274,9 +1301,14 @@ complete -F _{prog_name}_completion {prog_name}
 
         by_groups: dict[str, list[SwitchInfo]] = {}
         for si in self._switches_by_func.values():
-            if si.group not in by_groups:
-                by_groups[si.group] = []
-            by_groups[si.group].append(si)
+            group = (
+                "Hidden-switches"
+                if self._hide_meta_switches and si.group == "Meta-switches"
+                else si.group
+            )
+            if group not in by_groups:
+                by_groups[group] = []
+            by_groups[group].append(si)
 
         def switchs(
             by_groups: dict[str, list[SwitchInfo]], show_groups: bool

--- a/plumbum/cli/image.py
+++ b/plumbum/cli/image.py
@@ -31,12 +31,19 @@ class Image:
         if not self.char_ratio:  # Don't use if char ratio is 0
             return term
 
-        orig_ratio = orig[0] / orig[1] / self.char_ratio
+        # Cells are char_ratio times taller than they are wide, so a row count
+        # spans char_ratio "width-units" of height. To preserve the image's
+        # width/height aspect, the width in cells should equal
+        # height_in_cells * char_ratio * (orig_width / orig_height).
+        cell_ratio = orig[0] / orig[1] * self.char_ratio
 
-        if int(term[1] / orig_ratio) <= term[0]:
-            return int(term[1] / orig_ratio), term[1]
+        # First try filling the full terminal height; if that overflows the
+        # available width, fall back to filling the full width instead.
+        width = int(term[1] * cell_ratio)
+        if width <= term[0]:
+            return width, term[1]
 
-        return term[0], int(term[0] * orig_ratio)
+        return term[0], int(term[0] / cell_ratio)
 
     def show(self, filename: str, double: bool = False) -> None:
         """Display an image on the command line. Can select a size or show in double resolution."""

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -554,16 +554,15 @@ class Set(Validator[str]):
         if self.csv and check_csv:
             for v in value.split(self.csv):
                 yield from self._call_iter(v.strip(), check_csv=False)
+            return
 
-        if not self.case_sensitive:
-            value = value.lower()
+        cmp_value = value if self.case_sensitive else value.lower()
 
         for opt in self.values:
             if isinstance(opt, str):
-                if not self.case_sensitive:
-                    opt = opt.lower()  # noqa: PLW2901
-                if opt == value or value in self.all_markers:
-                    yield opt  # always return original value
+                cmp_opt = opt if self.case_sensitive else opt.lower()
+                if cmp_opt == cmp_value or cmp_value in self.all_markers:
+                    yield opt  # always return the configured (canonical) value
                 continue
             with contextlib.suppress(ValueError):
                 yield opt(value)

--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -556,13 +556,15 @@ class Set(Validator[str]):
                 yield from self._call_iter(v.strip(), check_csv=False)
             return
 
-        cmp_value = value if self.case_sensitive else value.lower()
+        if not self.case_sensitive:
+            value = value.lower()
 
         for opt in self.values:
             if isinstance(opt, str):
-                cmp_opt = opt if self.case_sensitive else opt.lower()
-                if cmp_opt == cmp_value or cmp_value in self.all_markers:
-                    yield opt  # always return the configured (canonical) value
+                if not self.case_sensitive:
+                    opt = opt.lower()  # noqa: PLW2901
+                if opt == value or value in self.all_markers:
+                    yield opt  # always return original value
                 continue
             with contextlib.suppress(ValueError):
                 yield opt(value)

--- a/plumbum/cli/terminal.py
+++ b/plumbum/cli/terminal.py
@@ -44,10 +44,18 @@ T = TypeVar("T")
 
 
 def readline(message: str = "") -> str:
-    """Gets a line of input from the user (stdin)"""
+    """Gets a line of input from the user (stdin).
+
+    Raises ``EOFError`` when stdin is exhausted/closed. ``sys.stdin.readline()``
+    returns an empty string (no trailing newline) at end-of-file, which would
+    otherwise cause the interactive helpers to loop forever.
+    """
     sys.stdout.write(message)
     sys.stdout.flush()
-    return sys.stdin.readline()
+    line = sys.stdin.readline()
+    if not line:
+        raise EOFError
+    return line
 
 
 def ask(question: str, default: bool | None = None) -> bool:
@@ -70,9 +78,11 @@ def ask(question: str, default: bool | None = None) -> bool:
 
     while True:
         try:
-            answer = readline(question).strip().lower()
+            answer: str | None = readline(question).strip().lower()
         except EOFError:
-            answer = None
+            if default is not None:
+                return default
+            raise
         if answer in {"y", "yes"}:
             return True
         if answer in {"n", "no"}:
@@ -130,7 +140,9 @@ def choose(
         try:
             choice: str | int = readline(msg).strip()
         except EOFError:
-            choice = ""
+            if default is not None:
+                return default
+            raise
         if not choice and default is not None:
             return default
         try:
@@ -169,7 +181,9 @@ def prompt(
         try:
             ans_str = readline(question).strip()
         except EOFError:
-            ans_str = ""
+            if default is not NotImplemented:
+                return default
+            raise
 
         if not ans_str:
             if default is not NotImplemented:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,8 +209,9 @@ class TestCLI:
         _, rc = SimpleApp.run(["foo", "--bacon=81", "--csv=all,100"], exit=False)
         assert rc == 0
         output = capsys.readouterr()
-        assert "min" in output.out
-        assert "max" in output.out
+        # case-insensitive Set yields the canonical (configured) spelling
+        assert "MIN" in output.out
+        assert "MAX" in output.out
         assert "100" in output.out
 
         _, rc = SimpleApp.run(["foo", "--bacon=81", "--num=MAX"], exit=False)
@@ -612,3 +613,84 @@ class TestSwitchCombinations:
             help=None,
         )
         assert isinstance(hash(info), int)
+
+
+class AbbrevApp(cli.Application):
+    ALLOW_ABBREV = True
+
+    foo = cli.Flag("--foo")
+    foobar = cli.Flag("--foobar")
+    verbose = cli.Flag("--verbose")
+
+    def main(self, *args):
+        self.tailargs = args
+
+
+class TestAbbrev:
+    def test_exact_match_wins_over_abbreviation(self):
+        # --foo is an exact switch name; it must not be rejected as an
+        # ambiguous prefix of --foobar.
+        inst, rc = AbbrevApp.run(["app", "--foo"], exit=False)
+        assert rc == 0
+        assert inst.foo is True
+        assert inst.foobar is False
+
+    def test_ambiguous_partial_still_errors(self, capsys):
+        _, rc = AbbrevApp.run(["app", "--foob"], exit=False)
+        # --foob is unambiguous (only --foobar), should succeed
+        assert rc == 0
+        _, rc = AbbrevApp.run(["app", "--fo"], exit=False)
+        assert rc == 2
+        assert "Ambiguous partial switch" in capsys.readouterr()[0]
+
+
+class TestFlagEquals:
+    def test_flag_with_value_errors(self, capsys):
+        # A no-argument flag given --verbose=yes must not leak '=yes' into the
+        # positional args; it should raise a clear error.
+        _inst, rc = AbbrevApp.run(["app", "--verbose=yes"], exit=False)
+        assert rc == 2
+        assert "does not take an argument" in capsys.readouterr()[0]
+
+
+class BadRequiresApp(cli.Application):
+    alpha = cli.Flag("--alpha", requires=["--nope"])
+
+    def main(self):
+        pass
+
+
+class BadExcludesApp(cli.Application):
+    alpha = cli.Flag("--alpha", excludes=["--nope"])
+
+    def main(self):
+        pass
+
+
+class TestBadRequiresExcludes:
+    def test_unknown_requires_raises_switch_error(self, capsys):
+        _, rc = BadRequiresApp.run(["app", "--alpha"], exit=False)
+        assert rc == 2
+        out = capsys.readouterr()[0]
+        assert "nope" in out
+        assert "unknown switch" in out.lower()
+
+    def test_unknown_excludes_raises_switch_error(self, capsys):
+        _, rc = BadExcludesApp.run(["app", "--alpha"], exit=False)
+        assert rc == 2
+        out = capsys.readouterr()[0]
+        assert "nope" in out
+        assert "unknown switch" in out.lower()
+
+
+class TestHelpAllDoesNotCorruptSharedSwitchInfo:
+    def test_helpall_leaves_shared_switchinfo_group_unchanged(self, capsys):
+        # Regression: helpall used to mutate the shared SwitchInfo objects that
+        # live on the function objects, permanently corrupting every later
+        # --help render in the process.
+        before = cli.Application.help._switch_info.group
+        _, rc = Geet.run(["geet", "--help-all"], exit=False)
+        assert rc == 0
+        capsys.readouterr()
+        after = cli.Application.help._switch_info.group
+        assert before == after == "Meta-switches"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,9 +209,8 @@ class TestCLI:
         _, rc = SimpleApp.run(["foo", "--bacon=81", "--csv=all,100"], exit=False)
         assert rc == 0
         output = capsys.readouterr()
-        # case-insensitive Set yields the canonical (configured) spelling
-        assert "MIN" in output.out
-        assert "MAX" in output.out
+        assert "min" in output.out
+        assert "max" in output.out
         assert "100" in output.out
 
         _, rc = SimpleApp.run(["foo", "--bacon=81", "--num=MAX"], exit=False)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from plumbum.cli.image import Image  # noqa: F401
+from plumbum.cli.image import Image
 from plumbum.colorlib.factories import ColorFactory
 from plumbum.colorlib.names import FindNearest, color_html
 from plumbum.colorlib.styles import (  # noqa: F401
@@ -178,3 +178,27 @@ class TestColorlibCorrectness:
         assert recovered.attributes.get("bold") is False, (
             f"bold must be False after round-trip, got attributes={recovered.attributes!r}"
         )
+
+
+class TestImageAspect:
+    def test_wide_image_stays_wide(self):
+        # Regression: a wide image (200x100) on an 80x25 terminal must render
+        # wide (fill the width), not tall.
+        img = Image()
+        width, height = img.best_aspect((200, 100), (80, 25))
+        assert width > height
+        assert width <= 80
+        assert height <= 25
+        # fills the available width for this case
+        assert width == 80
+
+    def test_tall_image_stays_tall(self):
+        img = Image()
+        width, height = img.best_aspect((100, 400), (80, 25))
+        assert height >= width
+        assert width <= 80
+        assert height <= 25
+
+    def test_char_ratio_zero_returns_term(self):
+        img = Image(char_ratio=0)
+        assert img.best_aspect((200, 100), (80, 25)) == (80, 25)

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -5,6 +5,8 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from io import StringIO
 
+import pytest
+
 from plumbum.cli.terminal import Progress, ask, choose, hexdump, prompt
 
 
@@ -125,6 +127,33 @@ class TestTerminal:
         with send_stdin():
             assert choose("Pick", dic, default="a") == "a"
         assert "[1]" in capsys.readouterr()[0]
+
+    def test_ask_eof_with_default(self):
+        # Exhausted stdin (EOF) must fall back to the default, not loop forever.
+        with send_stdin(""):
+            assert ask("Do you like cats?", default=True) is True
+        with send_stdin(""):
+            assert ask("Do you like cats?", default=False) is False
+
+    def test_ask_eof_no_default_raises(self):
+        with send_stdin(""), pytest.raises(EOFError):
+            ask("Do you like cats?")
+
+    def test_choose_eof_with_default(self):
+        with send_stdin(""):
+            assert choose("Pick", ["blue", "yellow"], default="yellow") == "yellow"
+
+    def test_choose_eof_no_default_raises(self):
+        with send_stdin(""), pytest.raises(EOFError):
+            choose("Pick", ["blue", "yellow"])
+
+    def test_prompt_eof_with_default(self):
+        with send_stdin(""):
+            assert prompt("Enter", default="hi") == "hi"
+
+    def test_prompt_eof_no_default_raises(self):
+        with send_stdin(""), pytest.raises(EOFError):
+            prompt("Enter", type=int)
 
     def test_hexdump(self):
         data = "hello world my name is queen marry" + "A" * 66 + "foo bar"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -13,13 +13,6 @@ class TestSet:
         assert CSV("a,b") == ["a", "b"]
         assert CSV("a") == ["a"]
 
-    def test_case_insensitive_returns_canonical(self):
-        # Regression: case-insensitive matching must yield the configured
-        # (canonical) spelling, not the lowercased user input.
-        s = Set("TCP", "UDP")
-        assert s("tcp") == "TCP"
-        assert s("UDP") == "UDP"
-
     def test_case_sensitive_match(self):
         s = Set("TCP", "UDP", case_sensitive=True)
         assert s("TCP") == "TCP"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,30 @@
 from __future__ import annotations
 
+import pytest
+
 from plumbum import cli
+from plumbum.cli.switches import CSV, Set
+
+
+class TestSet:
+    def test_csv_no_duplicate_unsplit(self):
+        # Regression: the per-item csv loop must `return` and not also validate
+        # the whole unsplit string (which produced ['a', 'b', 'a,b']).
+        assert CSV("a,b") == ["a", "b"]
+        assert CSV("a") == ["a"]
+
+    def test_case_insensitive_returns_canonical(self):
+        # Regression: case-insensitive matching must yield the configured
+        # (canonical) spelling, not the lowercased user input.
+        s = Set("TCP", "UDP")
+        assert s("tcp") == "TCP"
+        assert s("UDP") == "UDP"
+
+    def test_case_sensitive_match(self):
+        s = Set("TCP", "UDP", case_sensitive=True)
+        assert s("TCP") == "TCP"
+        with pytest.raises(ValueError):
+            s("tcp")
 
 
 class TestValidator:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the review in #820. Several CLI parsing and terminal bugs.

- **`Set._call_iter` CSV** — the csv branch didn't `return`, so it also validated the unsplit string: the exported `CSV("a,b")` yielded `['a','b','a,b']`. Fixed.
- **`ALLOW_ABBREV`** — an exact switch name that prefixes another (`--foo` vs `--foobar`) was rejected as ambiguous; exact match now wins (argparse-style).
- **`--flag=value` on a no-arg switch** silently leaked `=value` into positionals; now raises a clear `SwitchError`.
- **`helpall`** permanently mutated shared `SwitchInfo.group` objects process-wide; now computes the demoted grouping locally (regression test asserts the shared object is untouched).
- **`requires=`/`excludes=`** with an unknown name raised a bare `KeyError`; now a clear `SwitchError`.
- **`terminal.ask`/`choose`/`prompt`** infinite-looped on EOF (the caught `EOFError` was never raised by `sys.stdin.readline()`); `readline()` now detects EOF.
- **`Image.best_aspect`** inverted the aspect ratio for non-square images (wide rendered tall); math fixed with a numeric regression test.

The case-insensitive `Set` canonical-spelling behavior change moved to its own PR: #835. This PR is now bug-fixes-only.

`Range.choices()` materialization was left as-is (both callers fully materialize anyway — noted as follow-up). Tests added across `test_cli.py`/`test_validate.py`/`test_terminal.py`. `prek -a` clean; pytest green (pre-existing sandbox-only failures unrelated).
