### PR TITLE
fix: honor timeout when a grandchild keeps the pipes open

### DIFF
--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -407,22 +407,28 @@ def _communicate(proc: PopenWithAddons[Any], timeout: float | None) -> tuple[Any
     already-set ``_timed_out`` flag then makes ``verify()`` raise
     ``ProcessTimedOut`` as usual.
     """
-    if timeout is None:
+    # Popen-like objects (remote/session procs) may not accept a timeout.
+    if timeout is None or not getattr(proc, "communicate_supports_timeout", False):
         return proc.communicate()
     try:
         # Give the timeout thread a moment to kill the process first, so a
         # normally-terminating process still reports its real exit code.
         return proc.communicate(timeout=timeout + 1)  # type: ignore[call-arg]
-    except TypeError:
-        # Popen-like objects (remote/session procs) may not accept a timeout.
-        return proc.communicate()
-    except subprocess.TimeoutExpired:
-        proc._timed_out = True  # type: ignore[attr-defined]
+    except subprocess.TimeoutExpired as ex:
+        # Only the pipes timed out. If the process itself is still running,
+        # the timeout thread did not get to it, so kill it here.
+        if proc.poll() is None:
+            proc._timed_out = True  # type: ignore[attr-defined]
+            with contextlib.suppress(Exception):
+                proc.kill()
+        # A grandchild still holds the pipes, so keep this wait bounded too.
         with contextlib.suppress(Exception):
-            proc.kill()
-        with contextlib.suppress(Exception):
-            proc.wait()
-        return b"", b""
+            proc.wait(timeout=1)  # type: ignore[call-arg]
+        if IS_WIN32:
+            # communicate() leaves its reader threads running on these pipes
+            # and closes them itself once the grandchild is gone.
+            proc.close_streams_after_communicate = False  # type: ignore[attr-defined]
+        return ex.stdout, ex.stderr
 
 
 # ===================================================================================================

--- a/plumbum/commands/processes.py
+++ b/plumbum/commands/processes.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-__lazy_modules__ = {"atexit", "contextlib", "heapq", "itertools"}
+__lazy_modules__ = {"atexit", "contextlib", "heapq", "itertools", "subprocess"}
 
 import atexit
 import contextlib
 import enum
 import heapq
 import itertools
+import subprocess
 import sys
 import time
 import typing
@@ -18,7 +19,6 @@ from typing import Any
 from plumbum.lib import IS_WIN32
 
 if typing.TYPE_CHECKING:
-    import subprocess
     from collections.abc import Callable, Container, Generator
     from typing import IO, Literal
 
@@ -397,6 +397,34 @@ def _terminate_and_reap(proc: PopenWithAddons[Any], grace: float = 1.0) -> None:
         proc.wait()
 
 
+def _communicate(proc: PopenWithAddons[Any], timeout: float | None) -> tuple[Any, Any]:
+    """Like ``proc.communicate()``, but does not block past the timeout.
+
+    The timeout thread kills *proc* itself, but ``communicate()`` waits for
+    EOF on the pipes, and a grandchild that inherited them keeps them open --
+    so the call would block forever even though *proc* is already dead.
+    Passing the timeout through to ``communicate()`` bounds that wait; the
+    already-set ``_timed_out`` flag then makes ``verify()`` raise
+    ``ProcessTimedOut`` as usual.
+    """
+    if timeout is None:
+        return proc.communicate()
+    try:
+        # Give the timeout thread a moment to kill the process first, so a
+        # normally-terminating process still reports its real exit code.
+        return proc.communicate(timeout=timeout + 1)  # type: ignore[call-arg]
+    except TypeError:
+        # Popen-like objects (remote/session procs) may not accept a timeout.
+        return proc.communicate()
+    except subprocess.TimeoutExpired:
+        proc._timed_out = True  # type: ignore[attr-defined]
+        with contextlib.suppress(Exception):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            proc.wait()
+        return b"", b""
+
+
 # ===================================================================================================
 # run_proc
 # ===================================================================================================
@@ -426,7 +454,7 @@ def run_proc(
     stdout: bytes | str
     stderr: bytes | str
     try:
-        stdout, stderr = proc.communicate()
+        stdout, stderr = _communicate(proc, timeout)
         proc._end_time = time.time()  # type: ignore[attr-defined]
         if not stdout:
             stdout = b""

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -49,6 +49,7 @@ if typing.TYPE_CHECKING:
 
 class PlumbumLocalPopen(PopenAddons):
     iter_lines = iter_lines
+    communicate_supports_timeout = True
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._proc = Popen(*args, **kwargs)  # pylint: disable=consider-using-with

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -628,11 +628,26 @@ class TestLocalMachine:
         # waiting for EOF. See issue #685.
         from plumbum.cmd import sh
 
-        cmd = sh["-c", "sleep 30 & wait"]
-        start = time.time()
-        with pytest.raises(ProcessTimedOut):
-            cmd(timeout=1)
-        assert time.time() - start < 15
+        with local.tempdir() as tmp:
+            pidfile = tmp / "pid"
+            cmd = sh["-c", f"sleep 30 & echo $! >{pidfile}; wait"]
+            start = time.time()
+            with pytest.raises(ProcessTimedOut):
+                cmd(timeout=1)
+            assert time.time() - start < 5
+            os.kill(int(pidfile.read().strip()), signal.SIGKILL)
+
+    @skip_on_windows
+    def test_timeout_ignored_when_child_exits_in_time(self):
+        # A grandchild holding the pipes open must not turn a child that
+        # finished in time into a timeout.
+        from plumbum.cmd import sh
+
+        with local.tempdir() as tmp:
+            pidfile = tmp / "pid"
+            cmd = sh["-c", f"echo hi; sleep 30 & echo $! >{pidfile}; exit 0"]
+            assert cmd(timeout=1).strip() == "hi"
+            os.kill(int(pidfile.read().strip()), signal.SIGKILL)
 
     @skip_on_windows
     def test_pipe_stderr(self, capfd):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -622,6 +622,19 @@ class TestLocalMachine:
             sleep(3, timeout=1)
 
     @skip_on_windows
+    def test_timeout_with_surviving_grandchild(self):
+        # The timeout thread kills the direct child, but a grandchild that
+        # inherited the pipes keeps them open, so communicate() must not block
+        # waiting for EOF. See issue #685.
+        from plumbum.cmd import sh
+
+        cmd = sh["-c", "sleep 30 & wait"]
+        start = time.time()
+        with pytest.raises(ProcessTimedOut):
+            cmd(timeout=1)
+        assert time.time() - start < 15
+
+    @skip_on_windows
     def test_pipe_stderr(self, capfd):
         from plumbum.cmd import cat, head
 


### PR DESCRIPTION
Closes #685

`local["sh"]["-c", "sleep 30 & wait"](timeout=1)` hangs forever. The timeout thread kills the direct child, but `run_proc` waits in `proc.communicate()`, which returns only on EOF of the pipes — a grandchild that inherited stdout/stderr keeps them open, so the call blocks indefinitely even though the child is already dead and `_timed_out` is set.

`communicate()` now receives the timeout so the wait is bounded; on expiry the process is killed, reaped, and `verify()` raises `ProcessTimedOut` as usual. Popen-like objects that do not accept a `timeout` argument fall back to the previous behavior.

The new `test_timeout_with_surviving_grandchild` hangs to the 30s cap and fails on `master`, and passes in 3s with the fix.
