### PR TITLE
chore: secure CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,16 +9,25 @@ on:
 env:
   FORCE_COLOR: 3
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dist:
     name: Dist
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to check out the repository
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: hynek/build-and-inspect-python-package@v2
+    - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   deploy:
     name: Deploy
@@ -29,20 +38,20 @@ jobs:
       name: pypi
       url: https://pypi.org/p/plumbum
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write  # to mint an OIDC token for trusted publishing
+      attestations: write  # to write the build provenance attestation
 
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
 
     - name: Generate artifact attestation for sdist and wheel
-      uses: actions/attest-build-provenance@v4
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-path: "dist/*"
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         attestations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,22 +15,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 
 jobs:
 
   pre-commit:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # to check out the repository
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v7
+        persist-credentials: false
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.x"
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
     - name: Setup uv
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: pylint
       run: uvx nox -s pylint -- --output-format=github
 
@@ -55,21 +60,24 @@ jobs:
         - python-version: '3.15'
           os: macos-latest
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read  # to check out the repository
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Setup uv (cached)
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         enable-cache: true
         cache-suffix: ${{ matrix.os }}-${{ matrix.python-version }}
         cache-dependency-glob: "**/pyproject.toml"
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -80,8 +88,10 @@ jobs:
 
     - name: Install
       run: |
-        uv venv --python ${{ matrix.python-version }}
+        uv venv --python "$PYTHON_VERSION"
         uv pip install -e.[test] pytest-github-actions-annotate-failures
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
 
     - name: Setup SSH tests
       if: runner.os != 'Windows'
@@ -114,8 +124,10 @@ jobs:
         COVERALLS_FLAG_NAME: test-${{ matrix.os }}-${{ matrix.python-version }}
 
   coverage:
+    name: Coverage
     needs: [tests]
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
     - name: Install coveralls
       run: pipx install coveralls

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,12 @@
 ci:
+  autoupdate_schedule: monthly
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: "v6.0.0"
+  rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -19,14 +20,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.15.5"
+  rev: "b969e2851312ca2b24bbec879ba4954341d1bd12"  # frozen: v0.15.5
   hooks:
     - id: ruff-check
       args: ["--fix", "--unsafe-fixes"]
     - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v1.19.1"
+  rev: "a66e98df7b4aeeb3724184b332785976d062b92e"  # frozen: v1.19.1
   hooks:
   - id: mypy
     files: ^(plumbum|examples)
@@ -39,12 +40,12 @@ repos:
       - pillow
 
 - repo: https://github.com/abravalheri/validate-pyproject
-  rev: "v0.25"
+  rev: "4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7"  # frozen: v0.25
   hooks:
   - id: validate-pyproject
 
 - repo: https://github.com/codespell-project/codespell
-  rev: "v2.4.2"
+  rev: "57b21406f092110c18776e39b0bda50d37c945c8"  # frozen: v2.4.3
   hooks:
   - id: codespell
     args: ["-w"]
@@ -52,15 +53,22 @@ repos:
     exclude: "(^pyproject.toml|.po)$"
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: "v1.10.0"
+  rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316"  # frozen: v1.10.0
   hooks:
   - id: rst-backticks
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/henryiii/flake8-lazy
-  rev: v0.8.1
+  rev: 5fed9a818f2583f0403aed779bf2b6c9aa8d25f4  # frozen: v0.8.5
   hooks:
     - id: flake8-lazy
       args: [--apply=set]
       files: "^plumbum"
+
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: "451b56af716f9f0d0c2b816503a3fd0cf8b036fa"  # frozen: v1.29.0
+  hooks:
+  - id: zizmor
+    files: "^\\.github"
+    args: [--persona=pedantic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,10 @@ docs = [
 ]
 
 
+[tool.uv]
+exclude-newer = "7 days"
+
+
 [tool.mypy]
 files = ["plumbum", "examples"]
 python_version = "3.9"


### PR DESCRIPTION
Prompted by https://github.com/pypa/hatch/issues/2292.

:robot: _AI text below_ :robot:

- Pin all GitHub Actions to full SHAs with version comments.
- Add `permissions: {}` at the workflow level and give each job only the permissions it uses, with comments.
- Add `persist-credentials: false` to each checkout step.
- Add a `concurrency` group to the CD workflow.
- Pass the matrix Python version through an environment variable instead of direct template expansion.
- Name the coverage job.
- Add the zizmor pre-commit hook and update the other hooks, frozen to SHAs.
- Set `autoupdate_schedule: monthly` for pre-commit.ci.
- Change dependabot to monthly updates and add a 7-day cooldown.
- Add `exclude-newer = "7 days"` to `[tool.uv]`.

Major action bump: `hynek/build-and-inspect-python-package` v2 -> v3.0.1. The artifact name stays `Packages`.

Held back: ruff (v0.15.5) and mypy (v1.19.1) stay at their current versions, frozen to SHAs. The new versions report errors in source code that is not related to CI security. Each needs its own change set.