### PR TITLE
fix(cli)!: case-insensitive Set yields the canonical spelling

### DIFF
--- a/plumbum/cli/switches.py
+++ b/plumbum/cli/switches.py
@@ -555,15 +555,13 @@ class Set(Validator[str]):
             for v in value.split(self.csv):
                 yield from self._call_iter(v.strip(), check_csv=False)
 
-        if not self.case_sensitive:
-            value = value.lower()
+        cmp_value = value if self.case_sensitive else value.lower()
 
         for opt in self.values:
             if isinstance(opt, str):
-                if not self.case_sensitive:
-                    opt = opt.lower()  # noqa: PLW2901
-                if opt == value or value in self.all_markers:
-                    yield opt  # always return original value
+                cmp_opt = opt if self.case_sensitive else opt.lower()
+                if cmp_opt == cmp_value or cmp_value in self.all_markers:
+                    yield opt  # always return the configured (canonical) value
                 continue
             with contextlib.suppress(ValueError):
                 yield opt(value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,8 +209,9 @@ class TestCLI:
         _, rc = SimpleApp.run(["foo", "--bacon=81", "--csv=all,100"], exit=False)
         assert rc == 0
         output = capsys.readouterr()
-        assert "min" in output.out
-        assert "max" in output.out
+        # case-insensitive Set yields the canonical (configured) spelling
+        assert "MIN" in output.out
+        assert "MAX" in output.out
         assert "100" in output.out
 
         _, rc = SimpleApp.run(["foo", "--bacon=81", "--num=MAX"], exit=False)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
 from plumbum import cli
+from plumbum.cli.switches import Set
+
+
+class TestSet:
+    def test_case_insensitive_returns_canonical(self):
+        # Regression: case-insensitive matching must yield the configured
+        # (canonical) spelling, not the lowercased user input.
+        s = Set("TCP", "UDP")
+        assert s("tcp") == "TCP"
+        assert s("UDP") == "UDP"
 
 
 class TestValidator:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Split out of #824 so that PR stays bug-fixes-only.

Case-insensitive `Set` now yields the configured (canonical) spelling instead of the lowercased user input, e.g. `Set("TCP", "UDP")("tcp") == "TCP"`. This is a behavior change. One existing test was updated to expect the canonical spelling.
