### PR TITLE
fix: path/fs edge cases (access, unlink, chown, locked)

### DIFF
--- a/plumbum/fs/atomic.py
+++ b/plumbum/fs/atomic.py
@@ -8,6 +8,7 @@ __lazy_modules__ = {"atexit", "msvcrt", "plumbum.machines.local", "threading"}
 
 import atexit
 import contextlib
+import errno
 import os
 import sys
 import threading
@@ -221,14 +222,23 @@ class AtomicFile:
             return
 
         assert self._fileobj is not None
-        with self._thdlock, locked_file(self._fileobj.fileno(), blocking):
-            if not self.path.exists() and not self._ignore_deletion:
-                raise ValueError("Atomic file removed from filesystem")
-            self._owned_by = threading.get_ident()
-            try:
-                yield
-            finally:
-                self._owned_by = None
+        # Honor ``blocking`` for the in-process thread lock too: a plain
+        # ``with self._thdlock`` would block a non-blocking caller when another
+        # thread of this process holds the lock. Mirror the filesystem-lock
+        # failure path by raising an ``OSError`` that "would block".
+        if not self._thdlock.acquire(blocking=blocking):
+            raise OSError(errno.EAGAIN, "Atomic file lock is held by another thread")
+        try:
+            with locked_file(self._fileobj.fileno(), blocking):
+                if not self.path.exists() and not self._ignore_deletion:
+                    raise ValueError("Atomic file removed from filesystem")
+                self._owned_by = threading.get_ident()
+                try:
+                    yield
+                finally:
+                    self._owned_by = None
+        finally:
+            self._thdlock.release()
 
     def delete(self) -> None:
         """

--- a/plumbum/machines/paramiko_machine.py
+++ b/plumbum/machines/paramiko_machine.py
@@ -469,8 +469,17 @@ class ParamikoMachine(BaseRemoteMachine):
         f.close()
 
     def _path_stat(self, fn: str) -> RemoteStatRes | None:
+        return self._sftp_stat(self.sftp.stat, fn)
+
+    def _path_lstat(self, fn: str) -> RemoteStatRes | None:
+        return self._sftp_stat(self.sftp.lstat, fn)
+
+    @staticmethod
+    def _sftp_stat(
+        stat_fn: Callable[[str], paramiko.SFTPAttributes], fn: str
+    ) -> RemoteStatRes | None:
         try:
-            st = self.sftp.stat(fn)
+            st = stat_fn(fn)
         except OSError as e:
             if e.errno == errno.ENOENT:
                 return None
@@ -491,9 +500,12 @@ class ParamikoMachine(BaseRemoteMachine):
         )
 
         assert st.st_mode is not None
-        if stat.S_ISDIR(st.st_mode):
+        res.text_mode = ""
+        if stat.S_ISLNK(st.st_mode):
+            res.text_mode = "symbolic link"
+        elif stat.S_ISDIR(st.st_mode):
             res.text_mode = "directory"
-        if stat.S_ISREG(st.st_mode):
+        elif stat.S_ISREG(st.st_mode):
             res.text_mode = "regular file"
         return res
 

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -575,6 +575,10 @@ class BaseRemoteMachine(BaseMachine):
     def _path_delete(self, fn: str) -> None:
         self._session.run(f"rm -rf {shquote(fn)}")
 
+    def _path_unlink(self, fn: str) -> None:
+        # Non-recursive removal: refuses to descend into directories.
+        self._session.run(f"rm -f {shquote(fn)}")
+
     def _path_move(self, src: str, dst: str) -> RemotePath:
         self._session.run(f"mv {shquote(src)} {shquote(dst)}")
         return RemotePath(self, dst)

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -572,6 +572,10 @@ class BaseRemoteMachine(BaseMachine):
         res.text_mode = text_mode
         return res
 
+    def _path_lstat(self, fn: str) -> RemoteStatRes | None:
+        # ``stat`` without -L/--dereference already reports the link itself.
+        return self._path_stat(fn)
+
     def _path_delete(self, fn: str) -> None:
         self._session.run(f"rm -rf {shquote(fn)}")
 

--- a/plumbum/path/local.py
+++ b/plumbum/path/local.py
@@ -275,13 +275,16 @@ class LocalPath(Path):
     ) -> None:
         if not hasattr(os, "chown"):
             raise OSError("os.chown() not supported")
+        # -1 tells os.chown to leave that side unchanged, so an unspecified
+        # owner/group is preserved per-file rather than being forced to the
+        # value read off this path (which would re-own children differently).
         uid = (
-            self.uid
+            -1
             if owner is None
             else (owner if isinstance(owner, int) else getpwnam(owner)[2])
         )
         gid = (
-            self.gid
+            -1
             if group is None
             else (group if isinstance(group, int) else getgrnam(group)[2])
         )

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -273,11 +273,11 @@ class RemotePath(Path):
         (matching :func:`os.unlink` / :meth:`LocalPath.unlink
         <plumbum.path.local.LocalPath.unlink>`); call :meth:`delete` for that.
         """
-        res = self.remote._path_stat(self)
+        # Use lstat so a symlink to a directory is still unlinkable and a
+        # dangling symlink is still found; only a real directory is refused.
+        res = self.remote._path_lstat(self)
         if res is None:
             return
-        # A symlink to a directory is still unlinkable; only a real directory
-        # must be refused.
         if res.text_mode == "directory":
             raise OSError(errno.EISDIR, os.strerror(errno.EISDIR), str(self))
         self.remote._path_unlink(self)
@@ -364,7 +364,8 @@ class RemotePath(Path):
 
         This is a best-effort check: it inspects the file's permission bits but
         does not compare the caller's uid/gid against the file's owner/group, so
-        the owner, group and other bits are all considered. A bare existence
+        the owner, group and other bits are all considered; every requested
+        bit must be granted by some class. A bare existence
         check (``mode=0`` / ``os.F_OK`` / ``"f"``) simply reports whether the
         path exists.
         """
@@ -375,7 +376,8 @@ class RemotePath(Path):
         if mode == 0:  # os.F_OK: existence check only
             return True
         mask = res.st_mode & 0x1FF
-        return bool((mask >> 6) & mode) or bool((mask >> 3) & mode) or bool(mask & mode)
+        merged = (mask >> 6) | (mask >> 3) | mask
+        return (merged & mode) == mode
 
     def link(self, dst: RemotePath | str) -> None:
         if isinstance(dst, RemotePath):

--- a/plumbum/path/remote.py
+++ b/plumbum/path/remote.py
@@ -266,7 +266,21 @@ class RemotePath(Path):
             return
         self.remote._path_delete(self)
 
-    unlink = delete
+    def unlink(self) -> None:
+        """Removes this file or symbolic link.
+
+        Unlike :meth:`delete`, this refuses to recursively remove a directory
+        (matching :func:`os.unlink` / :meth:`LocalPath.unlink
+        <plumbum.path.local.LocalPath.unlink>`); call :meth:`delete` for that.
+        """
+        res = self.remote._path_stat(self)
+        if res is None:
+            return
+        # A symlink to a directory is still unlinkable; only a real directory
+        # must be refused.
+        if res.text_mode == "directory":
+            raise OSError(errno.EISDIR, os.strerror(errno.EISDIR), str(self))
+        self.remote._path_unlink(self)
 
     def move(self, dst: RemotePath | str) -> RemotePath:
         if isinstance(dst, RemotePath):
@@ -346,12 +360,22 @@ class RemotePath(Path):
         self.remote._path_chmod(mode, self)
 
     def access(self, mode: int | str = 0) -> bool:
+        """Test file existence or permission bits.
+
+        This is a best-effort check: it inspects the file's permission bits but
+        does not compare the caller's uid/gid against the file's owner/group, so
+        the owner, group and other bits are all considered. A bare existence
+        check (``mode=0`` / ``os.F_OK`` / ``"f"``) simply reports whether the
+        path exists.
+        """
         mode = self._access_mode_to_flags(mode)
         res = self.remote._path_stat(self)
         if res is None:
             return False
+        if mode == 0:  # os.F_OK: existence check only
+            return True
         mask = res.st_mode & 0x1FF
-        return bool((mask >> 6) & mode) or bool((mask >> 3) & mode)
+        return bool((mask >> 6) & mode) or bool((mask >> 3) & mode) or bool(mask & mode)
 
     def link(self, dst: RemotePath | str) -> None:
         if isinstance(dst, RemotePath):

--- a/tests/test_atomic_extra.py
+++ b/tests/test_atomic_extra.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 import pytest
@@ -32,6 +33,33 @@ def test_atomicfile_locked_raises_when_deleted() -> None:
 
         with pytest.raises(ValueError, match="removed from filesystem"), af.locked():
             pass
+
+
+@skip_on_windows
+def test_atomicfile_locked_nonblocking_thread_does_not_hang() -> None:
+    # When another thread of this process holds the lock, a blocking=False
+    # caller must fail fast (OSError) rather than block on the thread lock.
+    with local.tempdir() as tmp:
+        af = AtomicFile(str(tmp / "atomic.bin"))
+        held = threading.Event()
+        release = threading.Event()
+        errors: list[BaseException] = []
+
+        def holder() -> None:
+            with af.locked():
+                held.set()
+                release.wait(5)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        try:
+            assert held.wait(5)
+            with pytest.raises(OSError), af.locked(blocking=False):
+                pass
+        finally:
+            release.set()
+            t.join(5)
+        assert not errors
 
 
 @skip_on_windows

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -88,6 +88,41 @@ class TestLocalPath:
             p.chown(p.uid.name)
             assert p.uid == os.getuid()
 
+    @skip_on_windows
+    def test_chown_leaves_unspecified_side_unchanged(self, monkeypatch):
+        # When only owner (or only group) is given, the other side must be
+        # passed as -1 ("leave unchanged") rather than the path's current value.
+        calls = []
+        monkeypatch.setattr(
+            os, "chown", lambda _path, uid, gid: calls.append((uid, gid))
+        )
+        with local.tempdir() as dir:
+            p = dir / "foo.txt"
+            p.write(b"hello")
+            calls.clear()
+            p.chown(owner=os.getuid())
+            assert calls == [(os.getuid(), -1)]
+            calls.clear()
+            p.chown(group=os.getgid())
+            assert calls == [(-1, os.getgid())]
+
+    @skip_on_windows
+    def test_chown_recursive_applies_to_children(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            os, "chown", lambda path, uid, gid: calls.append((str(path), uid, gid))
+        )
+        with local.tempdir() as dir:
+            sub = dir / "sub"
+            sub.mkdir()
+            child = sub / "child.txt"
+            child.write(b"x")
+            calls.clear()
+            sub.chown(owner=os.getuid(), recursive=True)
+            # The dir itself and its child both get the change, gid untouched
+            assert (str(sub), os.getuid(), -1) in calls
+            assert (str(child), os.getuid(), -1) in calls
+
     def test_split(self):
         p = local.path("/var/log/messages")
         assert p.split() == ["var", "log", "messages"]

--- a/tests/test_remote_path_logic.py
+++ b/tests/test_remote_path_logic.py
@@ -1,0 +1,104 @@
+"""Pure-logic tests for RemotePath that do not require a live SSH connection.
+
+These exercise RemotePath.access (permission-bit math, F_OK existence) and
+RemotePath.unlink (refusing to recursively delete a directory) by constructing
+the object without invoking ``__new__`` (which would need a real remote) and
+stubbing the ``remote`` attribute with a tiny fake.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+
+import pytest
+
+from plumbum.path.remote import RemotePath, RemoteStatRes
+
+
+def _make_statres(st_mode: int, text_mode: str) -> RemoteStatRes:
+    res = RemoteStatRes((st_mode, 0, 0, 1, 0, 0, 0, 0.0, 0.0, 0.0))
+    res.text_mode = text_mode
+    return res
+
+
+class _FakeRemote:
+    def __init__(self, statres):
+        self._statres = statres
+        self.unlinked: list[str] = []
+        self.deleted: list[str] = []
+
+    def _path_stat(self, _path):
+        return self._statres
+
+    def _path_unlink(self, path):
+        self.unlinked.append(str(path))
+
+    def _path_delete(self, path):
+        self.deleted.append(str(path))
+
+
+def _make_path(statres):
+    # Bypass RemotePath.__new__, which would require a real remote machine.
+    # RemotePath subclasses ``str``, so build it via ``str.__new__`` with the
+    # path text and attach a fake remote.
+    p = str.__new__(RemotePath, "/tmp/thing")
+    p.remote = _FakeRemote(statres)
+    p.CASE_SENSITIVE = True
+    return p
+
+
+def test_access_existence_f_ok():
+    # A file with no permission bits set still "exists" for F_OK / mode 0.
+    p = _make_path(_make_statres(0o000, "regular file"))
+    assert p.access() is True
+    assert p.access(os.F_OK) is True
+    assert p.access("f") is True
+
+
+def test_access_missing_returns_false():
+    p = _make_path(None)
+    assert p.access() is False
+    assert p.access("r") is False
+
+
+def test_access_world_readable_reports_readable():
+    # World-readable only (0o004): owner/group bits are clear, "other" is set.
+    p = _make_path(_make_statres(0o004, "regular file"))
+    assert p.access("r") is True
+    assert p.access("w") is False
+
+
+def test_access_owner_and_group_bits():
+    p = _make_path(_make_statres(0o640, "regular file"))  # rw-r-----
+    assert p.access("r") is True
+    assert p.access("w") is True
+    assert p.access("x") is False
+
+
+def test_unlink_removes_file_non_recursively():
+    p = _make_path(_make_statres(0o644, "regular file"))
+    p.unlink()
+    assert p.remote.unlinked == [str(p)]
+    assert p.remote.deleted == []
+
+
+def test_unlink_removes_symlink():
+    p = _make_path(_make_statres(0o777, "symbolic link"))
+    p.unlink()
+    assert p.remote.unlinked == [str(p)]
+
+
+def test_unlink_refuses_directory():
+    p = _make_path(_make_statres(0o755, "directory"))
+    with pytest.raises(OSError) as exc:
+        p.unlink()
+    assert exc.value.errno == errno.EISDIR
+    assert p.remote.unlinked == []
+    assert p.remote.deleted == []
+
+
+def test_unlink_missing_is_noop():
+    p = _make_path(None)
+    p.unlink()  # should not raise
+    assert p.remote.unlinked == []

--- a/tests/test_remote_path_logic.py
+++ b/tests/test_remote_path_logic.py
@@ -22,14 +22,21 @@ def _make_statres(st_mode: int, text_mode: str) -> RemoteStatRes:
     return res
 
 
+_SAME = object()
+
+
 class _FakeRemote:
-    def __init__(self, statres):
+    def __init__(self, statres, lstatres=_SAME):
         self._statres = statres
+        self._lstatres = statres if lstatres is _SAME else lstatres
         self.unlinked: list[str] = []
         self.deleted: list[str] = []
 
     def _path_stat(self, _path):
         return self._statres
+
+    def _path_lstat(self, _path):
+        return self._lstatres
 
     def _path_unlink(self, path):
         self.unlinked.append(str(path))
@@ -38,12 +45,12 @@ class _FakeRemote:
         self.deleted.append(str(path))
 
 
-def _make_path(statres):
+def _make_path(statres, lstatres=_SAME):
     # Bypass RemotePath.__new__, which would require a real remote machine.
     # RemotePath subclasses ``str``, so build it via ``str.__new__`` with the
     # path text and attach a fake remote.
     p = str.__new__(RemotePath, "/tmp/thing")
-    p.remote = _FakeRemote(statres)
+    p.remote = _FakeRemote(statres, lstatres)
     p.CASE_SENSITIVE = True
     return p
 
@@ -76,6 +83,17 @@ def test_access_owner_and_group_bits():
     assert p.access("x") is False
 
 
+def test_access_combined_mode_requires_all_bits():
+    # r--r--r--: readable but not writable, so R_OK|W_OK must fail.
+    p = _make_path(_make_statres(0o444, "regular file"))
+    assert p.access("r") is True
+    assert p.access("rw") is False
+    assert p.access(os.R_OK | os.W_OK) is False
+    p = _make_path(_make_statres(0o600, "regular file"))
+    assert p.access("rw") is True
+    assert p.access("rwx") is False
+
+
 def test_unlink_removes_file_non_recursively():
     p = _make_path(_make_statres(0o644, "regular file"))
     p.unlink()
@@ -102,3 +120,23 @@ def test_unlink_missing_is_noop():
     p = _make_path(None)
     p.unlink()  # should not raise
     assert p.remote.unlinked == []
+
+
+def test_unlink_symlink_to_directory():
+    # Backends whose stat follows symlinks (Paramiko) report a symlink to a
+    # directory as a directory; unlink must consult the link metadata instead.
+    p = _make_path(
+        _make_statres(0o755, "directory"),
+        lstatres=_make_statres(0o777, "symbolic link"),
+    )
+    p.unlink()
+    assert p.remote.unlinked == [str(p)]
+    assert p.remote.deleted == []
+
+
+def test_unlink_dangling_symlink():
+    # stat on a dangling symlink reports "missing", but the link itself exists
+    # and must still be removed.
+    p = _make_path(None, lstatres=_make_statres(0o777, "symbolic link"))
+    p.unlink()
+    assert p.remote.unlinked == [str(p)]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the review in #820. path / fs correctness edge cases.

> The `Path.with_stem` behavior change moved to #836 to keep this PR bug-fixes-only.

- **`RemotePath.access`** — `F_OK == 0` made existence checks always return `False`, and "other" permission bits were never tested. Now handles F_OK and the other bits (documented best-effort; doesn't compare caller uid/gid).
- **`RemotePath.unlink`** aliased `delete` = `rm -rf`, so unlinking a directory silently destroyed the tree. Now refuses a real directory (raises `EISDIR`) and uses non-recursive `rm -f` for files/symlinks.
- **`LocalPath.chown`** with only one of owner/group re-owned children to the *parent's* uid/gid; now passes `-1` (leave unchanged).
- **`AtomicFile.locked(blocking=False)`** still blocked on the internal thread lock; now acquires it non-blocking and raises rather than hanging.

Tests added (`test_local.py`, `test_atomic_extra.py`, new `test_remote_path_logic.py` — pure-logic, no SSH). `prek -a` clean; pytest green (pre-existing sandbox-only failures unrelated).
