### PR TITLE
fix(cli): read main's signature through wraps decorators

### DIFF
--- a/plumbum/cli/application.py
+++ b/plumbum/cli/application.py
@@ -804,6 +804,15 @@ complete -F _{prog_name}_completion {prog_name}
             # TODO: This is required to handle (correctly) None, but probably could be done better
             return NotImplemented  # type: ignore[no-any-return]
 
+    def _main_argspec(self) -> inspect.FullArgSpec:
+        """Get the argspec of main, looking through functools.wraps decorators.
+
+        A wrapper usually declares ``*args, **kwargs``, but copies the
+        annotations of the function it wraps, so the two must be read from the
+        same place for the names to match.
+        """
+        return inspect.getfullargspec(inspect.unwrap(self.main))
+
     def _validate_args(
         self,
         swfuncs: dict[Callable[..., Any], SwitchParseInfo],
@@ -856,7 +865,7 @@ complete -F _{prog_name}_completion {prog_name}
                     )
                 )
 
-        m = inspect.getfullargspec(self.main)
+        m = self._main_argspec()
 
         max_args = sys.maxsize if m.varargs else len(m.args) - 1
         min_args = len(m.args) - 1 - (len(m.defaults) if m.defaults else 0)
@@ -888,12 +897,14 @@ complete -F _{prog_name}_completion {prog_name}
             )
 
         elif hasattr(m, "annotations") and m.annotations:
-            annotations = typing.get_type_hints(self.main)
+            # Unwrapped too: string annotations resolve in the wrapped
+            # function's module, not the decorator's
+            annotations = typing.get_type_hints(inspect.unwrap(self.main))
             args_names = list(m.args[1:])
             positional: list[Any] = [None] * len(args_names)
             varargs = None
 
-            # All args are positional, so convert kargs to positional
+            # Only annotations that name a positional argument are validators
             for item, annotation in annotations.items():
                 if item == m.varargs:
                     varargs = annotation
@@ -1276,7 +1287,7 @@ complete -F _{prog_name}_completion {prog_name}
             for line in wrapped_paragraphs(self.DESCRIPTION_MORE, cols):
                 print(line)
 
-        m = inspect.getfullargspec(self.main)
+        m = self._main_argspec()
         tailargs_str = m.args[1:]  # skip self
         if m.defaults:
             for i, d in enumerate(reversed(m.defaults)):

--- a/tests/test_cli_annotations.py
+++ b/tests/test_cli_annotations.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
+import functools
+
 from plumbum.cli import Application, ExistingFile
+
+
+def passthrough(func):
+    """A decorator that reshapes the signature, as in #755."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 class App(Application):
@@ -11,6 +23,17 @@ class App(Application):
 class KeywordOnlyApp(Application):
     def main(self, file: ExistingFile, *, verbose: bool = False):
         print(f"file={file.name} verbose={verbose}")
+
+
+class KeywordArgsApp(Application):
+    def main(self, file: ExistingFile, **kwargs: str):
+        print(f"file={file.name} kwargs={kwargs}")
+
+
+class DecoratedApp(Application):
+    @passthrough
+    def main(self, file: ExistingFile):
+        print(f"file={file.name}")
 
 
 def test_access_annotations(capsys):
@@ -25,3 +48,36 @@ def test_annotated_keyword_only_argument(capsys):
     assert rc == 0
     stdout, _ = capsys.readouterr()
     assert "file=pyproject.toml verbose=False" in stdout
+
+
+def test_annotated_var_keyword_argument(capsys):
+    _, rc = KeywordArgsApp.run(["prog", "pyproject.toml"], exit=False)
+    assert rc == 0
+    stdout, _ = capsys.readouterr()
+    assert "file=pyproject.toml kwargs={}" in stdout
+
+
+def test_decorated_main_validates(capsys):
+    _, rc = DecoratedApp.run(["prog", "pyproject.toml"], exit=False)
+    assert rc == 0
+    stdout, _ = capsys.readouterr()
+    assert "file=pyproject.toml" in stdout
+
+    _, rc = DecoratedApp.run(["prog", "no-such-file.txt"], exit=False)
+    assert rc == 2
+    stdout, _ = capsys.readouterr()
+    assert "no-such-file.txt" in stdout
+
+
+def test_decorated_main_arity(capsys):
+    _, rc = DecoratedApp.run(["prog", "pyproject.toml", "extra"], exit=False)
+    assert rc == 2
+    stdout, _ = capsys.readouterr()
+    assert "Expected at most 1 positional argument" in stdout
+
+
+def test_decorated_main_usage(capsys):
+    _, rc = DecoratedApp.run(["prog", "--help"], exit=False)
+    assert rc == 0
+    stdout, _ = capsys.readouterr()
+    assert "prog [SWITCHES] file" in stdout


### PR DESCRIPTION
Close #755.

:robot: _AI text below_ :robot:

Follow-up to #838, which stopped the crash from issue #755 but left the underlying mismatch in place.

`inspect.getfullargspec` does not follow `__wrapped__`, so a `main()` behind a `functools.wraps` decorator was read as the wrapper's `(*args, **kwargs)`, while `typing.get_type_hints` returned the inner function's annotations. The names never matched, so:

- annotation validators were silently skipped — `file: ExistingFile` arrived as a plain `str`, unvalidated;
- arity was unbounded, because the wrapper's `*args` set `max_args` to unlimited;
- `--help` showed `prog [SWITCHES] args...` instead of the real parameter names.

Both introspection sites now read the unwrapped function. `get_type_hints` is unwrapped as well: string annotations (under `from __future__ import annotations`) resolve against `__globals__`, which for a wrapper is the decorator's module, not the module where the validator is imported.

Undecorated applications are unaffected — `inspect.unwrap` returns the bound method unchanged.

Tests were written first: the three decorated-`main` tests fail before the change (`AttributeError` on `str.name`, `TypeError` from extra arguments, wrong usage string) and pass after. A test for an annotated `**kwargs` guards the case #838 fixed.

One related problem is left open: a keyword-only parameter without a default still raises `TypeError` when `main()` is called, because plumbum has no way to supply a value for it. A definition-time error would be better, but it changes behavior and belongs in its own PR.
