### PR TITLE
fix: Path.parent raises IndexError on filesystem root

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -652,8 +652,13 @@ class Path(str, ABC):
 
     @property
     def parent(self) -> Self:
-        """Pathlib like parent of the path."""
-        return self.parents[0]
+        """Pathlib like parent of the path.
+
+        When called on the root path (e.g. ``/``), returns itself, matching
+        the behaviour of :class:`pathlib.Path`.
+        """
+        parents = self.parents
+        return parents[0] if parents else self
 
 
 class RelativePath:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -205,14 +205,20 @@ class TestLocalPath:
 
     def test_parent_of_root(self):
         """Path.parent on the filesystem root must return itself (not raise IndexError)."""
+        import pathlib
         import sys
 
-        root = local.path("/")
-        assert str(root.parent) == "/", "root.parent should be /"
-        # Must match pathlib behaviour
-        import pathlib
-
-        assert str(root.parent) == str(pathlib.Path("/").parent)
+        # Use the real platform root: on Windows local.path("/") resolves to the
+        # current drive's root (e.g. "D:\"), not the literal string "/".
+        if sys.platform == "win32":
+            root = local.path(pathlib.Path.cwd().anchor)
+        else:
+            root = local.path("/")
+        # Core invariant: parent of root must be root itself (no IndexError).
+        assert root.parent == root, "root.parent should be root itself"
+        # Must match pathlib behaviour for the same root path.
+        pl_root = pathlib.Path(str(root))
+        assert str(root.parent) == str(pl_root.parent)
 
     def test_suffix_expected(self):
         assert self.longpath.preferred_suffix(".tar") == self.longpath

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -203,6 +203,17 @@ class TestLocalPath:
         filename_compare("/some/long/path")
         filename_compare(__file__)
 
+    def test_parent_of_root(self):
+        """Path.parent on the filesystem root must return itself (not raise IndexError)."""
+        import sys
+
+        root = local.path("/")
+        assert str(root.parent) == "/", "root.parent should be /"
+        # Must match pathlib behaviour
+        import pathlib
+
+        assert str(root.parent) == str(pathlib.Path("/").parent)
+
     def test_suffix_expected(self):
         assert self.longpath.preferred_suffix(".tar") == self.longpath
         assert (local.cwd / "this").preferred_suffix(".txt") == local.cwd / "this.txt"


### PR DESCRIPTION
## Summary

`LocalPath('/').parent` (and any `Path` subclass at the filesystem root) raised an
`IndexError` instead of returning the root itself.

**Root cause:** `Path.parents` builds its tuple from
`range(len(self.parts) - 1, 0, -1)`.  For the root path `'/'`, `parts` is
`('/',)`, so that range is empty → `parents` is `()`.  The `parent` property then
did `self.parents[0]`, which raised `IndexError`.

**Fix:** return `self` when `parents` is empty, exactly matching
`pathlib.Path('/').parent == PosixPath('/')`.

```python
# Before (raises IndexError)
from plumbum import local
local.path('/').parent

# After
local.path('/').parent  # → LocalPath('/')
```

A regression test is added to `TestLocalPath`.

---

This pull request was prepared with the assistance of AI, under my direction and review.