### PR TITLE
fix(cli): ignore annotations for non-positional main parameters

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -897,7 +897,7 @@ complete -F _{prog_name}_completion {prog_name}
             for item, annotation in annotations.items():
                 if item == m.varargs:
                     varargs = annotation
-                elif item != "return":
+                elif item in args_names:
                     positional[args_names.index(item)] = annotation
 
             new_tailargs = self._positional_validate(

--- a/tests/test_cli_annotations.py
+++ b/tests/test_cli_annotations.py
@@ -8,8 +8,20 @@ class App(Application):
         print(f"file={file.name}")
 
 
+class KeywordOnlyApp(Application):
+    def main(self, file: ExistingFile, *, verbose: bool = False):
+        print(f"file={file.name} verbose={verbose}")
+
+
 def test_access_annotations(capsys):
     _, rc = App.run(["prog", "pyproject.toml"], exit=False)
     assert rc == 0
     stdout, _ = capsys.readouterr()
     assert "file=pyproject.toml" in stdout
+
+
+def test_annotated_keyword_only_argument(capsys):
+    _, rc = KeywordOnlyApp.run(["prog", "pyproject.toml"], exit=False)
+    assert rc == 0
+    stdout, _ = capsys.readouterr()
+    assert "file=pyproject.toml verbose=False" in stdout


### PR DESCRIPTION
Helps with #755

An annotated keyword-only parameter on `main()` made `_validate_args` call `args_names.index(item)` for a name that is not a positional argument, raising `ValueError: 'verbose' is not in list` before the app could run (same shape as the reported `'FileArgument' is not in list` when a decorator reshapes the signature). Annotations are now only looked up when they name an actual positional argument.

Regression test in `tests/test_cli_annotations.py` fails with that `ValueError` without the change and passes with it.
