### PR TITLE
fix(session): keep the return code off the last line of output

### DIFF
--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -215,13 +215,14 @@ class SessionPopen(PopenAddons):
             self.returncode = "Unknown"  # type: ignore[assignment]
         self._done = True
         stdout_bytes = b"".join(stdout)
-        # the command trailer prints the return code on its own line, so it always
-        # appends a newline to the real output; strip it to return the output verbatim
-        # (e.g. `printf abc` yields b"abc", not b"abc\n"). Under a tty the injected
-        # newline is translated to CRLF, so strip that instead of eating a real "\r".
+        # the command trailer prints the return code (stdout) and the marker
+        # (stderr) on their own lines, so it always appends a newline to the real
+        # output; strip it to return the output verbatim (e.g. `printf abc` yields
+        # b"abc", not b"abc\n"). Under a tty the injected newline is translated to
+        # CRLF, so strip that instead of eating a real "\r".
         newline = b"\r\n" if self.isatty else b"\n"
         stdout_bytes = stdout_bytes.removesuffix(newline)
-        stderr_bytes = b"".join(stderr)
+        stderr_bytes = b"".join(stderr).removesuffix(b"\n")
         return stdout_bytes, stderr_bytes
 
 
@@ -341,7 +342,10 @@ class ShellSession:
             full_cmd = "true ; "
         full_cmd += f"printf '\\n%s\\n' \"$?\" ; echo '{marker}'"
         if not self.isatty:
-            full_cmd += f" ; echo '{marker}' 1>&2"
+            # the leading newline keeps the marker off the last line of stderr
+            # output, just like the return code on stdout; otherwise unterminated
+            # stderr output would hide the marker and hang communicate()
+            full_cmd += f" ; printf '\\n%s\\n' '{marker}' 1>&2"
         if self.custom_encoding:
             full_cmd_bytes = full_cmd.encode(self.custom_encoding)
         else:

--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -215,6 +215,12 @@ class SessionPopen(PopenAddons):
             self.returncode = "Unknown"  # type: ignore[assignment]
         self._done = True
         stdout_bytes = b"".join(stdout)
+        # the command trailer prints the return code on its own line, so it always
+        # appends a newline to the real output; strip it to return the output verbatim
+        # (e.g. `printf abc` yields b"abc", not b"abc\n"). Under a tty the injected
+        # newline is translated to CRLF, so strip that instead of eating a real "\r".
+        newline = b"\r\n" if self.isatty else b"\n"
+        stdout_bytes = stdout_bytes.removesuffix(newline)
         stderr_bytes = b"".join(stderr)
         return stdout_bytes, stderr_bytes
 
@@ -333,7 +339,7 @@ class ShellSession:
             full_cmd += " ; "
         else:
             full_cmd = "true ; "
-        full_cmd += f"echo $? ; echo '{marker}'"
+        full_cmd += f"printf '\\n%s\\n' \"$?\" ; echo '{marker}'"
         if not self.isatty:
             full_cmd += f" ; echo '{marker}' 1>&2"
         if self.custom_encoding:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -784,6 +784,8 @@ class TestLocalMachine:
         assert out.splitlines() == ["17"]
 
     @skip_on_windows
+    # without the fix the stderr case hangs instead of failing an assert
+    @pytest.mark.timeout(20)
     def test_session_no_trailing_newline(self):
         # regression for #494 / #275: output without a trailing newline used to
         # get the return code glued onto it, so parsing failed and returncode
@@ -802,6 +804,21 @@ class TestLocalMachine:
         rc, out, _ = sh.run("sh -c 'printf abc ; exit 3'", retcode=None)
         assert rc == 3
         assert out == "abc"
+
+        # stderr had the same gluing, but there it hid the end-marker and made
+        # communicate() block forever
+        rc, _, err = sh.run("printf err 1>&2")
+        assert rc == 0
+        assert err == "err"
+
+        rc, _, err = sh.run("printf 'FOO\nBAR' 1>&2")
+        assert rc == 0
+        assert err == "FOO\nBAR"
+
+        # newline-terminated stderr must stay verbatim
+        rc, _, err = sh.run("echo err 1>&2")
+        assert rc == 0
+        assert err == "err\n"
 
     def test_quoting(self):
         ssh = local["ssh"]

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -783,6 +783,26 @@ class TestLocalMachine:
         out = sh.run("echo $FOO")[1]
         assert out.splitlines() == ["17"]
 
+    @skip_on_windows
+    def test_session_no_trailing_newline(self):
+        # regression for #494 / #275: output without a trailing newline used to
+        # get the return code glued onto it, so parsing failed and returncode
+        # became the string "Unknown" while the output was corrupted or lost
+        sh = local.session()
+
+        rc, out, _ = sh.run("printf abc")
+        assert rc == 0
+        assert out == "abc"
+
+        rc, out, _ = sh.run("printf 'FOO\nBAR'")
+        assert rc == 0
+        assert out == "FOO\nBAR"
+
+        # a non-zero code must still be reported (not swallowed) for such output
+        rc, out, _ = sh.run("sh -c 'printf abc ; exit 3'", retcode=None)
+        assert rc == 3
+        assert out == "abc"
+
     def test_quoting(self):
         ssh = local["ssh"]
         pwd = local["pwd"]


### PR DESCRIPTION

Fixes #494

The session trailer runs `<cmd> ; echo $? ; echo '<marker>'`, so when a command's output has no trailing newline the return-code digits land on that last line. For `printf abc` the shell writes `abc0`, `int("abc0")` throws, and we fall into the `except` that sets `returncode = "Unknown"` and drops the real output. `session().run("printf abc")` currently returns `("Unknown", "")` instead of `(0, "abc")`.

The fix prints the return code on its own line (`printf '\n%s\n' "$?"`) so it can't share a line with the output, then strips that one injected newline back off. `printf` rather than a bare `echo` because a command in between would reset `$?` first; the strip is tty-aware since a pty turns the injected `\n` into `\r\n`. This is the one marker path that `local`/`SshMachine`/`ParamikoMachine` sessions all share, so it covers local and remote alike.

Regression test in `tests/test_local.py::test_session_no_trailing_newline`, fails on `master` and passes with the fix. Full local suite is green plus ruff/mypy/pylint; the optional SSH suite I couldn't run locally, but `test_remote.py::test_session` exercises the remote path in CI.

One call for you: this is the contained version and leaves the identical stderr-marker case alone to keep scope tight. If you'd rather fix both, the more general route is the reader-level one Henry hinted at on #275 (pick up the sentinel without depending on a newline). Happy to go that way instead.