### PR TITLE
fix: render bytes arguments as text instead of repr

### DIFF
--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -12,6 +12,7 @@ __lazy_modules__ = {
 
 import contextlib
 import functools
+import os
 import shlex
 import subprocess
 import typing
@@ -69,10 +70,20 @@ class RedirectionError(Exception):
 # ===================================================================================================
 # Utilities
 # ===================================================================================================
+def _stringify(value: Any) -> str:
+    """Renders a command-line argument as text.
+
+    ``bytes`` are decoded with :func:`os.fsdecode` rather than going through
+    ``str()``, which would render them as their ``repr`` (``b'test'``).
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return os.fsdecode(bytes(value))
+    return str(value)
+
+
 def shquote(text: Any) -> str:
     """Quotes the given text with shell escaping (assumes as syntax similar to ``sh``)"""
-    text = str(text)
-    return shlex.quote(text)
+    return shlex.quote(_stringify(text))
 
 
 def shquote_list(seq: Sequence[Any]) -> list[str]:
@@ -695,10 +706,11 @@ class ConcreteCommand(BaseCommand):
                     argv.extend(a.formulate(level + 1))
             elif isinstance(a, (list, tuple)):
                 argv.extend(
-                    shquote(b) if level >= self.QUOTE_LEVEL else str(b) for b in a
+                    shquote(b) if level >= self.QUOTE_LEVEL else _stringify(b)
+                    for b in a
                 )
             else:
-                argv.append(shquote(a) if level >= self.QUOTE_LEVEL else str(a))
+                argv.append(shquote(a) if level >= self.QUOTE_LEVEL else _stringify(a))
         return argv
 
     @property

--- a/plumbum/commands/base.py
+++ b/plumbum/commands/base.py
@@ -74,7 +74,11 @@ def _stringify(value: Any) -> str:
     """Renders a command-line argument as text.
 
     ``bytes`` are decoded with :func:`os.fsdecode` rather than going through
-    ``str()``, which would render them as their ``repr`` (``b'test'``).
+    ``str()``, which would render them as their ``repr`` (``b'test'``). On
+    POSIX this round-trips any byte string, because ``subprocess`` encodes the
+    argument back with :func:`os.fsencode`. On Windows, and for remote
+    machines, only bytes that the local filesystem encoding can decode are
+    supported; other bytes raise ``UnicodeDecodeError``.
     """
     if isinstance(value, (bytes, bytearray, memoryview)):
         return os.fsdecode(bytes(value))
@@ -390,7 +394,7 @@ class BoundCommand(BaseCommand):
     def popen(
         self, args: Sequence[Any] | str = (), **kwargs: Any
     ) -> PopenWithAddons[str]:
-        if isinstance(args, str):
+        if isinstance(args, (str, bytes, bytearray)):
             args = [
                 args,
             ]

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -172,7 +172,7 @@ class LocalCommand(ConcreteCommand):
         env: dict[str, str] | BaseEnv[LocalPath] | None = None,
         **kwargs: Any,
     ) -> PopenWithAddons[str]:
-        if isinstance(args, str):
+        if isinstance(args, (str, bytes, bytearray)):
             args = (args,)
         return self.machine._popen(
             self.executable,

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1322,3 +1322,24 @@ def test_is_recursive_glob(pattern, expected):
     from plumbum.machines.remote import _is_recursive_glob
 
     assert _is_recursive_glob(pattern) is expected
+
+
+class TestBytesArguments:
+    """``bytes`` arguments must be decoded, not rendered via ``repr``.
+
+    See https://github.com/tomerfiliba/plumbum/issues/600
+    """
+
+    def test_shquote_bytes(self):
+        from plumbum.commands import shquote
+
+        assert shquote(b"test") == "test"
+        assert shquote(b"a b") == "'a b'"
+
+    @skip_on_windows
+    def test_bytes_argument(self):
+        assert local["echo"](b"test").strip() == "test"
+
+    @skip_on_windows
+    def test_bytes_argument_in_list(self):
+        assert local["echo"][[b"a", b"b"]]().split() == ["a", "b"]

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1342,4 +1342,13 @@ class TestBytesArguments:
 
     @skip_on_windows
     def test_bytes_argument_in_list(self):
-        assert local["echo"][[b"a", b"b"]]().split() == ["a", "b"]
+        # A nested list is one argument that formulate() expands in place
+        assert local["echo"].formulate(0, [[b"a", b"b"]])[1:] == ["a", "b"]
+        assert local["echo"].run([[b"a", b"b"]])[1].split() == ["a", "b"]
+
+    @skip_on_windows
+    def test_bytes_as_only_argument(self):
+        # bytes must not be iterated like a sequence of arguments
+        assert local["echo"].run(b"ab")[1].strip() == "ab"
+        assert local["echo"].run(bytearray(b"ab"))[1].strip() == "ab"
+        assert local["echo"]["x"].run(b"ab")[1].split() == ["x", "ab"]


### PR DESCRIPTION
Closes #600

`local["echo"](b"test")` passed the `bytes` through `str()`, so the child process received the literal `b'test'` instead of `test`. Arguments now go through a small `_stringify` helper that decodes bytes with `os.fsdecode`, used by both `shquote` and the unquoted `formulate` paths.

Added `TestBytesArguments` in `tests/test_local.py` (fails on master, passes with the fix). Command *names* still require `str`; this covers arguments only.
