### PR TITLE
fix(cli): don't change the global SIGPIPE disposition

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -918,6 +918,46 @@ complete -F _{prog_name}_completion {prog_name}
 
         return out_args
 
+    def _parse_and_dispatch(self, argv: list[str]) -> tuple[Application, int]:
+        """Parses ``argv``, runs switches and ``main()``; returns the final
+        instance (the nested subcommand's, if one ran) and the return code."""
+        inst: Application = self
+        retcode: int | None = 0
+        try:
+            swfuncs, tailargs = self._parse_args(argv)
+            ordered, tailargs = self._validate_args(swfuncs, tailargs)
+        except ShowHelp:
+            self.help()
+        except ShowHelpAll:
+            self.helpall()
+        except ShowVersion:
+            self.version()
+        except ShowCompletion:
+            info = swfuncs[self.completions.__func__]  # type: ignore[attr-defined]
+            self._print_completion(info.val[0])
+        except SwitchError as ex:
+            print(T_("Error: {0}").format(ex))
+            print(T_("------"))
+            self.help()
+            retcode = 2
+        else:
+            for f, a in ordered:
+                f(self, *a)
+
+            cleanup = None
+            if not self.nested_command or self.CALL_MAIN_IF_NESTED_COMMAND:
+                retcode = self.main(*tailargs)
+                cleanup = functools.partial(self.cleanup, retcode)
+            if not retcode and self.nested_command:
+                subapp, argv = self.nested_command
+                subapp.parent = self
+                inst, retcode = subapp.run(argv, exit=False)
+
+            if cleanup:
+                cleanup()
+
+        return inst, retcode or 0
+
     @typing.overload
     @classmethod
     def run(
@@ -960,44 +1000,8 @@ complete -F _{prog_name}_completion {prog_name}
         cls.autocomplete(argv)
         argv = list(argv)
         inst = cls(argv.pop(0))
-        retcode = 0
         try:
-            try:
-                swfuncs, tailargs = inst._parse_args(argv)
-                ordered, tailargs = inst._validate_args(swfuncs, tailargs)
-            except ShowHelp:
-                inst.help()
-            except ShowHelpAll:
-                inst.helpall()
-            except ShowVersion:
-                inst.version()
-            except ShowCompletion:
-                info = swfuncs[inst.completions.__func__]  # type: ignore[attr-defined]
-                inst._print_completion(info.val[0])
-            except SwitchError as ex:
-                print(T_("Error: {0}").format(ex))
-                print(T_("------"))
-                inst.help()
-                retcode = 2
-            else:
-                for f, a in ordered:
-                    f(inst, *a)
-
-                cleanup = None
-                if not inst.nested_command or inst.CALL_MAIN_IF_NESTED_COMMAND:
-                    retcode = inst.main(*tailargs)
-                    cleanup = functools.partial(inst.cleanup, retcode)
-                if not retcode and inst.nested_command:
-                    subapp, argv = inst.nested_command
-                    subapp.parent = inst
-                    inst_app, retcode = subapp.run(argv, exit=False)
-                    inst = inst_app  # type: ignore[assignment]
-
-                if cleanup:
-                    cleanup()
-
-                if retcode is None:
-                    retcode = 0
+            inst, retcode = inst._parse_and_dispatch(argv)  # type: ignore[assignment]
         except BrokenPipeError:
             # The reader closed the pipe (e.g. output piped to ``head``).
             # Never change the SIGPIPE disposition instead: that would make a

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -1002,6 +1002,9 @@ complete -F _{prog_name}_completion {prog_name}
         inst = cls(argv.pop(0))
         try:
             inst, retcode = inst._parse_and_dispatch(argv)  # type: ignore[assignment]
+            if exit:
+                # surface an EPIPE now, while we can still handle it below
+                sys.stdout.flush()
         except BrokenPipeError:
             # The reader closed the pipe (e.g. output piped to ``head``).
             # Never change the SIGPIPE disposition instead: that would make a
@@ -1009,7 +1012,7 @@ complete -F _{prog_name}_completion {prog_name}
             retcode = 1
             if exit:
                 # Point stdout at devnull so the interpreter's final flush
-                # doesn't raise a second BrokenPipeError.
+                # doesn't raise on whatever is still buffered.
                 with contextlib.suppress(OSError, ValueError):
                     devnull = os.open(os.devnull, os.O_WRONLY)
                     os.dup2(devnull, sys.stdout.fileno())

--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -955,13 +955,6 @@ complete -F _{prog_name}_completion {prog_name}
            Setting ``exit`` to ``False`` is intended for testing/debugging purposes only -- do
            not override it in other situations.
         """
-        # Handle SIGPIPE to avoid BrokenPipeError when output is piped (e.g., to head)
-        # This is only available on Unix systems
-        with contextlib.suppress(ImportError, AttributeError):
-            import signal
-
-            signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
         if argv is None:
             argv = sys.argv
         cls.autocomplete(argv)
@@ -969,41 +962,53 @@ complete -F _{prog_name}_completion {prog_name}
         inst = cls(argv.pop(0))
         retcode = 0
         try:
-            swfuncs, tailargs = inst._parse_args(argv)
-            ordered, tailargs = inst._validate_args(swfuncs, tailargs)
-        except ShowHelp:
-            inst.help()
-        except ShowHelpAll:
-            inst.helpall()
-        except ShowVersion:
-            inst.version()
-        except ShowCompletion:
-            info = swfuncs[inst.completions.__func__]  # type: ignore[attr-defined]
-            inst._print_completion(info.val[0])
-        except SwitchError as ex:
-            print(T_("Error: {0}").format(ex))
-            print(T_("------"))
-            inst.help()
-            retcode = 2
-        else:
-            for f, a in ordered:
-                f(inst, *a)
+            try:
+                swfuncs, tailargs = inst._parse_args(argv)
+                ordered, tailargs = inst._validate_args(swfuncs, tailargs)
+            except ShowHelp:
+                inst.help()
+            except ShowHelpAll:
+                inst.helpall()
+            except ShowVersion:
+                inst.version()
+            except ShowCompletion:
+                info = swfuncs[inst.completions.__func__]  # type: ignore[attr-defined]
+                inst._print_completion(info.val[0])
+            except SwitchError as ex:
+                print(T_("Error: {0}").format(ex))
+                print(T_("------"))
+                inst.help()
+                retcode = 2
+            else:
+                for f, a in ordered:
+                    f(inst, *a)
 
-            cleanup = None
-            if not inst.nested_command or inst.CALL_MAIN_IF_NESTED_COMMAND:
-                retcode = inst.main(*tailargs)
-                cleanup = functools.partial(inst.cleanup, retcode)
-            if not retcode and inst.nested_command:
-                subapp, argv = inst.nested_command
-                subapp.parent = inst
-                inst_app, retcode = subapp.run(argv, exit=False)
-                inst = inst_app  # type: ignore[assignment]
+                cleanup = None
+                if not inst.nested_command or inst.CALL_MAIN_IF_NESTED_COMMAND:
+                    retcode = inst.main(*tailargs)
+                    cleanup = functools.partial(inst.cleanup, retcode)
+                if not retcode and inst.nested_command:
+                    subapp, argv = inst.nested_command
+                    subapp.parent = inst
+                    inst_app, retcode = subapp.run(argv, exit=False)
+                    inst = inst_app  # type: ignore[assignment]
 
-            if cleanup:
-                cleanup()
+                if cleanup:
+                    cleanup()
 
-            if retcode is None:
-                retcode = 0
+                if retcode is None:
+                    retcode = 0
+        except BrokenPipeError:
+            # The reader closed the pipe (e.g. output piped to ``head``).
+            # Never change the SIGPIPE disposition instead: that would make a
+            # socket send() to a closed peer kill the whole process.
+            retcode = 1
+            if exit:
+                # Point stdout at devnull so the interpreter's final flush
+                # doesn't raise a second BrokenPipeError.
+                with contextlib.suppress(OSError, ValueError):
+                    devnull = os.open(os.devnull, os.O_WRONLY)
+                    os.dup2(devnull, sys.stdout.fileno())
 
         if exit:
             sys.exit(retcode)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,6 +498,39 @@ if __name__ == '__main__':
         assert "Traceback" not in result.stderr, f"Traceback in stderr: {result.stderr}"
 
     @pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="requires SIGPIPE")
+    def test_broken_pipe_at_shutdown_flush(self, tmp_path):
+        """Output still buffered when the reader is gone must not print
+        'Exception ignored ... BrokenPipeError' at interpreter shutdown."""
+        import subprocess
+        import sys
+
+        script = tmp_path / "straggler.py"
+        script.write_text(
+            f"""
+import sys, time
+sys.path.insert(0, {str(local.cwd)!r})
+from plumbum.cli import Application
+
+class App(Application):
+    def main(self):
+        print("1\\n2\\n3\\n4\\n5", flush=True)
+        time.sleep(0.5)  # let head exit
+        print("straggler")  # stays in the buffer until shutdown
+
+if __name__ == '__main__':
+    App.run()
+"""
+        )
+        result = subprocess.run(
+            f"{sys.executable} {script} | head -5",
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.stderr == ""
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="requires SIGPIPE")
     def test_run_keeps_sigpipe_disposition(self):
         # SIG_DFL would make a socket send() to a closed peer kill the whole
         # process (e.g. an rpyc server) instead of raising BrokenPipeError.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import signal
+
+import pytest
+
 from plumbum import cli, local
 from plumbum.cli.switches import SwitchInfo
 from plumbum.cli.terminal import get_terminal_size
@@ -492,6 +496,27 @@ if __name__ == '__main__':
         )
         # No traceback should be in stderr
         assert "Traceback" not in result.stderr, f"Traceback in stderr: {result.stderr}"
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="requires SIGPIPE")
+    def test_run_keeps_sigpipe_disposition(self):
+        # SIG_DFL would make a socket send() to a closed peer kill the whole
+        # process (e.g. an rpyc server) instead of raising BrokenPipeError.
+        before = signal.getsignal(signal.SIGPIPE)
+        try:
+            _, rc = SimpleApp.run(["foo", "--bacon=2"], exit=False)
+        finally:
+            after = signal.getsignal(signal.SIGPIPE)
+            signal.signal(signal.SIGPIPE, before)
+        assert rc == 0
+        assert after == before
+
+    def test_run_handles_broken_pipe(self):
+        class BrokenApp(cli.Application):
+            def main(self):
+                raise BrokenPipeError
+
+        _, rc = BrokenApp.run(["app"], exit=False)
+        assert rc == 1
 
 
 class ExcludesApp(cli.Application):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Since 2.0.1 (#727), `Application.run()` set SIGPIPE to `SIG_DFL` process-wide. A user reported that this intermittently killed their rpyc servers on Fedora 43: rpyc's entry points are plumbum `Application`s, and with `SIG_DFL` a socket `send()` to a peer that already closed delivers a fatal SIGPIPE instead of raising `BrokenPipeError`. The Python docs warn against exactly this: https://docs.python.org/3/library/signal.html#note-on-sigpipe

This removes the signal change and instead catches `BrokenPipeError` around the body of `run()`, redirecting stdout to devnull before exit so the interpreter's final flush doesn't raise again — the pattern the docs recommend. The piped-help fix from #727 still works, and its test still passes.

Adds two regression tests: `run()` leaves the SIGPIPE disposition alone, and a `BrokenPipeError` from `main()` returns exit code 1. Both fail without the fix. Probably worth a 2.0.2 patch release.