### PR TITLE
fix(cli): select translation language from LC_MESSAGES, not LC_CTYPE

### DIFF
--- a/plumbum/cli/i18n.py
+++ b/plumbum/cli/i18n.py
@@ -5,7 +5,9 @@ __lazy_modules__ = {"gettext", "importlib", "importlib.resources"}
 import locale
 
 # High performance method for English (no translation needed)
-loc = locale.getlocale()[0]
+# LC_MESSAGES is the correct category for selecting a message translation,
+# but it's not available on Windows, so fall back to the getlocale() default.
+loc = locale.getlocale(getattr(locale, "LC_MESSAGES", locale.LC_CTYPE))[0]
 if loc is None or loc.startswith("en") or loc == "C":
 
     class NullTranslation:

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -59,3 +59,37 @@ def test_help_lang(capsys):
     stdout, _ = capsys.readouterr()
     assert "Utilisation" in stdout
     assert "Imprime ce message d'aide et sort" in stdout
+
+
+@pytest.fixture
+def french_ctype_only():
+    if not hasattr(locale, "LC_MESSAGES"):
+        pytest.skip("LC_MESSAGES is not available on this platform")
+
+    try:
+        locale.setlocale(locale.LC_CTYPE, "fr_FR.utf-8")
+        locale.setlocale(locale.LC_MESSAGES, "C")
+        reload_cli()
+        yield
+    except locale.Error:
+        pytest.skip(
+            "No fr_FR locale found, run 'sudo locale-gen fr_FR.UTF-8' to run this test"
+        )
+    finally:
+        locale.setlocale(locale.LC_ALL, "")
+        reload_cli()
+
+
+@pytest.mark.usefixtures("french_ctype_only")
+def test_help_lang_follows_lc_messages_not_lc_ctype(capsys):
+    class Simple(plumbum.cli.Application):
+        foo = plumbum.cli.SwitchAttr("--foo")
+
+        def main(self):
+            pass
+
+    _, rc = Simple.run(["foo", "-h"], exit=False)
+    assert rc == 0
+    stdout, _ = capsys.readouterr()
+    assert "Usage" in stdout
+    assert "Utilisation" not in stdout


### PR DESCRIPTION
locale.getlocale() defaults to the LC_CTYPE category, which controls character classification/encoding, not message language. This meant setting LC_CTYPE (e.g. for correct string handling) alone could force translated CLI messages even when LC_MESSAGES/LANG requested English.

Explicitly query LC_MESSAGES, the POSIX category meant for this, falling back to the previous LC_CTYPE-based default on platforms (Windows) where LC_MESSAGES doesn't exist.