### PR TITLE
fix!: with_stem keeps only the final suffix (pathlib semantics)

### DIFF
--- a/plumbum/path/base.py
+++ b/plumbum/path/base.py
@@ -265,7 +265,7 @@ class Path(str, ABC):
 
         .. versionadded:: 2.0
         """
-        return self.with_name(stem + "".join(self.suffixes))
+        return self.with_name(stem + self.suffix)
 
     @abstractmethod
     def glob(self, pattern: str) -> builtins.list[Self]:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -109,6 +109,16 @@ class TestLocalPath:
         with pytest.raises(ValueError):
             p1.with_suffix("nodot")
 
+    def test_with_stem(self):
+        p1 = local.path("/some/long/path/to/file.txt")
+        p2 = local.path("file.tar.gz")
+        # Only the last suffix is preserved (pathlib semantics)
+        assert p2.with_stem("x") == local.path("x.gz")
+        assert p1.with_stem("other") == local.path("/some/long/path/to/other.txt")
+        # Round-trip invariant: replacing the stem with itself is a no-op
+        assert p1.with_stem(p1.stem) == p1
+        assert p2.with_stem(p2.stem) == p2
+
     def test_newname(self):
         # This picks up the drive letter differently if not constructed here
         p1 = local.path("/some/long/path/to/file.txt")
@@ -257,7 +267,8 @@ class TestLocalPath:
             assert renamed.name == "renamed.txt"
 
             long_name = tmp / "file.with.many.dots.txt"
-            assert long_name.with_stem("new").name == "new.with.many.dots.txt"
+            # with_stem replaces only the last suffix (pathlib semantics)
+            assert long_name.with_stem("new").name == "new.txt"
 
             assert nested.match("*.txt")
             assert nested.match("b/*.txt")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Split out of #825 to isolate the one behavior change from the bug fixes.

`with_stem` now keeps only the final suffix, matching `pathlib`:
`local.path("b.tar.gz").with_stem("x")` returns `x.gz` (was `x.tar.gz`).
This makes `p.with_stem(p.stem)` a no-op.

This is a behavior change, so one existing assertion in `test_local.py`
was updated to expect the new result.
