### PR TITLE
fix: parse ps output by header column offsets

### DIFF
--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-__lazy_modules__ = {"inspect", "io"}
+__lazy_modules__ = {"inspect", "io", "re"}
 
 import inspect
 import os
+import re
 import sys
 from contextlib import contextmanager
 from io import StringIO
@@ -31,19 +32,30 @@ class ProcInfo:
 def _parse_ps_lines(lines: list[str]) -> Generator[ProcInfo, None, None]:
     """Parse the output of ``ps -e -o pid,uid,stat,args``.
 
-    The args column is located by its offset in the header line rather than by
-    whitespace splitting, because ``ps`` may emit an empty STAT field, which
-    would otherwise shift every following field.
+    A plain whitespace split is not sufficient, because ``ps`` can emit an empty
+    STAT field, which makes the command line look like the STAT value. The args
+    column of the header tells the two cases apart: a field that starts at or
+    after that column is the command line, not a STAT value.
     """
-    header = lines[0]
-    # The args column is the last header field; its name differs between
+    # The last header field is the args column; its name differs between
     # implementations ("ARGS" on BSD/Darwin, "COMMAND" on Linux).
-    args_offset = len(header) - len(header.split()[-1])
+    fields = list(re.finditer(r"\S+", lines[0]))
+    uid_end = fields[1].end()
+    args_start = fields[-1].start()
     for line in lines[1:]:
-        pid, uid, *stat = line[:args_offset].split()
-        yield ProcInfo(
-            int(pid), int(uid), stat[0] if stat else "", line[args_offset:].strip()
-        )
+        match = re.match(r"\s*(\d+)\s+(\d+)", line)
+        if match is None:
+            raise ValueError(f"Unexpected ps output line: {line!r}")
+        rest = line[match.end() :]
+        stat_start = match.end() + len(rest) - len(rest.lstrip())
+        # ps sizes each column to its widest value but does not pad the header
+        # to match, so move the args column right by as much as this row
+        # overflows the header.
+        if stat_start >= args_start + max(0, match.end() - uid_end):
+            stat, args = "", rest.strip()
+        else:
+            stat, _, args = rest.strip().partition(" ")
+        yield ProcInfo(int(match[1]), int(match[2]), stat, args.strip())
 
 
 @contextmanager

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -28,6 +28,24 @@ class ProcInfo:
         return f"{self.__class__.__name__}({self.pid!r}, {self.uid!r}, {self.stat!r}, {self.args!r})"
 
 
+def _parse_ps_lines(lines: list[str]) -> Generator[ProcInfo, None, None]:
+    """Parse the output of ``ps -e -o pid,uid,stat,args``.
+
+    The args column is located by its offset in the header line rather than by
+    whitespace splitting, because ``ps`` may emit an empty STAT field, which
+    would otherwise shift every following field.
+    """
+    header = lines[0]
+    # The args column is the last header field; its name differs between
+    # implementations ("ARGS" on BSD/Darwin, "COMMAND" on Linux).
+    args_offset = len(header) - len(header.split()[-1])
+    for line in lines[1:]:
+        pid, uid, *stat = line[:args_offset].split()
+        yield ProcInfo(
+            int(pid), int(uid), stat[0] if stat else "", line[args_offset:].strip()
+        )
+
+
 @contextmanager
 def captured_stdout(stdin: str = "") -> Generator[TextIO, None, None]:
     """

--- a/plumbum/machines/local.py
+++ b/plumbum/machines/local.py
@@ -32,7 +32,7 @@ from typing import Any, ClassVar
 from plumbum.commands import CommandNotFound, ConcreteCommand
 from plumbum.commands.daemons import posix_daemonize, win32_daemonize
 from plumbum.commands.processes import iter_lines
-from plumbum.lib import IS_WIN32, ProcInfo, StaticProperty
+from plumbum.lib import IS_WIN32, ProcInfo, StaticProperty, _parse_ps_lines
 from plumbum.machines.base import BaseMachine, PopenAddons, PopenWithAddons
 from plumbum.machines.env import BaseEnv
 from plumbum.machines.session import ShellSession
@@ -434,12 +434,7 @@ class LocalMachine(BaseMachine):
             """
             ps = self["ps"]
             lines = ps("-e", "-o", "pid,uid,stat,args").splitlines()
-            lines.pop(0)  # header
-            for line in lines:
-                parts = line.strip().split()
-                yield ProcInfo(
-                    int(parts[0]), int(parts[1]), parts[2], " ".join(parts[3:])
-                )
+            yield from _parse_ps_lines(lines)
 
     def pgrep(self, pattern: str) -> Generator[ProcInfo, None, None]:
         """

--- a/plumbum/machines/remote.py
+++ b/plumbum/machines/remote.py
@@ -15,7 +15,7 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
 from plumbum.commands import CommandNotFound, ConcreteCommand, shquote
-from plumbum.lib import ProcInfo
+from plumbum.lib import ProcInfo, _parse_ps_lines
 from plumbum.machines.base import BaseMachine, PopenWithAddons
 from plumbum.machines.env import BaseEnv
 from plumbum.path.local import LocalPath
@@ -477,10 +477,7 @@ class BaseRemoteMachine(BaseMachine):
         """
         ps = self["ps"]
         lines = ps("-e", "-o", "pid,uid,stat,args").splitlines()
-        lines.pop(0)  # header
-        for line in lines:
-            parts = line.strip().split()
-            yield ProcInfo(int(parts[0]), int(parts[1]), parts[2], " ".join(parts[3:]))
+        yield from _parse_ps_lines(lines)
 
     def pgrep(self, pattern: str) -> Generator[ProcInfo, None, None]:
         """

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -109,6 +109,38 @@ def test_parse_ps_lines_handles_empty_stat_field() -> None:
     )
 
 
+def test_parse_ps_lines_handles_wide_columns() -> None:
+    # ps widens a column to its widest value but keeps the header unchanged, so
+    # the args column of a row can be to the right of the header one.
+    lines = [
+        "  PID   UID STAT ARGS",
+        "    1 12345678 Ssl  python3 /t.py",
+        "12345 2000000000 S<Lsl+ python3 -m pytest",
+        "   42 4294967294        sleep 5",
+    ]
+
+    small, wide, no_stat = lib._parse_ps_lines(lines)
+
+    assert (small.pid, small.uid, small.stat, small.args) == (
+        1,
+        12345678,
+        "Ssl",
+        "python3 /t.py",
+    )
+    assert (wide.pid, wide.uid, wide.stat, wide.args) == (
+        12345,
+        2000000000,
+        "S<Lsl+",
+        "python3 -m pytest",
+    )
+    assert (no_stat.pid, no_stat.uid, no_stat.stat, no_stat.args) == (
+        42,
+        4294967294,
+        "",
+        "sleep 5",
+    )
+
+
 def test_read_fd_decode_safely_raises_when_stream_ends_mid_char() -> None:
     # One byte of a 4-byte UTF-8 sequence forces retry loop then final decode failure.
     read_fd, write_fd = os.pipe()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -84,6 +84,31 @@ def test_read_fd_decode_safely_raises_on_invalid_sequence() -> None:
             os.close(write_fd)
 
 
+def test_parse_ps_lines_handles_empty_stat_field() -> None:
+    # Some ``ps`` implementations emit an empty STAT field; the remaining
+    # columns must not shift (see issue #844).
+    lines = [
+        "  PID   UID STAT ARGS",
+        "    1     0 Ss   /sbin/launchd",
+        "12345   501      python -m pytest",
+    ]
+
+    launchd, python = lib._parse_ps_lines(lines)
+
+    assert (launchd.pid, launchd.uid, launchd.stat, launchd.args) == (
+        1,
+        0,
+        "Ss",
+        "/sbin/launchd",
+    )
+    assert (python.pid, python.uid, python.stat, python.args) == (
+        12345,
+        501,
+        "",
+        "python -m pytest",
+    )
+
+
 def test_read_fd_decode_safely_raises_when_stream_ends_mid_char() -> None:
     # One byte of a 4-byte UTF-8 sequence forces retry loop then final decode failure.
     read_fd, write_fd = os.pipe()


### PR DESCRIPTION
Closes #844

`list_processes()` splits each `ps` row on whitespace, which assumes STAT is never empty. Some `ps` builds (e.g. the non-Apple Darwin build referenced in the issue) emit an empty STAT, so every later field shifted — the first word of the command line was read as STAT — and `pgrep()` stopped matching. Both the local and remote parsers now share a helper that locates the args column by its offset in the `ps` header line, so an empty STAT stays empty and args stays intact.

Regression test added in `tests/test_lib.py`; it fails against the old whitespace-splitting logic (`stat='python'`, `args='-m pytest'`) and passes with the fix. `tests/test_lib.py` and `tests/test_local.py` are green locally (138 passed, 3 skipped).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
