### PR TITLE
fix: allow negative uid in ps output parsing (regression from #845)

### DIFF
--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -43,8 +43,6 @@ def _parse_ps_lines(lines: list[str]) -> Generator[ProcInfo, None, None]:
     uid_end = fields[1].end()
     args_start = fields[-1].start()
     for line in lines[1:]:
-        # uid can be negative: macOS ps reports -2 ("nobody") for some system
-        # processes.
         match = re.match(r"\s*(\d+)\s+(-?\d+)", line)
         if match is None:
             raise ValueError(f"Unexpected ps output line: {line!r}")

--- a/plumbum/lib.py
+++ b/plumbum/lib.py
@@ -43,7 +43,9 @@ def _parse_ps_lines(lines: list[str]) -> Generator[ProcInfo, None, None]:
     uid_end = fields[1].end()
     args_start = fields[-1].start()
     for line in lines[1:]:
-        match = re.match(r"\s*(\d+)\s+(\d+)", line)
+        # uid can be negative: macOS ps reports -2 ("nobody") for some system
+        # processes.
+        match = re.match(r"\s*(\d+)\s+(-?\d+)", line)
         if match is None:
             raise ValueError(f"Unexpected ps output line: {line!r}")
         rest = line[match.end() :]

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -141,6 +141,24 @@ def test_parse_ps_lines_handles_wide_columns() -> None:
     )
 
 
+def test_parse_ps_lines_handles_negative_uid() -> None:
+    # macOS ps reports uid -2 ("nobody") for some system processes, e.g.
+    # distnoted; the id regex must accept a leading '-'.
+    lines = [
+        "  PID   UID STAT ARGS",
+        " 3472    -2      (distnoted)",
+    ]
+
+    (distnoted,) = lib._parse_ps_lines(lines)
+
+    assert (distnoted.pid, distnoted.uid, distnoted.stat, distnoted.args) == (
+        3472,
+        -2,
+        "",
+        "(distnoted)",
+    )
+
+
 def test_read_fd_decode_safely_raises_when_stream_ends_mid_char() -> None:
     # One byte of a 4-byte UTF-8 sequence forces retry loop then final decode failure.
     read_fd, write_fd = os.pipe()


### PR DESCRIPTION
## This is a regression in #845, and it affects stock macOS

#845 correctly fixed the empty-`STAT` misparse from #844. But its id regex,
`re.match(r"\s*(\d+)\s+(\d+)", line)`, only matches non-negative integers,
and **macOS reports `nobody` as uid `-2`**:

```console
$ dscl . -read /Users/nobody UniqueID
UniqueID: -2
$ id nobody
uid=4294967294(nobody) ...        # same value, unsigned 32-bit
```

`uid_t` is unsigned 32-bit in the kernel, so `-2` wraps to `4294967294`;
`id` prints the unsigned form and `ps` prints the signed one. Every Mac runs
at least one `nobody`-owned daemon, so real `ps -e -o pid,uid,stat,args`
output contains rows like:

```
 3472    -2 S    /usr/sbin/distnoted agent
81401    -2 Ss   /usr/libexec/dhcp6d
```

This is **not** limited to the non-Apple `ps` build discussed in #844 —
Apple's stock `/bin/ps` prints `-2` as well.

The previous whitespace-splitting code handled this fine, because
`int("-2")` is valid. The new regex does not match the row at all, so
`_parse_ps_lines` raises instead. Running #845 exactly as merged against
real stock `/bin/ps` output from this machine (726 rows):

```
#845 parser (as merged on main):  ValueError: Unexpected ps output line: ' 3472    -2 S    /usr/sbin/distnoted agent'
pre-#845 whitespace-split parser: OK - parsed 726 rows
```

So as it stands, the next release carrying #845 would make
`list_processes()` and `pgrep()` raise `ValueError` on an ordinary macOS
machine, where they previously worked. That's the reason I'd suggest this
wants to land before that release rather than sitting as a nice-to-have.

## Change

Widen the uid group to `-?\d+`, matching the sign that `int()` on the
capture group already handles correctly. One character of regex; no change
to the empty-`STAT` logic #845 introduced.

## Test plan

- [x] Added `test_parse_ps_lines_handles_negative_uid` to `tests/test_lib.py`,
      using the exact row observed on real hardware. Fails without the fix
      (`ValueError`), passes with it.
- [x] Replayed captured stock Apple `/bin/ps -e -o pid,uid,stat,args` output
      (726 rows) through the patched parser: all 726 rows parse, and both
      negative-uid rows come back intact —
      `pid=3472 uid=-2 stat='S' args='/usr/sbin/distnoted agent'` and
      `pid=81401 uid=-2 stat='Ss' args='/usr/libexec/dhcp6d'`.
- [x] Full suite on aarch64-darwin against a nixpkgs-built Python/`ps`, with
      `test_pgrep` **not** deselected: 407 passed, 0 failed. Without this fix
      the same build dies with the `ValueError` above.

The existing regression tests from #845 don't catch this because their
synthetic rows all use non-negative uids.

## Open question

Should `pid` also accept a sign, for symmetry? I left it strict, since
`ps -e` shouldn't emit negative pids and I'd rather not loosen validation
without a real case behind it. Happy to change it if you'd prefer.

---

This change was prepared with AI assistance: the underlying issue was
root-caused by patching `test_pgrep` to dump its own `ProcInfo` on a real
machine, and every claim above was verified by running the parsers against
live `ps` output rather than reasoned about. Same disclosure precedent as
#845.

Assisted-by: ClaudeCode:claude-sonnet-5